### PR TITLE
Implement support for IRCv3.1's away-notify extension

### DIFF
--- a/src/kvirc/kernel/KviIrcConnection.cpp
+++ b/src/kvirc/kernel/KviIrcConnection.cpp
@@ -487,6 +487,11 @@ void KviIrcConnection::handleInitialCapLs()
 		szRequests.append("znc.in/server-time-iso ");
 	}
 
+	if(serverInfo()->supportedCaps().contains("away-notify",Qt::CaseInsensitive))
+	{
+		szRequests.append("away-notify ");
+	}
+
 	if(szRequests.isEmpty())
 	{
 		endInitialCapNegotiation();
@@ -1953,6 +1958,11 @@ void KviIrcConnection::heartbeat(kvi_time_t tNow)
 	{
 		if(KVI_OPTION_BOOL(KviOption_boolEnableAwayListUpdates))
 		{
+			if(m_pStateData->enabledCaps().contains("away-notify"))
+			{
+				// no need to send WHO requests if the away-notify extension is enabled
+				return;
+			}
 			// update the channel WHO lists (fixes users away state)
 			// first of all, we send our request not more often than every 50 secs
 			if((tNow - stateData()->lastSentChannelWhoRequest()) > 50)

--- a/src/kvirc/sparser/KviIrcServerParser.h
+++ b/src/kvirc/sparser/KviIrcServerParser.h
@@ -234,6 +234,7 @@ private:
 	void parseUserMode(KviIrcMessage *msg,const char * modeflptr);
 	void parseLiteralCap(KviIrcMessage * msg);
 	void parseLiteralAuthenticate(KviIrcMessage * msg);
+	void parseLiteralAway(KviIrcMessage *msg);
 
 	void parseCtcpRequest(KviCtcpMessage *msg);
 	void parseCtcpReply(KviCtcpMessage *msg);

--- a/src/kvirc/sparser/KviIrcServerParser_literalHandlers.cpp
+++ b/src/kvirc/sparser/KviIrcServerParser_literalHandlers.cpp
@@ -2385,3 +2385,27 @@ void KviIrcServerParser::parseLiteralAuthenticate(KviIrcMessage *msg)
 	KviCString szAuth(msg->safeParam(0));
 	msg->connection()->handleAuthenticate(szAuth);
 }
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// AWAY
+//
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void KviIrcServerParser::parseLiteralAway(KviIrcMessage *msg)
+{
+	// AWAY (IRCv3.1)
+	// :<source_mask> AWAY :<part message>
+	QString szNick,szUser,szHost;
+	msg->decodeAndSplitPrefix(szNick,szUser,szHost);
+
+	QString awayMsg = msg->paramCount() > 0 ? msg->connection()->decodeText(msg->safeTrailing()) : QString();
+
+	// Update the user entry
+	KviIrcUserDataBase * db = msg->connection()->userDataBase();
+	KviIrcUserEntry * e = db->find(szNick);
+	if(e)
+	{
+		e->setAway(!awayMsg.isEmpty());
+	}
+}

--- a/src/kvirc/sparser/KviIrcServerParser_tables.cpp
+++ b/src/kvirc/sparser/KviIrcServerParser_tables.cpp
@@ -30,6 +30,7 @@
 KviLiteralMessageParseStruct KviIrcServerParser::m_literalParseProcTable[]=
 {
 	{ "AUTHENTICATE" , PTM(parseLiteralAuthenticate) },
+	{ "AWAY"         , PTM(parseLiteralAway)         },
 	{ "CAP"          , PTM(parseLiteralCap)          },
 	{ "ERROR"        , PTM(parseLiteralError)        },
 	{ "INVITE"       , PTM(parseLiteralInvite)       },

--- a/src/modules/options/OptionsWidget_channel.cpp
+++ b/src/modules/options/OptionsWidget_channel.cpp
@@ -141,11 +141,11 @@ OptionsWidget_channelAdvanced::OptionsWidget_channelAdvanced(QWidget * pParent)
 	mergeTip(u,__tr2qs_ctx("<center>Minimum value: <b>0 days</b><br>Maximum value: <b>10 days</b></center>","options"));
 	connect(b,SIGNAL(toggled(bool)),u,SLOT(setEnabled(bool)));
 
- 	b = addBoolSelector(0,3,4,3,__tr2qs_ctx("Keep away list updated by sending WHO requests","options"),KviOption_boolEnableAwayListUpdates);
+ 	b = addBoolSelector(0,3,4,3,__tr2qs_ctx("Keep away list updated","options"),KviOption_boolEnableAwayListUpdates);
 	mergeTip(b,
 		__tr2qs_ctx("<center>KVIrc sends out a channel /WHO message every now and then to keep " \
 			"the channel away list in sync. Use this option to disable this feature (and to save " \
-			"your IRC bandwidth.</center>","options"));
+			"your IRC bandwidth. If the server supports IRCv3.1's away-notify extension, it will be used instead of WHO requests.</center>","options"));
 
 	addRowSpacer(0,5,4,5);
 }


### PR DESCRIPTION
It will be used to get immediate updates of other user's away status instead of polling every channel using WHO requests. 
