### PR TITLE
fix input icon - history disabled is wrong -part 2

### DIFF
--- a/src/kvirc/ui/KviInput.cpp
+++ b/src/kvirc/ui/KviInput.cpp
@@ -408,7 +408,7 @@ void KviInput::applyOptions()
 		connect(m_pHistoryButton,SIGNAL(clicked()),this,SLOT(historyButtonClicked()));
 	} else {
 		QIcon is1;
-		is1.addPixmap(*(g_pIconManager->getSmallIcon(KviIconManager::QuitSplit)));
+		is1.addPixmap(*(g_pIconManager->getSmallIcon(KviIconManager::HandlerDisabled)));
 		m_pHistoryButton->setIcon(is1);
 		KviTalToolTip::add(m_pHistoryButton,__tr2qs("Input History Disabled"));
 		m_pHistoryButton->disconnect(SIGNAL(clicked()));


### PR DESCRIPTION
Previous PR: Fixing ("Input History Disabled") associated Icon.

line 115 in KviInput.cpp `KviIconManager::QuitSplit` -> `KviIconManager::HandlerDisabled`

This PR does the second line I missed, due to not enough coffee

line 411 in KviInput.cpp `KviIconManager::QuitSplit` -> `KviIconManager::HandlerDisabled`

> Note: need to add proper icons for this.
