### PR TITLE
protocol: Update IRCd protocols

### DIFF
--- a/src/kvirc/kernel/KviIrcConnectionServerInfo.cpp
+++ b/src/kvirc/kernel/KviIrcConnectionServerInfo.cpp
@@ -337,7 +337,7 @@ const QString & KviUnrealIrcServerInfo::getChannelModeDescription(char mode)
 		case 'a': return __tr2qs("Protected/admin nicks"); break;
 		case 'c': return __tr2qs("No control codes (colors, bold, ..)"); break;
 		case 'f': return __tr2qs("Flood protection (<num><type>:<secs>)"); break;
-		case 'h': return __tr2qs("Half-operators");break;
+		case 'h': return __tr2qs("Half-operators"); break;
 		case 'j': return __tr2qs("Join throttling (<num>:<secs>)"); break;
 		case 'q': return __tr2qs("Channel owners"); break;
 		case 'r': return __tr2qs("Registered"); break;
@@ -394,7 +394,7 @@ const QString & KviIrcdSevenIrcServerInfo::getChannelModeDescription(char mode)
 		case 'T': return __tr2qs("Forbid channel NOTICEs"); break;
 		case 'c': return __tr2qs("No control codes (colors, bold, ..)"); break;
 		case 'f': return __tr2qs("Forward to another channel on uninvited"); break;
-		case 'g': return __tr2qs("Allow anybody to invite");break;
+		case 'g': return __tr2qs("Allow anybody to invite"); break;
 		case 'j': return __tr2qs("Join throttling (<num>:<secs>)"); break;
 		case 'p': return __tr2qs("Paranoid (disable KNOCK)"); break;
 		case 'q': return __tr2qs("Quiet Ban Editor"); break;
@@ -430,7 +430,7 @@ const QString & KviBahamutIrcServerInfo::getChannelModeDescription(char mode)
 		case 'S': return __tr2qs("Need SSL connection to join"); break;
 		case 'U': return __tr2qs("Permit foreign users without auth to JOIN"); break;
 		case 'd': return __tr2qs("Need op/voice to change nick"); break;
-		case 'h': return __tr2qs("Half-operators");break;
+		case 'h': return __tr2qs("Half-operators"); break;
 		case 'r': return __tr2qs("Registered"); break;
 		case 'u': return __tr2qs("Hide QUIT and PART messages"); break;
 	}
@@ -441,8 +441,8 @@ const QString & KviInspIRCdIrcServerInfo::getChannelModeDescription(char mode)
 {
 	switch(mode)
 	{
-		case 'A': return __tr2qs("Allow anybody to invite");break;
-		case 'B': return __tr2qs("Block messages with too many CAPS");break;
+		case 'A': return __tr2qs("Allow anybody to invite"); break;
+		case 'B': return __tr2qs("Block messages with too many CAPS"); break;
 		case 'C': return __tr2qs("Forbid channel CTCPs"); break;
 		case 'D': return __tr2qs("Delay users join to first message"); break;
 		case 'F': return __tr2qs("Limit nick changes (<num>:<secs>)"); break;
@@ -530,7 +530,7 @@ const QString & KviPlexusIrcServerInfo::getChannelModeDescription(char mode)
 		case 'S': return __tr2qs("Need SSL connection to join"); break;
 		case 'a': return __tr2qs("Protected/admin nicks"); break;
 		case 'c': return __tr2qs("No control codes (colors, bold, ..)"); break;
-		case 'h': return __tr2qs("Half-operators");break;
+		case 'h': return __tr2qs("Half-operators"); break;
 		case 'p': return __tr2qs("Paranoia"); break;
 		case 'q': return __tr2qs("Channel owners"); break;
 		case 'z': return __tr2qs("Persistent (staff only)"); break;
@@ -545,6 +545,9 @@ const QString & KviOftcIrcServerInfo::getChannelModeDescription(char mode)
 		case 'M': return __tr2qs("Moderate non auth users"); break;
 		case 'R': return __tr2qs("Only registered nicks can join"); break;
 		case 'S': return __tr2qs("Need SSL connection to join"); break;
+		case 'h': return __tr2qs("Half-operators"); break;
+		case 'q': return __tr2qs("Quiet"); break;
+		case 'z': return __tr2qs("Reduced moderation for ops"); break;
 	}
 	return KviBasicIrcServerInfo::getChannelModeDescription(mode);
 }
@@ -553,6 +556,7 @@ const QString & KviDarenetIrcServerInfo::getChannelModeDescription(char mode)
 {
 	switch(mode)
 	{
+		case 'A': return __tr2qs("Admin password"); break;
 		case 'C': return __tr2qs("Forbid channel CTCPs"); break;
 		case 'D': return __tr2qs("Delay users join to first message"); break;
 		case 'M': return __tr2qs("Moderate non auth users"); break;
@@ -560,9 +564,12 @@ const QString & KviDarenetIrcServerInfo::getChannelModeDescription(char mode)
 		case 'R': return __tr2qs("Registered (staff only)"); break;
 		case 'S': return __tr2qs("Strip color codes"); break;
 		case 'T': return __tr2qs("No multi-targets"); break;
+		case 'U': return __tr2qs("User password"); break;
 		case 'Z': return __tr2qs("Need SSL connection to join"); break;
 		case 'c': return __tr2qs("No control codes (colors, bold, ..)"); break;
 		case 'd': return __tr2qs("Contains hidden users (previously +D)"); break;
+		case 'h': return __tr2qs("Half-operators"); break;
+		case 'q': return __tr2qs("Quiet"); break;
 		case 'r': return __tr2qs("Only registered nicks can join"); break;
 		case 'u': return __tr2qs("Squelch parts/quits"); break;
 		case 'z': return __tr2qs("Persistent (staff only)"); break;

--- a/src/kvirc/kernel/KviIrcConnectionServerInfo.cpp
+++ b/src/kvirc/kernel/KviIrcConnectionServerInfo.cpp
@@ -244,6 +244,8 @@ void KviIrcConnectionServerInfo::setServerVersion(const QString & version)
 		m_pServInfo = new KviInspIRCdIrcServerInfo(this, version);
 	else if(version.contains("snircd",Qt::CaseInsensitive))
 		m_pServInfo = new KviSnircdIrcServerInfo(this, version);
+	else if(version.contains("ircd-darenet",Qt::CaseInsensitive))
+		m_pServInfo = new KviDarenetIrcServerInfo(this, version);
 	else if(version.contains("u2",Qt::CaseInsensitive))
 		m_pServInfo = new KviIrcuIrcServerInfo(this, version);
 	else if(version.contains("plexus",Qt::CaseInsensitive))
@@ -252,6 +254,8 @@ void KviIrcConnectionServerInfo::setServerVersion(const QString & version)
 		m_pServInfo = new KviCritenIrcServerInfo(this, version);
 	else if(version.contains("nemesis",Qt::CaseInsensitive))
 		m_pServInfo = new KviNemesisIrcServerInfo(this, version);
+	else if(version.contains("oftc",Qt::CaseInsensitive))
+		m_pServInfo = new KviOftcIrcServerInfo(this, version);
 	else
 		m_pServInfo = new KviBasicIrcServerInfo(this, version);
 }
@@ -500,10 +504,15 @@ const QString & KviIrcuIrcServerInfo::getChannelModeDescription(char mode)
 {
 	switch(mode)
 	{
+		case 'A': return __tr2qs("Admin password"); break;
+		case 'C': return __tr2qs("Forbid channel CTCPs"); break;
 		case 'D': return __tr2qs("Delay users join to first message"); break;
-		case 'R': return __tr2qs("Registered"); break;
+		case 'R': return __tr2qs("Registered (staff only)"); break;
+		case 'U': return __tr2qs("User password"); break;
+		case 'c': return __tr2qs("No control codes (colors, bold, ..)"); break;
 		case 'd': return __tr2qs("Contains hidden users (previously +D)"); break;
 		case 'r': return __tr2qs("Only registered nicks can join"); break;
+		case 'z': return __tr2qs("Persistent (staff only)"); break;
 	}
 	return KviBasicIrcServerInfo::getChannelModeDescription(mode);
 }
@@ -513,6 +522,7 @@ const QString & KviPlexusIrcServerInfo::getChannelModeDescription(char mode)
 	switch(mode)
 	{
 		case 'B': return __tr2qs("Bandwidth Saver"); break;
+		case 'C': return __tr2qs("Forbid channel CTCPs"); break;
 		case 'M': return __tr2qs("Moderate non auth users"); break;
 		case 'N': return __tr2qs("Forbid channel NOTICEs"); break;
 		case 'O': return __tr2qs("IRC-Op only channel"); break;
@@ -523,6 +533,38 @@ const QString & KviPlexusIrcServerInfo::getChannelModeDescription(char mode)
 		case 'h': return __tr2qs("Half-operators");break;
 		case 'p': return __tr2qs("Paranoia"); break;
 		case 'q': return __tr2qs("Channel owners"); break;
+		case 'z': return __tr2qs("Persistent (staff only)"); break;
+	}
+	return KviBasicIrcServerInfo::getChannelModeDescription(mode);
+}
+
+const QString & KviOftcIrcServerInfo::getChannelModeDescription(char mode)
+{
+	switch(mode)
+	{
+		case 'M': return __tr2qs("Moderate non auth users"); break;
+		case 'R': return __tr2qs("Only registered nicks can join"); break;
+		case 'S': return __tr2qs("Need SSL connection to join"); break;
+	}
+	return KviBasicIrcServerInfo::getChannelModeDescription(mode);
+}
+
+const QString & KviDarenetIrcServerInfo::getChannelModeDescription(char mode)
+{
+	switch(mode)
+	{
+		case 'C': return __tr2qs("Forbid channel CTCPs"); break;
+		case 'D': return __tr2qs("Delay users join to first message"); break;
+		case 'M': return __tr2qs("Moderate non auth users"); break;
+		case 'N': return __tr2qs("Block channel notices"); break;
+		case 'R': return __tr2qs("Registered (staff only)"); break;
+		case 'S': return __tr2qs("Strip color codes"); break;
+		case 'T': return __tr2qs("No multi-targets"); break;
+		case 'Z': return __tr2qs("Need SSL connection to join"); break;
+		case 'c': return __tr2qs("No control codes (colors, bold, ..)"); break;
+		case 'd': return __tr2qs("Contains hidden users (previously +D)"); break;
+		case 'r': return __tr2qs("Only registered nicks can join"); break;
+		case 'u': return __tr2qs("Squelch parts/quits"); break;
 		case 'z': return __tr2qs("Persistent (staff only)"); break;
 	}
 	return KviBasicIrcServerInfo::getChannelModeDescription(mode);

--- a/src/kvirc/kernel/KviIrcConnectionServerInfo.h
+++ b/src/kvirc/kernel/KviIrcConnectionServerInfo.h
@@ -179,6 +179,30 @@ public:
 	virtual const QString & getChannelModeDescription(char mode);
 };
 
+class KVIRC_API KviOftcIrcServerInfo : public KviBasicIrcServerInfo
+{
+	//oftc; note: hybrid+oftc is an extension to hybrid
+public:
+	KviOftcIrcServerInfo(KviIrcConnectionServerInfo * pParent = 0, const QString & version = KviQString::Empty)
+		:KviBasicIrcServerInfo(pParent, version) {;};
+	virtual char getRegisterModeChar() { return 'R'; };
+	virtual const char * getSoftware() { return "Hybrid+Oftc"; };
+	virtual bool getNeedsOpToListModeseI() { return true; };
+	virtual const QString & getChannelModeDescription(char mode);
+};
+
+class KVIRC_API KviDarenetIrcServerInfo : public KviBasicIrcServerInfo
+{
+	//darenet; note: u2+ircd-darenet is an extension to ircu
+public:
+	KviDarenetIrcServerInfo(KviIrcConnectionServerInfo * pParent = 0, const QString & version = KviQString::Empty)
+		:KviBasicIrcServerInfo(pParent, version) {;};
+	virtual char getRegisterModeChar() { return 'r'; };
+	virtual const char * getSoftware() { return "Ircu+Darenet"; };
+	virtual bool getNeedsOpToListModeseI() { return false; };
+	virtual const QString & getChannelModeDescription(char mode);
+};
+
 class KVIRC_API KviIrcConnectionServerInfo
 {
 	friend class KviConsoleWindow; // for now

--- a/src/kvirc/sparser/KviIrcServerParser.h
+++ b/src/kvirc/sparser/KviIrcServerParser.h
@@ -136,8 +136,12 @@ private:
 	void parseNumeric003(KviIrcMessage *msg);
 	void parseNumeric004(KviIrcMessage *msg);
 	void parseNumeric005(KviIrcMessage *msg);
+	void parseNumeric020(KviIrcMessage *msg);
+	void parseNumeric344(KviIrcMessage *msg);
+	void parseNumeric345(KviIrcMessage *msg);
 	void parseNumeric367(KviIrcMessage *msg);
 	void parseNumeric368(KviIrcMessage *msg);
+	void parseNumeric480(KviIrcMessage *msg);
 	void parseNumeric728(KviIrcMessage *msg);
 	void parseNumeric729(KviIrcMessage *msg);
 
@@ -159,7 +163,6 @@ private:
 	void parseNumericReopList(KviIrcMessage *msg);
 	void parseNumericEndOfReopList(KviIrcMessage * msg);
 	void parseNumericInvited(KviIrcMessage * msg);
-	void parseNumericEndOfReopListOrInvited(KviIrcMessage *msg);
 	void parseNumericSpamFilterList(KviIrcMessage *msg);
 	void parseNumericEndOfSpamFilterList(KviIrcMessage *msg);
 	void parseNumericWhoReply(KviIrcMessage *msg);
@@ -197,7 +200,6 @@ private:
 	void parseNumericUserMode(KviIrcMessage * msg);
 	void parseNumericCodePageSet(KviIrcMessage * msg);
 	void parseNumericCodePageScheme(KviIrcMessage * msg);
-	void parseNumeric020(KviIrcMessage *msg);
 	void parseNumericCannotSend(KviIrcMessage *msg);
 	void parseNumericNoSuchChannel(KviIrcMessage *msg);
 	void parseNumericNoSuchServer(KviIrcMessage *msg);
@@ -218,6 +220,11 @@ private:
 	void parseCommandHelp(KviIrcMessage *msg);
 	void parseCommandEndOfHelp(KviIrcMessage *msg);
 	void parseChannelHelp(KviIrcMessage *msg);
+	void parseNumericNeedSSL(KviIrcMessage *msg);
+	void parseNumericOftcQuietList(KviIrcMessage *msg);
+	void parseNumericOftcEndOfQuietList(KviIrcMessage *msg);
+	void parseNumericQuietList(KviIrcMessage *msg);
+	void parseNumericEndOfQuietList(KviIrcMessage *msg);
 
 	void parseLiteralPing(KviIrcMessage *msg);
 	void parseLiteralJoin(KviIrcMessage *msg);

--- a/src/kvirc/sparser/KviIrcServerParser_tables.cpp
+++ b/src/kvirc/sparser/KviIrcServerParser_tables.cpp
@@ -433,8 +433,8 @@ messageParseProc KviIrcServerParser::m_numericParseProcTable[1000]=
 	PTM(parseNumericInviting)                      , // 341 RPL_INVITING
 	0,                                               // 342 RPL_SUMMONING
 	0,                                               // 343
-	PTM(parseNumericReopList)                      , // 344 RPL_REOPLIST
-	PTM(parseNumericEndOfReopListOrInvited)        , // 345 RPL_ENDOFREOPLIST, RPL_INVITED
+	PTM(parseNumeric344)                           , // 344 RPL_REOPLIST, RPL_QUIETLIST
+	PTM(parseNumeric345)                           , // 345 RPL_ENDOFREOPLIST, RPL_INVITED, RPL_QUIETLISTEND
 	PTM(parseNumericInviteList)                    , // 346 RPL_INVITELIST
 	PTM(parseNumericEndOfInviteList)               , // 347 RPL_ENDOFINVITELIST
 	PTM(parseNumericExceptList)                    , // 348 RPL_EXCEPTLIST
@@ -569,7 +569,7 @@ messageParseProc KviIrcServerParser::m_numericParseProcTable[1000]=
 	PTM(parseChannelHelp),                           // 477 RPL_CHANNELHELP
 	0,                                               // 478 ERR_BANLISTFULL
 	0,                                               // 479 ERR_BADCHANNAME, ERR_LINKFAIL
-	0,                                               // 480 ERR_NOULINE, ERR_CANNOTKNOCK
+	PTM(parseNumeric480),                            // 480 ERR_NOULINE, ERR_CANNOTKNOCK, ERR_SSLONLYCHAN
 	0,                                               // 481 ERR_NOPRIVILEGES
 	PTM(otherChannelError),                          // 482 ERR_CHANOPRIVSNEEDED
 	0,                                               // 483 ERR_CANTKILLSERVER


### PR DESCRIPTION
IRCds added: hybrid+oftc, u2+ircd-darenet
IRCds modified: IRCu(Added +AU[.13+] +czCR[previously missing]),
Plexus(Added +C[previously missing])

Numerics added/modified: 480(Added function for SSL information),
344(Added handler for RPL_REOPLIST or RPL_QUIETLIST[oftc/darenet]),
345(Added handler for oftc/darenet RPL_QUIETLISTEND)
728(Added handler for OFTC style quiet lists)
729(Added handler for OFTC style RPL_QUIETLISTEND[darenet])

---

Not a whole lot I can say, I'm starting to add more support for newer IRCds. A plan I have in the future is to create base classes for TS6 and P10 based servers then create derived classes for it's forks to make adding and modifying new IRCds a bit easier and require less code. But this is what I can come up with for the moment, I'll open another pull request (assuming you find this useful) with more IRCd support in a little bit.
