### PR TITLE
fix #1591 add custom cursor thickness size

### DIFF
--- a/src/kvirc/kernel/KviOptions.cpp
+++ b/src/kvirc/kernel/KviOptions.cpp
@@ -333,7 +333,8 @@ KviBoolOption g_boolOptionsTable[KVI_NUM_BOOL_OPTIONS]=
 	BOOL_OPTION("ShowDialogOnChannelCtcpPage",false,KviOption_sectFlagCtcp),
 	BOOL_OPTION("PopupNotifierOnNewNotices",true,KviOption_sectFlagFrame),
 	BOOL_OPTION("UserListViewUseAwayColor",true,KviOption_sectFlagUserListView | KviOption_resetUpdateGui),
-	BOOL_OPTION("ShowUserFlagForChannelsInWindowList",true,KviOption_sectFlagWindowList | KviOption_resetUpdateGui)
+	BOOL_OPTION("ShowUserFlagForChannelsInWindowList",true,KviOption_sectFlagWindowList | KviOption_resetUpdateGui),
+	BOOL_OPTION("EnableCustomCursorWidth",false,KviOption_resetUpdateGui)
 };
 
 #define STRING_OPTION(_txt,_val,_flags) KviStringOption(KVI_STRING_OPTIONS_PREFIX _txt,_val,_flags)
@@ -669,7 +670,8 @@ KviUIntOption g_uintOptionsTable[KVI_NUM_UINT_OPTIONS]=
 	UINT_OPTION("OnJoinRequestsDelay",1,KviOption_sectFlagConnection), // FIXME: Wouldn't this be nicer in msecs defaulting to 100-200 ?
 	UINT_OPTION("ToolBarIconSize",22,KviOption_groupTheme | KviOption_resetReloadImages),
 	UINT_OPTION("ToolBarButtonStyle",0,KviOption_groupTheme ), // 0 = Qt::ToolButtonIconOnly
-	UINT_OPTION("MaximumBlowFishKeySize",56,KviOption_sectFlagNone)
+	UINT_OPTION("MaximumBlowFishKeySize",56,KviOption_sectFlagNone),
+	UINT_OPTION("CustomCursorWidth",1,KviOption_resetUpdateGui)
 };
 
 #define FONT_OPTION(_name,_face,_size,_flags) \

--- a/src/kvirc/kernel/KviOptions.h
+++ b/src/kvirc/kernel/KviOptions.h
@@ -353,8 +353,9 @@ DECLARE_OPTION_STRUCT(KviStringListOption,QStringList)
 #define KviOption_boolPopupNotifierOnNewNotices 258                      /* query */
 #define KviOption_boolUserListViewUseAwayColor 259                       /* userlist */
 #define KviOption_boolShowUserFlagForChannelsInWindowList 260
+#define KviOption_boolEnableCustomCursorWidth 261                          /* interface */
 
-#define KVI_NUM_BOOL_OPTIONS 261
+#define KVI_NUM_BOOL_OPTIONS 262
 
 
 #define KVI_STRING_OPTIONS_PREFIX "string"
@@ -547,7 +548,7 @@ DECLARE_OPTION_STRUCT(KviStringListOption,QStringList)
 #define KviOption_uintOutgoingTrafficLimitUSeconds 13                /* connection::transport */
 #define KviOption_uintNotifyListIsOnDelayTimeInSecs 14               /* notify */
 #define KviOption_uintNotifyListUserhostDelayTimeInSecs 15           /* notify */
-#define KviOption_uintTreeWindowListMinimumWidth 16           /* ?? interface::general ?? */
+#define KviOption_uintTreeWindowListMinimumWidth 16                  /* ?? interface::general ?? */
 #define KviOption_uintAvatarOfferTimeoutInSecs 17                    /* irc::ctcp::avatar */
 #define KviOption_uintIrcViewMaxBufferSize 18                        /* interface::features::components::ircview */
 #define KviOption_uintIrcViewToolTipTimeoutInMsec 19                 /* interface::features::components::ircview */
@@ -618,8 +619,9 @@ DECLARE_OPTION_STRUCT(KviStringListOption,QStringList)
 #define KviOption_uintToolBarIconSize 79
 #define KviOption_uintToolBarButtonStyle 80
 #define KviOption_uintMaximumBlowFishKeySize 81
+#define KviOption_uintCustomCursorWidth 82                             /* Interface */
 
-#define KVI_NUM_UINT_OPTIONS 82
+#define KVI_NUM_UINT_OPTIONS 83
 
 namespace KviIdentdOutputMode {
 	enum Mode {

--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -132,12 +132,6 @@ KviInputEditor::KviInputEditor(QWidget * pPar, KviWindow * pWnd, KviUserListView
 	m_pUndoStack = NULL;
 	m_pRedoStack = NULL;
 
-#if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
-	SystemParametersInfo(SPI_GETCARETWIDTH, 0, &m_iCursorWidth, 0);
-#else //COMPILE_ON_WINDOWS || COMPILE_ON_MINGW
-	m_iCursorWidth = KVI_OPTION_UINT(KviOption_uintCustomCursorWidth);
-#endif
-
 	setAttribute(Qt::WA_InputMethodEnabled, true);
 
 	setAutoFillBackground(false);
@@ -191,8 +185,18 @@ void KviInputEditor::applyOptions(bool bRefreshCachedMetrics)
 	newFont.setKerning(false);
 	newFont.setStyleStrategy(QFont::StyleStrategy(newFont.styleStrategy() | QFont::ForceIntegerMetrics));
 	setFont(newFont);
+
 	//set cursor custom width
-	m_iCursorWidth = KVI_OPTION_UINT(KviOption_uintCustomCursorWidth);
+	if (KVI_OPTION_BOOL(KviOption_boolEnableCustomCursorWidth))
+	{
+		m_iCursorWidth = KVI_OPTION_UINT(KviOption_uintCustomCursorWidth);
+	} else {
+#if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
+		SystemParametersInfo(SPI_GETCARETWIDTH, 0, &m_iCursorWidth, 0);
+#else //COMPILE_ON_WINDOWS || COMPILE_ON_MINGW
+		m_iCursorWidth = 1;
+#endif
+	}
 
 	if(bRefreshCachedMetrics)
 	{

--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -117,7 +117,7 @@ KviInputEditor::KviInputEditor(QWidget * pPar, KviWindow * pWnd, KviUserListView
 	m_bTextDisplayBufferDirty = true;
 
 	m_bCursorOn            = false;                         //Cursor state
-	m_iCursorTimer         = 0;                             //Timer that iverts the cursor state
+	m_iCursorTimer         = 0;                             //Timer that inverts the cursor state
 	m_iDragTimer           = 0;                             //Timer for drag selection updates
 	m_iLastCursorXPosition = 0;                             //Calculated in paintEvent
 	m_iSelectionAnchorChar = -1;                            //Character clicked at the beginning of the selection process
@@ -135,7 +135,7 @@ KviInputEditor::KviInputEditor(QWidget * pPar, KviWindow * pWnd, KviUserListView
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
 	SystemParametersInfo(SPI_GETCARETWIDTH, 0, &m_iCursorWidth, 0);
 #else //COMPILE_ON_WINDOWS || COMPILE_ON_MINGW
-	m_iCursorWidth = 1;
+	m_iCursorWidth = KVI_OPTION_UINT(KviOption_uintCustomCursorWidth);
 #endif
 
 	setAttribute(Qt::WA_InputMethodEnabled, true);
@@ -191,6 +191,8 @@ void KviInputEditor::applyOptions(bool bRefreshCachedMetrics)
 	newFont.setKerning(false);
 	newFont.setStyleStrategy(QFont::StyleStrategy(newFont.styleStrategy() | QFont::ForceIntegerMetrics));
 	setFont(newFont);
+	//set cursor custom width
+	m_iCursorWidth = KVI_OPTION_UINT(KviOption_uintCustomCursorWidth);
 
 	if(bRefreshCachedMetrics)
 	{

--- a/src/modules/options/OptionsWidget_input.cpp
+++ b/src/modules/options/OptionsWidget_input.cpp
@@ -155,7 +155,11 @@ OptionsWidget_inputFeatures::OptionsWidget_inputFeatures(QWidget * parent)
 
 	addStringSelector(g,__tr2qs_ctx("Nick completion postfix string","options"),KviOption_stringNickCompletionPostfix);
 	addBoolSelector(g,__tr2qs_ctx("Use the completion postfix string for the first word only","options"),KviOption_boolUseNickCompletionPostfixForFirstWordOnly);
-	addRowSpacer(0,6,0,6);
+
+	KviBoolSelector *d = addBoolSelector(0,6,0,6,__tr2qs_ctx("Enable custom cursor width","options"),KviOption_boolEnableCustomCursorWidth);
+	KviUIntSelector *f = addUIntSelector(0,7,0,7,__tr2qs_ctx("Cursor width - in pixels","options"),KviOption_uintCustomCursorWidth,1,24,8,true);
+	connect(d,SIGNAL(toggled(bool)),f,SLOT(setEnabled(bool)));
+	addRowSpacer(0,8,0,8);
 }
 
 OptionsWidget_inputFeatures::~OptionsWidget_inputFeatures()

--- a/src/modules/options/OptionsWidget_input.cpp
+++ b/src/modules/options/OptionsWidget_input.cpp
@@ -156,8 +156,9 @@ OptionsWidget_inputFeatures::OptionsWidget_inputFeatures(QWidget * parent)
 	addStringSelector(g,__tr2qs_ctx("Nick completion postfix string","options"),KviOption_stringNickCompletionPostfix);
 	addBoolSelector(g,__tr2qs_ctx("Use the completion postfix string for the first word only","options"),KviOption_boolUseNickCompletionPostfixForFirstWordOnly);
 
-	KviBoolSelector *d = addBoolSelector(0,6,0,6,__tr2qs_ctx("Enable custom cursor width","options"),KviOption_boolEnableCustomCursorWidth);
-	KviUIntSelector *f = addUIntSelector(0,7,0,7,__tr2qs_ctx("Cursor width - in pixels","options"),KviOption_uintCustomCursorWidth,1,24,8,true);
+	KviBoolSelector *d = addBoolSelector(0,6,0,6,__tr2qs_ctx("Use a custom cursor width","options"),KviOption_boolEnableCustomCursorWidth);
+	KviUIntSelector *f = addUIntSelector(0,7,0,7,__tr2qs_ctx("Custom cursor width:","options"),KviOption_uintCustomCursorWidth,1,24,8,KVI_OPTION_BOOL(KviOption_boolEnableCustomCursorWidth));
+	f->setSuffix(__tr2qs_ctx(" px","options"));
 	connect(d,SIGNAL(toggled(bool)),f,SLOT(setEnabled(bool)));
 	addRowSpacer(0,8,0,8);
 }


### PR DESCRIPTION
By default it will look like this (with this PR) in Linux

If I understand https://github.com/kvirc/KVIrc/commit/a506f83cf7861f105546fc72065838e6fee1efd0 correctly, Windows users get the Windows default or what their accessibility options defines.

That would be ideal in Linux counterparts but Ive no idea how to achieve that.

**Before**
![capture](https://cloud.githubusercontent.com/assets/3521959/10187389/1d1ba592-6750-11e5-8fbb-97adaa994e07.PNG)

**After**
![capture1](https://cloud.githubusercontent.com/assets/3521959/10187370/fc3044fa-674f-11e5-895c-50327de81e08.png)

We can either make the cursor 2 pixels wide or better, this one uses 8 since its my preferred cursor type and what Im use to in all terminals.
