### PR TITLE
[readme] add Ubuntu ppa KVIrc community member provided.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ This is the Github development and bug tracker home for the KVIrc project.
 
 #### Download
 
-Try one of our fresh out-of-the-press Windows development builds for x86 or x64 bit.  
+Try one of our fresh out-of-the-press nightly development builds for x86 or x64 bit.  
 
 - [Nightly Windows x86 / x64 bit builds](http://kvirc.d00p.de/)
-- [Ubuntu PPA] Coming soon, maybe!
+- [Ubuntu 14.4x LTS / 15.x](https://launchpad.net/~alex-p/+archive/ubuntu/kvirc) 
 - [Other Linux] - Volunteer now.
 
 #### Install and compile


### PR DESCRIPTION
I did some hunting around, found a community member that builds KVIrc stable and asked him if he would be interested in doing the nightly builds.

After a few hours much to my surprise I had a reply waiting on my inbox, nice!! Thx Alex :D

I think this is a good thing, especially since the stable 4.2.0 builds are far from really ideal.
Since most users are too afraid of a command line to compile and current builds IMO are the best builds for KVIrc yet, this should help that segment of the users grab their fix.

**EDIT**
~~Should I add a warning to the GTKSTYLE one? Its apparently supposed to be prone to breaking themes~~
Removed optional PPA with GTKSTYLE=ON (its not worth the possible trouble
 [Ubuntu 14.4x LTS / 15.x](https://launchpad.net/~alex-p/+archive/ubuntu/kvirc-gtkstyle) With GTKSTYLE=ON  
.
Please review.

```
Sent: Tuesday, September 08, 2015 at 10:27 PM
From: Alex_P 
To: universal 
Subject: Re: KVirc 4.3.2 git master builds


Hi. Yes, I know about moving on www.github.com.
I also changed the rules of the assembly and created a PPA forUbuntu Vivid and Ubuntu Trusty:
https://launchpad.net/~alex-p/+archive/ubuntu/kvirc
https://launchpad.net/~alex-p/+archive/ubuntu/kvirc-gtkstyle  (GTKSTYLE=ON)
You can add these links Readme.md. I'll update the build in the PPA
```

These are Qt5 based

```
Source: kvirc
Binary: kvirc, libkvilib4, kvirc-modules, kvirc-data, kvirc-dbg
Architecture: any all
Version: 4:4.3.2~git-5289-g0e9ae5d-1ppa1~trusty1
Maintainer: Alexander Pozdnyakov
Homepage: http://www.kvirc.de/
Standards-Version: 3.9.6
Build-Depends: debhelper (>= 8.9.4), cmake (>= 2.8.4+dfsg.1-3), libperl-dev, zlib1g-dev, libx11-dev, libxrender-dev, libssl-dev, qtbase5-dev, qttools5-dev-tools, libqt5x11extras5-dev, libphonon4qt5-dev, qttools5-dev, libqt5svg5-dev, qtmultimedia5-dev, libqt5webkit5-dev, libphonon4qt5experimental-dev, pkg-config, libxss-dev, python-dev, libqtwebkit-dev
Package-List:
 kvirc deb net optional arch=any
 kvirc-data deb net optional arch=all
 kvirc-dbg deb debug extra arch=any
 kvirc-modules deb libs optional arch=any
 libkvilib4 deb libs optional arch=any
```
