### PR TITLE
protocol: Hook 345 for ircd-darenet

### DIFF
--- a/src/kvirc/sparser/KviIrcServerParser_numericHandlers.cpp
+++ b/src/kvirc/sparser/KviIrcServerParser_numericHandlers.cpp
@@ -2174,7 +2174,7 @@ void KviIrcServerParser::parseNumeric345(KviIrcMessage * msg)
 	KviIrcConnectionServerInfo * pServerInfo = msg->connection()->serverInfo();
 
 	QString version = pServerInfo->software();
-	if(version == "Snircd" || version == "Ircu")
+	if(version == "Snircd" || version == "Ircu" || version == "Ircu+Darenet")
 		parseNumericInvited(msg);
 	else if(version == "Hybrid+Oftc")
 		parseNumericOftcEndOfQuietList(msg);


### PR DESCRIPTION
ircd-darenet is also a fork of IRCu, which means that
numeric 345 is also its RPL_INVITED.
