### PR TITLE
Fix readme, appveyor and travis separate lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Travis Build Status](https://travis-ci.org/kvirc/KVIrc.svg?branch=master)](https://travis-ci.org/kvirc/KVIrc) [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/j6tjel0eaeyixcbn/branch/master?svg=true)](https://ci.appveyor.com/project/DarthGandalf/kvirc/branch/master)
+[![Travis Build Status](https://travis-ci.org/kvirc/KVIrc.svg?branch=master)](https://travis-ci.org/kvirc/KVIrc)
+[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/j6tjel0eaeyixcbn/branch/master?svg=true)](https://ci.appveyor.com/project/DarthGandalf/kvirc/branch/master)
 
 ![KVIrc logo](https://raw.githubusercontent.com/kvirc/KVIrc/master/data/icons/128x128/kvirc.png "KVIrc - The visual IRC client for the masses!")
 


### PR DESCRIPTION
pragma merged PR before I had a chance to address comments in  https://github.com/kvirc/KVIrc/pull/1527#discussion_r38232504
