### PR TITLE
Show WindowList With User Flag Option

### DIFF
--- a/src/kvirc/kernel/KviOptions.cpp
+++ b/src/kvirc/kernel/KviOptions.cpp
@@ -331,7 +331,8 @@ KviBoolOption g_boolOptionsTable[KVI_NUM_BOOL_OPTIONS]=
 	BOOL_OPTION("MinimizeInTray",false,KviOption_sectFlagFrame | KviOption_resetUpdateGui),
 	BOOL_OPTION("DisplayNotifierOnPrimaryScreen",true,KviOption_sectFlagFrame),
 	BOOL_OPTION("ShowDialogOnChannelCtcpPage",false,KviOption_sectFlagCtcp),
-	BOOL_OPTION("PopupNotifierOnNewNotices",true,KviOption_sectFlagFrame)
+	BOOL_OPTION("PopupNotifierOnNewNotices",true,KviOption_sectFlagFrame),
+	BOOL_OPTION("ShowWindowListWithUserFlag",true,KviOption_sectFlagWindowList | KviOption_resetUpdateGui),
 };
 
 #define STRING_OPTION(_txt,_val,_flags) KviStringOption(KVI_STRING_OPTIONS_PREFIX _txt,_val,_flags)

--- a/src/kvirc/kernel/KviOptions.h
+++ b/src/kvirc/kernel/KviOptions.h
@@ -351,7 +351,7 @@ DECLARE_OPTION_STRUCT(KviStringListOption,QStringList)
 #define KviOption_boolDisplayNotifierOnPrimaryScreen 256                 /* notifier */
 #define KviOption_boolShowDialogOnChannelCtcpPage 257
 #define KviOption_boolPopupNotifierOnNewNotices 258                      /* query */
-#define KviOption_boolUserListViewAwayColor 259                          /* userlist */
+#define KviOption_boolUserListViewUseAwayColor 259                          /* userlist */
 #define KviOption_boolShowWindowListWithUserFlag 260
 
 #define KVI_NUM_BOOL_OPTIONS 261

--- a/src/kvirc/kernel/KviOptions.h
+++ b/src/kvirc/kernel/KviOptions.h
@@ -351,8 +351,9 @@ DECLARE_OPTION_STRUCT(KviStringListOption,QStringList)
 #define KviOption_boolDisplayNotifierOnPrimaryScreen 256                 /* notifier */
 #define KviOption_boolShowDialogOnChannelCtcpPage 257
 #define KviOption_boolPopupNotifierOnNewNotices 258                      /* query */
+#define KviOption_boolShowWindowListWithUserFlag 259
 
-#define KVI_NUM_BOOL_OPTIONS 259
+#define KVI_NUM_BOOL_OPTIONS 260
 
 
 #define KVI_STRING_OPTIONS_PREFIX "string"

--- a/src/kvirc/ui/KviUserListView.cpp
+++ b/src/kvirc/ui/KviUserListView.cpp
@@ -1853,7 +1853,7 @@ void KviUserListViewArea::paintEvent(QPaintEvent * e)
 				iAvatarAndTextX += 1;
 			}
 
-			if(pEntry->globalData()->isAway() && KVI_OPTION_BOOL(KviOption_BoolUserListViewAwayColor))
+			if(pEntry->globalData()->isAway() && KVI_OPTION_BOOL(KviOption_boolUserListViewAwayColor))
 			{
 				QRgb rgb2 = pClrFore->rgb();
 				QRgb rgb1 = KVI_OPTION_COLOR(KviOption_colorUserListViewAwayForeground).rgb();

--- a/src/kvirc/ui/KviUserListView.cpp
+++ b/src/kvirc/ui/KviUserListView.cpp
@@ -1853,7 +1853,7 @@ void KviUserListViewArea::paintEvent(QPaintEvent * e)
 				iAvatarAndTextX += 1;
 			}
 
-			if(pEntry->globalData()->isAway() && KVI_OPTION_BOOL(KviOption_boolUserListViewAwayColor))
+			if(pEntry->globalData()->isAway() && KVI_OPTION_BOOL(KviOption_boolUserListViewUseAwayColor))
 			{
 				QRgb rgb2 = pClrFore->rgb();
 				QRgb rgb1 = KVI_OPTION_COLOR(KviOption_colorUserListViewAwayForeground).rgb();

--- a/src/kvirc/ui/KviWindowListBase.cpp
+++ b/src/kvirc/ui/KviWindowListBase.cpp
@@ -447,7 +447,12 @@ void KviWindowListButton::drawButtonLabel(QPainter * pPainter)
 		break;
 		case KviWindow::Channel:
 		case KviWindow::DeadChannel:
-			szText = ((KviChannelWindow *)m_pWindow)->nameWithUserFlag();
+			if(KVI_OPTION_BOOL(KviOption_boolShowWindowListWithUserFlag))
+			{
+				szText = ((KviChannelWindow *)m_pWindow)->nameWithUserFlag();
+			} else {
+				szText = ((KviChannelWindow *)m_pWindow)->target();
+			}
 		break;
 		case KviWindow::Query:
 		case KviWindow::DeadQuery:

--- a/src/modules/options/OptionsWidget_userList.cpp
+++ b/src/modules/options/OptionsWidget_userList.cpp
@@ -64,7 +64,7 @@ OptionsWidget_userListForeground::OptionsWidget_userListForeground(QWidget * par
 
 	KviTalHBox * ahb = new KviTalHBox(g);
 	ahb->setSpacing(4);
-	KviBoolSelector * ab = addBoolSelector(ahb,__tr2qs_ctx("Away:","options"),KviOption_BoolUserListViewAwayColor);
+	KviBoolSelector * ab = addBoolSelector(ahb,__tr2qs_ctx("Away:","options"),KviOption_boolUserListViewAwayColor);
 	KviColorSelector * as = addColorSelector(ahb,__tr2qs_ctx("","options"),KviOption_colorUserListViewAwayForeground);
 	connect(ab,SIGNAL(toggled(bool)),as,SLOT(setEnabled(bool)));
 

--- a/src/modules/options/OptionsWidget_userList.cpp
+++ b/src/modules/options/OptionsWidget_userList.cpp
@@ -64,7 +64,7 @@ OptionsWidget_userListForeground::OptionsWidget_userListForeground(QWidget * par
 
 	KviTalHBox * ahb = new KviTalHBox(g);
 	ahb->setSpacing(4);
-	KviBoolSelector * ab = addBoolSelector(ahb,__tr2qs_ctx("Away:","options"),KviOption_boolUserListViewAwayColor);
+	KviBoolSelector * ab = addBoolSelector(ahb,__tr2qs_ctx("Away:","options"),KviOption_boolUserListViewUseAwayColor);
 	KviColorSelector * as = addColorSelector(ahb,__tr2qs_ctx("","options"),KviOption_colorUserListViewAwayForeground);
 	connect(ab,SIGNAL(toggled(bool)),as,SLOT(setEnabled(bool)));
 

--- a/src/modules/options/OptionsWidget_windowList.cpp
+++ b/src/modules/options/OptionsWidget_windowList.cpp
@@ -50,7 +50,8 @@ OptionsWidget_windowList::OptionsWidget_windowList(QWidget * parent)
 	addBoolSelector(0,4,0,4,__tr2qs_ctx("Show IRC context indicator in window list","options"),KviOption_boolUseWindowListIrcContextIndicator);
 	addBoolSelector(0,5,0,5,__tr2qs_ctx("Enable window tooltips","options"),KviOption_boolShowWindowListToolTips);
 	addBoolSelector(0,6,0,6,__tr2qs_ctx("Show header","options"),KviOption_boolShowTreeWindowListHeader);
-	addRowSpacer(0,7,0,7);
+	addBoolSelector(0,7,0,7,__tr2qs_ctx("Show user flag for channels","options"),KviOption_boolShowWindowListWithUserFlag);
+	addRowSpacer(0,8,0,8);
 }
 
 


### PR DESCRIPTION
To be able to hide the user flag(s) for channels in the window list. I.e. op or voice (@,+).
