### PR TITLE
Add initial GitHub readme with markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,39 @@
-[![Travis Build Status](https://travis-ci.org/kvirc/KVIrc.svg?branch=master)](https://travis-ci.org/kvirc/KVIrc)
-[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/j6tjel0eaeyixcbn/branch/master?svg=true)](https://ci.appveyor.com/project/DarthGandalf/kvirc/branch/master)
+[![Travis Build Status](https://travis-ci.org/kvirc/KVIrc.svg?branch=master)](https://travis-ci.org/kvirc/KVIrc) [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/j6tjel0eaeyixcbn/branch/master?svg=true)](https://ci.appveyor.com/project/DarthGandalf/kvirc/branch/master)
 
-See doc/README
+![KVIrc logo](https://raw.githubusercontent.com/kvirc/KVIrc/master/data/icons/128x128/kvirc.png "KVIrc - The visual IRC client for the masses!")
+
+#### About
+
+KVIrc is a free portable IRC client based on the excellent Qt GUI toolkit.
+KVirc is being written by Szymon Stefanek and the KVIrc development team with the contribution of many IRC addicted developers around the world.
+
+This is the Github development and bug tracker home for the KVIrc project.
+
+#### Getting involved
+
+- [Contributing](http://www.kvirc.net/?id=contribute "Contribute")
+
+#### Help & Support
+
+- [KVIrc - wiki F.A.Q.](https://github.com/kvirc/KVIrc/wiki/FAQ "KVIrc - FAQ")
+- [KVIrc - Project F.A.Q.](https://github.com/kvirc/KVIrc/blob/master/doc/FAQ "Project F.A.Q.")
+- [KVIrc manual](http://www.kvirc.net/doc/ "KVIrc manual")
+- [Open a bug report](https://github.com/kvirc/KVIrc/issues "Open a bug report")
+- [#KVIrc](http://webchat.freenode.net?nick=kvirc-user&channels=%23kvirc&prompt=1&uio=OT10cnVlde) on freenode.net
+- [Further information](https://github.com/kvirc/KVIrc/tree/master/doc "Further information reading")
+
+#### Download
+
+ Coming soon...
+
+#### Install and compile
+
+- [Linux install](https://github.com/kvirc/KVIrc/blob/master/doc/INSTALL "Linux install")
+- [Mac install](https://github.com/kvirc/KVIrc/blob/master/doc/INSTALL-MacOS.txt "MacOS install")
+- [Windows install](https://github.com/kvirc/KVIrc/blob/master/doc/INSTALL-Win32.txt "Windows 32 install")
+
+#### Licensing
+
+[GPLv2](https://github.com/kvirc/KVIrc/blob/master/doc/LICENSE-GPLV2 "GPLv2")  
+[GPLv3](https://github.com/kvirc/KVIrc/blob/master/doc/LICENSE-GPLV3 "GPLv3")  
+[OpenSSL](https://github.com/kvirc/KVIrc/blob/master/doc/LICENSE-OPENSSL "OpenSSL")


### PR DESCRIPTION
Add initial project readme.
All Github projects have one, KVIrc should be no exception. 

To preview see https://github.com/uNiversaI/KVIrc/blob/Mary-had-a-little-lamb/README.md

Please provide feedback on things to add / remove or improve. before merging but things can always be added after
