### PR TITLE
[ListWindow] use getSmallIcon() instead and fix assignments

### DIFF
--- a/src/kvirc/kernel/KviDefaultScript.cpp
+++ b/src/kvirc/kernel/KviDefaultScript.cpp
@@ -474,7 +474,7 @@ KviDefaultScriptDialog::KviDefaultScriptDialog()
 
 	m_pAdvanced->setLayout(pAdvLayout);
 
-	QPixmap * pImage = g_pIconManager->getSmallIcon(262);
+	QPixmap * pImage = g_pIconManager->getSmallIcon(150);
 	QPushButton * pAdvanced = new QPushButton(*pImage,__tr2qs("Advanced..."),this);
 	connect(pAdvanced,SIGNAL(clicked()),this,SLOT(advanced()));
 	pLayout->addWidget(pAdvanced,2,0,1,1);

--- a/src/kvirc/kernel/KviOptions.cpp
+++ b/src/kvirc/kernel/KviOptions.cpp
@@ -740,8 +740,8 @@ KviMessageTypeSettingsOption g_msgtypeOptionsTable[KVI_NUM_MSGTYPE_OPTIONS]=
 	MSGTYPE_OPTION("Echo",__tr_no_lookup("Normal text"),KviIconManager::None,KVI_MSGTYPE_LEVEL_1),
 	MSGTYPE_OPTION_SPEC("Selection",__tr_no_lookup("Selection"),KviIconManager::None,KviControlCodes::White,KviControlCodes::Black,KVI_MSGTYPE_LEVEL_1),
 	MSGTYPE_OPTION_SPEC("Highlight",__tr_no_lookup("Highlighted text"),KviIconManager::Alert,KviControlCodes::White,KviControlCodes::Black,KVI_MSGTYPE_LEVEL_5),
-	MSGTYPE_OPTION_SPEC("Url",__tr_no_lookup("URL foreground"),KviIconManager::None,KviControlCodes::Blue,KviControlCodes::Transparent,KVI_MSGTYPE_LEVEL_1),
-	MSGTYPE_OPTION_SPEC("Link",__tr_no_lookup("Link overlay foreground"),KviIconManager::None,KviControlCodes::Blue,KviControlCodes::Transparent,KVI_MSGTYPE_LEVEL_1),
+	MSGTYPE_OPTION_SPEC("Url",__tr_no_lookup("URL foreground"),KviIconManager::Url,KviControlCodes::Blue,KviControlCodes::Transparent,KVI_MSGTYPE_LEVEL_1),
+	MSGTYPE_OPTION_SPEC("Link",__tr_no_lookup("Link overlay foreground"),KviIconManager::Url,KviControlCodes::Blue,KviControlCodes::Transparent,KVI_MSGTYPE_LEVEL_1),
 	MSGTYPE_OPTION_SPEC("ParserError",__tr_no_lookup("Parser error"),KviIconManager::ParserError,KviControlCodes::Red,KviControlCodes::Transparent,KVI_MSGTYPE_LEVEL_2),
 	MSGTYPE_OPTION_SPEC("ParserWarning",__tr_no_lookup("Parser warning"),KviIconManager::ParserWarning,KviControlCodes::Red,KviControlCodes::Transparent,KVI_MSGTYPE_LEVEL_2),
 	MSGTYPE_OPTION("HostLookup",__tr_no_lookup("Host lookup result"),KviIconManager::Server,KVI_MSGTYPE_LEVEL_3),
@@ -878,7 +878,7 @@ KviMessageTypeSettingsOption g_msgtypeOptionsTable[KVI_NUM_MSGTYPE_OPTIONS]=
 	//         messages with higher level are rendered with more visible color (i.e. red)
 	//         messages with very high level might flash the tray and end up in the notifier
 	//         level 1 or 2 for standard torrent messages is ok
-	MSGTYPE_OPTION("BitTorrent",__tr_no_lookup("BitTorrent message"),KviIconManager::MultiMedia,KVI_MSGTYPE_LEVEL_2),
+	MSGTYPE_OPTION("BitTorrent",__tr_no_lookup("BitTorrent message"),KviIconManager::Gnutella,KVI_MSGTYPE_LEVEL_2),
 	MSGTYPE_OPTION("IrcOp",__tr_no_lookup("IRC Op status set"),KviIconManager::IrcOp,KVI_MSGTYPE_LEVEL_5),
 	MSGTYPE_OPTION("DeIrcOp",__tr_no_lookup("IRC Op status unset"),KviIconManager::DeIrcOp,KVI_MSGTYPE_LEVEL_5),
 	MSGTYPE_OPTION("MeIrcOp",__tr_no_lookup("Own IRC Op status set"),KviIconManager::MeIrcOp,KVI_MSGTYPE_LEVEL_5),

--- a/src/modules/list/ListWindow.cpp
+++ b/src/modules/list/ListWindow.cpp
@@ -199,14 +199,14 @@ ListWindow::ListWindow(KviConsoleWindow * lpConsole)
 	m_pOpenButton = new QToolButton(pBox);
 	m_pOpenButton->setObjectName("import_list");
 	m_pOpenButton->setIconSize(QSize(16,16));
-	m_pOpenButton->setIcon(QIcon(*(g_pIconManager->getBigIcon(KVI_BIGICON_OPEN))));
+	m_pOpenButton->setIcon(QIcon(*(g_pIconManager->getSmallIcon(KviIconManager::Folder))));
 	KviTalToolTip::add(m_pOpenButton,__tr2qs("Import List"));
 	connect(m_pOpenButton,SIGNAL(clicked()),this,SLOT(importList()));
 
 	m_pSaveButton = new QToolButton(pBox);
 	m_pSaveButton->setObjectName("export_list");
 	m_pSaveButton->setIconSize(QSize(16,16));
-	m_pSaveButton->setIcon(QIcon(*(g_pIconManager->getBigIcon(KVI_BIGICON_SAVE))));
+	m_pSaveButton->setIcon(QIcon(*(g_pIconManager->getSmallIcon(KviIconManager::Floppy))));
 	KviTalToolTip::add(m_pSaveButton,__tr2qs("Export List"));
 	connect(m_pSaveButton,SIGNAL(clicked()),this,SLOT(exportList()));
 
@@ -220,7 +220,7 @@ ListWindow::ListWindow(KviConsoleWindow * lpConsole)
 	m_pStopListDownloadButton = new QToolButton(pBox);
 	m_pStopListDownloadButton->setObjectName("stoplistdownload_button");
 	m_pStopListDownloadButton->setIconSize(QSize(16,16));
-	m_pStopListDownloadButton->setIcon(QIcon(*(g_pIconManager->getSmallIcon(KviIconManager::NickNameProblem))));
+	m_pStopListDownloadButton->setIcon(QIcon(*(g_pIconManager->getSmallIcon(KviIconManager::Discard))));
 	KviTalToolTip::add(m_pStopListDownloadButton,__tr2qs("Stop list download"));
 	connect(m_pStopListDownloadButton,SIGNAL(clicked()),this,SLOT(stoplistdownload()));
 


### PR DESCRIPTION
Please review.

Im not sure if there's a reason why in ListWindow.cpp this toolbar is using `getBigIcon()` intead of `getSmallIcon()` 

Since its 16x16 only and `m_pStopListDownloadButton` is using `getSmallIcon()` I decided this change makes sense.
Let me know if this is right and merge if it is. Else Ill only assing the right icon to `m_pStopListDownloadButton` and discard the other changes.
