### PR TITLE
Show WindowList With User Flag Option

### DIFF
--- a/src/kvirc/kernel/KviOptions.cpp
+++ b/src/kvirc/kernel/KviOptions.cpp
@@ -332,7 +332,8 @@ KviBoolOption g_boolOptionsTable[KVI_NUM_BOOL_OPTIONS]=
 	BOOL_OPTION("DisplayNotifierOnPrimaryScreen",true,KviOption_sectFlagFrame),
 	BOOL_OPTION("ShowDialogOnChannelCtcpPage",false,KviOption_sectFlagCtcp),
 	BOOL_OPTION("PopupNotifierOnNewNotices",true,KviOption_sectFlagFrame),
-	BOOL_OPTION("UserListViewUseAwayColor",true,KviOption_sectFlagUserListView)
+	BOOL_OPTION("UserListViewUseAwayColor",true,KviOption_sectFlagUserListView),
+	BOOL_OPTION("ShowWindowListWithUserFlag",true,KviOption_sectFlagWindowList | KviOption_resetUpdateGui)
 };
 
 #define STRING_OPTION(_txt,_val,_flags) KviStringOption(KVI_STRING_OPTIONS_PREFIX _txt,_val,_flags)

--- a/src/kvirc/kernel/KviOptions.h
+++ b/src/kvirc/kernel/KviOptions.h
@@ -352,8 +352,9 @@ DECLARE_OPTION_STRUCT(KviStringListOption,QStringList)
 #define KviOption_boolShowDialogOnChannelCtcpPage 257
 #define KviOption_boolPopupNotifierOnNewNotices 258                      /* query */
 #define KviOption_boolUserListViewUseAwayColor 259                       /* userlist */
+#define KviOption_boolShowWindowListWithUserFlag 260
 
-#define KVI_NUM_BOOL_OPTIONS 260
+#define KVI_NUM_BOOL_OPTIONS 261
 
 
 #define KVI_STRING_OPTIONS_PREFIX "string"

--- a/src/kvirc/ui/KviWindowListBase.cpp
+++ b/src/kvirc/ui/KviWindowListBase.cpp
@@ -447,7 +447,12 @@ void KviWindowListButton::drawButtonLabel(QPainter * pPainter)
 		break;
 		case KviWindow::Channel:
 		case KviWindow::DeadChannel:
-			szText = ((KviChannelWindow *)m_pWindow)->nameWithUserFlag();
+			if(KVI_OPTION_BOOL(KviOption_boolShowWindowListWithUserFlag))
+			{
+				szText = ((KviChannelWindow *)m_pWindow)->nameWithUserFlag();
+			} else {
+				szText = ((KviChannelWindow *)m_pWindow)->target();
+			}
 		break;
 		case KviWindow::Query:
 		case KviWindow::DeadQuery:

--- a/src/modules/options/OptionsWidget_windowList.cpp
+++ b/src/modules/options/OptionsWidget_windowList.cpp
@@ -50,7 +50,8 @@ OptionsWidget_windowList::OptionsWidget_windowList(QWidget * parent)
 	addBoolSelector(0,4,0,4,__tr2qs_ctx("Show IRC context indicator in window list","options"),KviOption_boolUseWindowListIrcContextIndicator);
 	addBoolSelector(0,5,0,5,__tr2qs_ctx("Enable window tooltips","options"),KviOption_boolShowWindowListToolTips);
 	addBoolSelector(0,6,0,6,__tr2qs_ctx("Show header","options"),KviOption_boolShowTreeWindowListHeader);
-	addRowSpacer(0,7,0,7);
+	addBoolSelector(0,7,0,7,__tr2qs_ctx("Show user flag for channels","options"),KviOption_boolShowWindowListWithUserFlag);
+	addRowSpacer(0,8,0,8);
 }
 
 


### PR DESCRIPTION
To be able to hide the user flag(s) for channels in the window list. I.e. op or voice (@,+).
