### PR TITLE
Split from #1631 - Simpler to digest typos and capitalization fixes and syntax normalization.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -259,7 +259,7 @@ February 2010
    - Readded the theme choice on first setup
    [Noldor]
    - Rewrote the aliaseditor module
-   - kvirc theme manager script
+   - KVIrc theme manager script
    - Created classeditor module
    [HelLViS69]
    - Readded the ability to customize CTCP version reply
@@ -482,7 +482,7 @@ October 2009
    - Splitted locale stuff for object classes
 
    [HelLViS69]
-   - Splitted locale stuff for kvirc target
+   - Splitted locale stuff for KVIrc target
 
 04 November 2008
    [CtrlAltCa]
@@ -2652,7 +2652,7 @@ Christmas Eve (Western Hemisphere) 2003:
     - Preliminary rearrangements of code for KviConsole.... the header is
       becoming a mess need to order the code syntactically and then maybe extract
       some code to be put in external classes. KviIrcConnection could be an idea.
-    - Beginning of code for the toolbar button management... need a module ?
+    - Beginning of code for the toolbar button management... need a module?
 
 29 Mar 2002:
     [Pragma]

--- a/cmake/kvirc-config.cmake
+++ b/cmake/kvirc-config.cmake
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-#   A script for retrieving the latest kvirc build configuration
+#   A script for retrieving the latest KVIrc build configuration
 #   Mainly used for building plugins out of the source tree
 #   The idea is "stolen" from the gtk-config and xmms-config scripts :)
 #

--- a/data/config/preinstalled.kvc.win32-example
+++ b/data/config/preinstalled.kvc.win32-example
@@ -6,7 +6,7 @@
 ## for Windows with custom preferences. You can tell
 ## KVIrc to skip some pages in setup wizard. For
 ## example, you can use custom serverlist, or tell
-## KVIrc to not show directody selection dialog, if
+## KVIrc to not show directory selection dialog, if
 ## you think, that it is confusing users.
 
 #[Setup]

--- a/data/defscript/CMakeLists.txt
+++ b/data/defscript/CMakeLists.txt
@@ -6,7 +6,7 @@ if(UNIX)
 	if(APPLE)
 		install(FILES ${files} DESTINATION ${CMAKE_INSTALL_PREFIX}/Contents/Resources/defscript/)
 	else()
-		# Assume linux
+		# Assume Linux
 		install(FILES ${files} DESTINATION ${CMAKE_INSTALL_PREFIX}/share/kvirc/${VERSION_BRANCH}/defscript/)
 	endif()
 elseif(WIN32)

--- a/data/defscript/aliases.kvs
+++ b/data/defscript/aliases.kvs
@@ -307,7 +307,7 @@ alias(awayall)
 
 # notify: this is a bit more complex
 # We want to add an user to the notify list with a single command
-# The notify lists are handled thru the registered users database
+# The notify lists are handled through the registered users database
 alias(notify)
 {
 	# This one adds a registered users database entry
@@ -338,7 +338,7 @@ alias(notify)
 
 	%oldNicks = $reguser.property($0,notify)
 
-	# It would be a good idea to check if the nikckname is already in the %oldNicks list
+	# It would be a good idea to check if the nickname is already in the %oldNicks list
 	# but this is left as exercise for the reader.
 
 	%oldNicks << $0
@@ -390,7 +390,7 @@ alias(ignore)
 	}
 }
 
-# Dcc...people commonly use "dcc send" instead of "dcc.send"
+# DCC... people commonly use "dcc send" instead of "dcc.send"
 alias(dcc)
 {
 	switch($0)
@@ -423,7 +423,7 @@ alias(dcc)
 }
 
 #
-# return a string with the name of the curerent usermode
+# return a string with the name of the current usermode
 #
 alias(usermodename)
 {

--- a/data/defscript/toolbars.kvs
+++ b/data/defscript/toolbars.kvs
@@ -1,7 +1,7 @@
 # Default toolbars file
 
 toolbar.create irccontext $tr("IRC Context","defscript") $icon("irc4")
-# toolbar.additem irccontext kvirc.irccontextdisplay - info dublicated with te status line
+# toolbar.additem irccontext kvirc.irccontextdisplay - info duplicated with the status line
 toolbar.additem irccontext kvirc.connect
 toolbar.additem irccontext kvirc.servermenu
 toolbar.additem irccontext kvirc.newirccontext

--- a/data/doctemplates/ircintro.template
+++ b/data/doctemplates/ircintro.template
@@ -9,29 +9,29 @@
 	@body:
 		[big]What is IRC ?[/big][br]
 		Internet Relay Chat (IRC) is one of the most popular and most interactive services on the Internet.
-		When you've been wondering 'where the others are?', then IRC is what you're looking for.
+		When you've been wondering [i]where the others are?[/i], then IRC is what you're looking for.
 		IRC allows real-time conversations with people from the whole planet, 24-hours a day, worldwide.
 		[br]
 		[big]How does it work ?[/big][br]
-		IRC consists of various separate networks (or "nets") of IRC servers: machines that allow users to connect to IRC.
+		IRC consists of various separate networks (or [i]nets[/i]) of IRC servers: machines that allow users to connect to IRC.
 		The largest nets are EFnet (the original IRC net, often having more than 32,000 people at once), Undernet, IRCnet, DALnet, and NewNet.
-		Generally, the user (such as you) runs a program (called "irc client") to connect to a server on one of the IRC nets.
-		The server will relay the information between you and the "rest" of the network (obviously including the other irc users).
-		Each user is known on IRC by a nickname (or "nick"), such as smartgal or FunGuy.
-		To avoid conflicts with other users, it is best to use a nick that is not too common, e.g., "john" is a poor choice.
-		Some networks allow the registration of nicknames: once you have registered a nickname noone else will be able to use it.
-		Once connected to an IRC server on an IRC network, you will usually join one or more [b]channels[/b] and converse with other irc users.
+		Generally, the user (such as you) runs a program (called IRC client) to connect to a server on one of the IRC nets.
+		The server will relay the information between you and the [i]rest[/i] of the network (obviously including the other IRC users).
+		Each user is known on IRC by a nickname or [i]nick[/i], such as smartgal or FunGuy.
+		To avoid conflicts with other users, it is best to use a nick that is not too common, e.g., [i]john[/i] is a poor choice.
+		Some networks allow the registration of nicknames: once you have registered a nickname no one else will be able to use it.
+		Once connected to an IRC server on an IRC network, you will usually join one or more [b]channels[/b] and converse with other IRC users.
 		On EFnet, there often are more than 12,000 channels, each one devoted to a different topic.
 		[br]
 		[big]Channels[/big][br]
 		Channel names usually begin with a #, as in #irchelp.
 		The same channels are shared among all IRC servers on the same net, so you do not have to be on the same IRC server as your friends.
-		Each channel can be joined by a "virtually" unlimited number of users and every word spoken "to the channel" is
+		Each channel can be joined by a virtually unlimited number of users and every word spoken to the channel is
 		seen by all the users that have joined it.
 		Each channel has a topic that usually describes the ideas being exchanged between users in that moment.
-		It is a good idea to take a look at the topic before starting to talk "randomly" :).
-		Channels are run by channel operators, or just "ops" for short, who can control the channel by choosing who may join (by "banning" some users),
-		who must leave (by "kicking" them out), and even who may speak (by making the channel "moderated")!
+		It is a good idea to take a look at the topic before starting to talk [i]randomly[/i] :).
+		Channels are run by channel operators, or just [i]ops[/i] for short, who can control the channel by choosing who may join (by [i]banning[/i] some users),
+		who must leave (by [i]kicking[/i] them out), and even who may speak (by making the channel [i]moderated[/i])!
 		Channel ops have complete control over their channel, and their decisions are final.
 		If you are banned from a channel, send a /msg to a channel op and ask nicely to be let in
 		(see the /who command in the next section to learn how to find ops).
@@ -46,10 +46,10 @@
 		When you join a channel, say hello. Don't expect to get hello's back from everyone,
 		especially when there are lots of people on the channel.
 		If you've never visited the channel before and have no idea what to expect,
-		just sit back and watch for awhile to get a feel for the flow of the channel (thats called "lurking").
+		just sit back and watch for awhile to get a feel for the flow of the channel (thats called lurking).
 		[br]
 		[big]Finding more info[/big][br]
-		The web is full of information about IRC: it's just a matter of typing "IRC" in a search engine.
+		The web is full of information about IRC: it's just a matter of typing [i]IRC[/i] in a search engine.
 		An user-friendly site to start from might be www.irchelp.org: you will find a huge list of
 		documents and links that will hopefully answer to all your questions.
 		You may also give a short read to the [doc:kvircintro]Introduction to KVIrc[/doc] which will

--- a/data/doctemplates/kvircintro.template
+++ b/data/doctemplates/kvircintro.template
@@ -11,7 +11,7 @@
 
 		In really simple words KVIrc is a Chat client: you use it to talk to other
 		people over the internet. More specifically KVIrc is an IRC client
-		and if you haven't readed it yet please take a look at the [doc:ircintro]IRC introduction[/doc]
+		and if you haven't read it yet please take a look at the [doc:ircintro]IRC introduction[/doc]
 		then come back here. Now that you know what IRC is then you already know
 		that an IRC client acts as a relay for the information that you
 		exchange with your IRC server. KVIrc also acts as a filter and provides
@@ -20,28 +20,28 @@
 		KVIrc also contains a sophisticated scripting language that allows you to
 		implement automated reactions to the network events. This is something similar
 		to creating a robot that acts spontaneously after you have told him what to do.
-		The scripting language allows you to enchance the KVIrc's interface and
+		The scripting language allows you to enhance the KVIrc's interface and
 		to handle special IRC network features that KVIrc itself isn't aware of.
 
 		[big]History[/big]
 
-		The original meaning of the name "KVIrc" was, more or less, "K Visual IRC Client".
+		The original meaning of the name KVIrc was, more or less, [i]K Visual IRC Client[/i].
 		The initial K is a common prefix for the applications written for the KDE
 		desktop environment: this was the case of the initial versions of KVIrc.
-		Starting from version 2.0.0 the absolute KDE dependancy has been dropped (for several
+		Starting from version 2.0.0 the absolute KDE dependency has been dropped (for several
 		valid reasons) and the support became optional.[br]
-		"Visual" was (and is) one of the client goals: having an user-friendly interface to the IRC world.
-		Many extreme-unix users have misinterpreted the "user-friendly" interface and have tagged
-		KVIrc as a client for "newbies". Well... that is partially true: KVIrc is ALSO a client for newbies:
-		A total IRC novice should be able to "chat" in few minutes after installing the program,
-		preferably without bothering to read any manual. Yes ,I know that it is not in "unix"-style.
-		On the other side, KVIrc contains a whole bunch of compex features that can be discovered
+		[i]Visual[/i] was (and is) one of the client goals: having an user-friendly interface to the IRC world.
+		Many extreme UNIX users have misinterpreted the [i]user-friendly[/i] interface and have tagged
+		KVIrc as a client for newbies. Well... that is partially true: KVIrc is ALSO a client for newbies:
+		A total IRC novice should be able to chat in few minutes after installing the program,
+		preferably without bothering to read any manual. Yes, I know that it is not in [i]UNIX[/i] style.
+		On the other side, KVIrc contains a whole bunch of complex features that can be discovered
 		only by reading the documentation and experimenting. I bet that you can also
 		find a lot of undocumented tricks :)
 
-		[big]A bit of "philosophy"[/big]
+		[big]A bit of [i]philosophy[/i][/big]
 
-		At the time of writing (Feb 2005) KVIrc approaches release 3.2.0. The small
+		At the time of writing (Feb 2005) KVIrc approaches release 3.2.6. The small
 		[b]one-man-project[/b] has grown to the level of a small [b]community[/b].
 		People from around the world have joined our development efforts and are
 		constantly donating their time, eyes and bandwidth in order to make KVIrc
@@ -49,9 +49,9 @@
 		program for chatting, they are giving you the great opportunity to see what's behind
 		the scenes: you have the source code for the whole application.
 		In practical terms this means more or less 300.000 lines of tested, debugged and
-		commented C++ code, several perl scripts, dozens of makefiles and all the means
+		commented C++ code, several PERL scripts, dozens of makefiles and all the means
 		that you need to produce a working KVIrc executable on all the supported platforms.
-		There is a lot of knowledge (some people call it "technology" because it sells better)
+		There is a lot of knowledge (some people call it [i]technology[/i] because it sells better)
 		inside, ready to be acquired by an attentive reader. Don't forget that the freedom of
 		building your own executable from the sources gives you the opportunity
 		of verifying the source itself: for example you might be interested in verifying

--- a/data/man/kvirc.en.1
+++ b/data/man/kvirc.en.1
@@ -64,14 +64,14 @@ Use this port for connection.
 This option requires also a server name.
 .TP 8
 .B [ircurl]
-An url in the following form:
+An URL in the following form:
 
   irc[6]://<server>[:<port>][/<channel>[?<pass>]]
 
-For each url on the commandline create a new irc-context
+For each URL on the commandline create a new irc-context
 and attempt to connect to <server> on the specified <port>.
 The optional <channel> is joined just after the connection
-has been estabilished.
+has been established.
 
 .SH ENVIRONMENT
 .PP

--- a/data/resources_win32/version.h
+++ b/data/resources_win32/version.h
@@ -39,7 +39,7 @@
 #define VER_COMPANYNAME_STR		"KVIrc Development Team"
 #define VER_FILEDESCRIPTION_STR		"KVIrc"
 #define VER_INTERNALNAME_STR		"KVIrc"
-#define VER_LEGALCOPYRIGHT_STR		"Copyright © 2015"
+#define VER_LEGALCOPYRIGHT_STR		"Copyright Â© 2015"
 #define VER_ORIGINALFILENAME_STR	"kvirc.exe"
 #define VER_PRODUCTNAME_STR		"K Visual IRC Client"
 

--- a/doc/hackers.guide.txt
+++ b/doc/hackers.guide.txt
@@ -205,12 +205,12 @@ The source tree
 |       |                 to be loaded by the winamp program in order to make
 |       |                 communications with KVIrc possible.
 |       |
-|       |-- mircimport    A server entry importer from the mirc's servers.ini
+|       |-- mircimport    A server entry importer from the mIRC's servers.ini
 |       |
 |       |-- my            my.* scripting stuff
 |       |
 |       |-- notifier      the notifier module creates a dialog that keeps you
-|       |                 informed about new messages when kvirc is minimized
+|       |                 informed about new messages when KVIrc is minimized
 |       |
 |       |-- objects       All the object oriented scripting stuff
 |       |

--- a/scripts/config/kvirc4-config.in
+++ b/scripts/config/kvirc4-config.in
@@ -89,7 +89,7 @@ print_syntax()
 	echo "Syntax : kvirc-config [OPTIONS]"
 	echo "  options:"
 	echo "    --version         : KVIrc version"
-	echo "    --prefix          : Intallation prefix"
+	echo "    --prefix          : Installation prefix"
 	echo "    --include_dir     : KVIrc include directory (where headers are stored)"
 	echo "    --exec_prefix     : Binaries installation prefix"
 	echo "    --rpath_flags     : Rpath flags used in the KVIrc compilation"

--- a/src/kvilib/config/KviBuildInfo.h
+++ b/src/kvilib/config/KviBuildInfo.h
@@ -41,9 +41,9 @@
 * \brief This namespace contains information gathered at KVIrc build time.
 *
 * This, in fact, is the last time that "cmake" ran and successfully generated the
-* kvilib Makefile. Since kvilib is generally built with the kvirc
+* kvilib Makefile. Since kvilib is generally built with the KVIrc
 * executable, then you can assume that the information returned
-* from this namespace strictly applies also to kvirc.
+* from this namespace strictly applies also to KVIrc.
 */
 namespace KviBuildInfo
 {

--- a/src/kvilib/config/kvi_debug.h
+++ b/src/kvilib/config/kvi_debug.h
@@ -77,7 +77,7 @@
 	// The following two macros are used to create unique variable names
 	// by the means of the __LINE__ builtin macro.
 	// The ## token paste operator must be called inside a macro and must
-	// preceede a macro parameter. This is why we can't use directly
+	// precede a macro parameter. This is why we can't use directly
 	//
 	// #define UNIQUEVARIABLE int name ## __LINE__
 	//

--- a/src/kvilib/config/kvi_settings.h
+++ b/src/kvilib/config/kvi_settings.h
@@ -142,12 +142,12 @@
 
 
 /**
-* \def KVI_VERSION Defines the current kvirc version
-* \def KVIRC_VERSION_BRANCH Defines the kvirc version of the current branch
-* \def KVI_RELEASE_NAME Defines the codename for the current kvirc release
+* \def KVI_VERSION Defines the current KVIrc version
+* \def KVIRC_VERSION_BRANCH Defines the KVIrc version of the current branch
+* \def KVI_RELEASE_NAME Defines the codename for the current KVIrc release
 * \def _GNU_SOURCE Enables _GNU_SOURCE features
 * \def KVI_PTR2MEMBER Cross-platform macro that returns a member from its pointer
-* \def KVI_DEPRECATED Prefix for deprecated objects inside kvirc code (currently unused)
+* \def KVI_DEPRECATED Prefix for deprecated objects inside KVIrc code (currently unused)
 * \def BIG_ENDIAN_MACHINE_BYTE_ORDER If defined, the current target processor is big endian, little endian otherwise
 */
 

--- a/src/kvilib/core/kvi_inttypes.h
+++ b/src/kvilib/core/kvi_inttypes.h
@@ -79,7 +79,7 @@
 		typedef long int kvi_i32_t;
 		typedef unsigned long int kvi_u32_t;
 	#else
-		#error "Can't find a 32 bit integral type on this system"
+		#error "Can't find a 32-bit integral type on this system"
 		#error "Please report to pragma at kvirc dot net"
 	#endif
 
@@ -92,7 +92,7 @@
 		typedef int kvi_i16_t;
 		typedef long int kvi_u16_t;
 	#else
-		#error "Can't find a 16 bit integral type on this system"
+		#error "Can't find a 16-bit integral type on this system"
 		#error "Please report to pragma at kvirc dot net"
 	#endif
 

--- a/src/kvilib/ext/KviAnimatedPixmapCache.cpp
+++ b/src/kvilib/ext/KviAnimatedPixmapCache.cpp
@@ -183,10 +183,10 @@ void KviAnimatedPixmapCache::timeoutEvent()
 {
 	/*
 	* We are adding 15msecs to the current time. This MAY lead to the situation,
-	* when the current frame will be painted a bit earlier, then i should.
-	* But we are just playing animated gifs, not a HDTV video. So it should be ok.
+	* when the current frame will be painted a bit earlier, then I should.
+	* But we are just playing animated gifs, not a HDTV video. So it should be OK.
 	*
-	* But it makes good speedup if there will be event, sceduled in such order:
+	* But it makes good speedup if there will be event, scheduled in such order:
 	* 1 event  at time X
 	* 3 events at time X+2msec
 	* 2 events at time X+6msec

--- a/src/kvilib/ext/KviCryptEngine.cpp
+++ b/src/kvilib/ext/KviCryptEngine.cpp
@@ -129,7 +129,7 @@
 		Well, there is no protocol actually, only the existing implementations, that
 		can be accessed by anyone that want to reproduce them. There are only some
 		points relating to the crypting engines that need to be cleared:[br]
-		The crypted text must be suitable to be sent thru an IRC connection;
+		The crypted text must be suitable to be sent through an IRC connection;
 		this means that some characters can not appear in the crypted text (e.g. CR,LF,NULL....).
 		KVIrc solves it in a simple way: the crypted binary data is encoded,
 		either as hexadecimal numeric string or in base64.[br]

--- a/src/kvilib/ext/KviCryptEngine.h
+++ b/src/kvilib/ext/KviCryptEngine.h
@@ -93,7 +93,7 @@ class KviCString;
 		//
 		// Encrypts utf8 plainText and returns the encrypted
 		// data in outBuffer. The encrypted data must be
-		// suitable for sending thru an IRC (eventually DCC
+		// suitable for sending through an IRC (eventually DCC
 		// that is less restrictive) connection and must be utf8 encoded: so
 		// no NULL, CR and LF in the output.
 		// 0x01 should be also avoided since

--- a/src/kvilib/file/KviFileUtils.h
+++ b/src/kvilib/file/KviFileUtils.h
@@ -51,7 +51,7 @@
 #endif
 
 // #warning "Add kvi_trashFile(const char * path) ? - is it needed in the whole app"
-// #warning "or should it be availible only for dirbrowser module ?"
+// #warning "or should it be available only for dirbrowser module?"
 /**
 * \namespace KviFileUtils
 * \brief A namespace to handle file utilities functions

--- a/src/kvilib/irc/KviControlCodes.h
+++ b/src/kvilib/irc/KviControlCodes.h
@@ -49,7 +49,7 @@
 
 
 // ASCII Stuff: the following defines are meant to be escape sequences
-//              that can go thru an IRC connection
+//              that can go through an IRC connection
 
 // The following table is a 30-minute analysis of the escape characters commonly used over the IRC protocol...
 // created when looking for a good placement for the CRYPT escape char in KVirc.

--- a/src/kvilib/irc/KviIrcServerDataBase.cpp
+++ b/src/kvilib/irc/KviIrcServerDataBase.cpp
@@ -163,7 +163,7 @@ bool KviIrcServerDataBase::makeCurrentServer(KviIrcServerDefinition * pDef, QStr
 		KviIrcNetwork * pNet = m_pRecords->find(szNet);
 		if(pNet)
 			return makeCurrentBestServerInNetwork(szNet,pNet,szError);
-		szError = __tr2qs("The server specification seems to be in the net:<string> but the network couln't be found in the database");
+		szError = __tr2qs("The server specification seems to be in the net:<string> but the network couldn't be found in the database");
 		return false;
 	}
 
@@ -185,7 +185,7 @@ bool KviIrcServerDataBase::makeCurrentServer(KviIrcServerDefinition * pDef, QStr
 			}
 			++it;
 		}
-		szError = __tr2qs("The server specification seems to be in the id:<string> form but the identifier coulnd't be found in the database");
+		szError = __tr2qs("The server specification seems to be in the id:<string> form but the identifier couldn't be found in the database");
 		return false;
 	}
 

--- a/src/kvilib/net/KviDnsResolverNew.cpp
+++ b/src/kvilib/net/KviDnsResolverNew.cpp
@@ -141,7 +141,7 @@ void KviDnsResolver::slotHostLookupTerminated(const QHostInfo &oHostInfo)
 				m_pPrivateData->pAddressList->append(new QString(oAddress.toString()));
 			break;
 			default:
-				KVI_ASSERT_MSG(false,"Invalid dns query type!");
+				KVI_ASSERT_MSG(false,"Invalid DNS query type!");
 				m_pPrivateData->eState = Failure;
 				m_pPrivateData->eError = KviError::InternalError;
 				m_pPrivateData->szError = __tr2qs("Internal error: unhandled DNS query type");

--- a/src/kvirc/kernel/KviActionManager.cpp
+++ b/src/kvirc/kernel/KviActionManager.cpp
@@ -59,12 +59,12 @@ KviActionManager::KviActionManager()
 	__var = new KviActionCategory(__name,__vname,__descr); \
 	m_pCategories->replace(__name,__var)
 
-	CATEGORY(m_pCategoryIrc,"irc",__tr2qs("IRC"),__tr2qs("IRC Context related actions"));
+	CATEGORY(m_pCategoryIrc,"irc",__tr2qs("IRC"),__tr2qs("IRC context related actions"));
 	CATEGORY(m_pCategoryGeneric,"generic",__tr2qs("Generic"),__tr2qs("Generic actions"));
 	CATEGORY(m_pCategorySettings,"settings",__tr2qs("Settings"),__tr2qs("Actions related to settings"));
 	CATEGORY(m_pCategoryScripting,"scripting",__tr2qs("Scripting"),__tr2qs("Scripting related actions"));
 	CATEGORY(m_pCategoryGUI,"gui",__tr2qs("GUI"),__tr2qs("Actions related to the Graphic User Interface"));
-	CATEGORY(m_pCategoryChannel,"channel",__tr2qs("Channel"),__tr2qs("IRC Channel related actions"));
+	CATEGORY(m_pCategoryChannel,"channel",__tr2qs("Channel"),__tr2qs("IRC channel related actions"));
 	CATEGORY(m_pCategoryTools,"tools",__tr2qs("Tools"),__tr2qs("Actions that will appear in the \"Tools\" menu"));
 
 	m_bCustomizingToolBars = false;
@@ -282,7 +282,7 @@ KviAction * KviActionManager::getAction(const QString &szName)
 	if((idx == 5) && (!m_bCoreActionsRegistered))
 	{
 		// the core actions are all like kvirc.name
-		// so the dot is at poisition 5 (6th char)
+		// so the dot is at position 5 (6th char)
 		// the first requested core action will trigger this
 		// the nice thing is that we will probably already have a frame when
 		// the core actions are registered thus stuff like windowStack() can be accessed...

--- a/src/kvirc/kernel/KviApplication.cpp
+++ b/src/kvirc/kernel/KviApplication.cpp
@@ -1069,11 +1069,11 @@ void KviApplication::checkSuggestRestoreDefaultScript()
 		switch(
 			QMessageBox::question(0,__tr2qs("Update default scripts"),
 				__tr2qs("<b>Hi!</b><br><br>" \
-					"<b>It seems that you have just upgraded KVirc from a previous version.</b><br><br>" \
+					"<b>It seems that you have just upgraded KVIrc from a previous version.</b><br><br>" \
 					"The KVIrc default scripts needs to be updated too, to play nice with your fresh new KVIrc.<br>" \
 					"You may want to avoid this update if you plan to revert to a previous KVIrc version soon," \
 					"or if you have created a lot of custom scripts and want to stay safe and avoid any deletion or overwrite.<br>" \
-					"If you want to update the default scripts, i can restore the new default script for you.<br>" \
+					"If you want to update the default scripts, I can restore the new default script for you.<br>" \
 					"<b>Do you want the default script to be restored?</b><br><br>"),
 				__tr2qs("No and Don't Ask Me Again"),__tr2qs("No"),__tr2qs("Yes"),1,1)
 		)

--- a/src/kvirc/kernel/KviIrcContext.cpp
+++ b/src/kvirc/kernel/KviIrcContext.cpp
@@ -682,7 +682,7 @@ void KviIrcContext::connectionEstabilished()
 {
 	//qDebug("context::connectionEstabilished");
 	//
-	// The connection has been estabilished, the
+	// The connection has been established, the
 	// KviIrcConnection will attempt to login now
 	//
 	m_uConnectAttemptCount = 1;

--- a/src/kvirc/kernel/KviUserInput.cpp
+++ b/src/kvirc/kernel/KviUserInput.cpp
@@ -129,7 +129,7 @@ namespace KviUserInput
 							return;
 						}
 					}
-					pWindow->output(KVI_OUT_PARSERERROR,__tr2qs("You are not connected to a server"));
+					pWindow->output(KVI_OUT_PARSERERROR,__tr2qs("You're not connected to a server"));
 				break;
 				case KviWindow::Channel:
 				case KviWindow::Query:

--- a/src/kvirc/kvs/KviKvsCoreCallbackCommands.cpp
+++ b/src/kvirc/kvs/KviKvsCoreCallbackCommands.cpp
@@ -77,14 +77,14 @@ namespace KviKvsCoreCallbackCommands
 			$0 contains the query string (<dnsquery> in fact)[br]
 			$1 contains the value 1 if the query was succesfull.[br]
 			In that case the remaining parameters are set as follows:[br]
-			$2 contains the first ip address associated to the <dnsquery>[br]
+			$2 contains the first IP address associated to the <dnsquery>[br]
 			$3 contains the hostname associated to the <dnsquery>[br]
 			$4 contains the eventual <magicdata> passed.[br]
 			If $1 contains the value 0 then the query has failed and[br]
 			$2 contains an error message explaining the failure.[br]
 			$3 is empty[br]
 			$4 contains the eventual <magicdata> passed.[br]
-			Please note that if the dns query fails to even start for some
+			Please note that if the DNS query fails to even start for some
 			reason then your callback MAY be called even before ahost() returns.[br]
 		@switches:
 			!sw: -i
@@ -180,7 +180,7 @@ namespace KviKvsCoreCallbackCommands
 			The implementation code can be either a single KVS instruction
 			or an instruction block (instruction list enclosed in braces).[br]
 			If the alias already exists, it is replaced with the new implementation.[br]
-			If the <implementation> is empty (eg. "{}" or just a ";")
+			If the <implementation> is empty (e.g. "{}" or just a ";")
 			the alias <alias_name> is removed.
 			If the "remove" form is used but the specified <alias_name> does not exist
 			in the alias store then a warning is printed unless
@@ -224,7 +224,7 @@ namespace KviKvsCoreCallbackCommands
 		@type:
 			command
 		@short:
-			A synomim for alias
+			A synonym for alias
 		@syntax:
 			function [-q] (<function_name>) <implementation>
 			function [-q] (<function_name>){}
@@ -232,7 +232,7 @@ namespace KviKvsCoreCallbackCommands
 			!sw: -q | --quiet
 			Causes the command to run quietly
 		@description:
-			This command is a synonim for [cmd]alias[/cmd].
+			This command is a synonym for [cmd]alias[/cmd].
 		@seealso:
 			[doc:kvs_aliasesandfunctions]Aliases and functions[/doc]
 	*/
@@ -264,7 +264,7 @@ namespace KviKvsCoreCallbackCommands
 		tmp.replace("::","@"); // @ is not allowed by the rule above
 		if(tmp.indexOf(":") != -1)
 		{
-			KVSCCC_pContext->error(__tr2qs_ctx("Stray ':' character in alias name: did you mean ...<namespace>::<name> ?","kvs"));
+			KVSCCC_pContext->error(__tr2qs_ctx("Stray ':' character in alias name: did you mean ...<namespace>::<name>?","kvs"));
 			return false;
 		}
 
@@ -322,7 +322,7 @@ namespace KviKvsCoreCallbackCommands
 			Asynchronous WHOIS
 		@switches:
 			!sw: -i | --idle-time
-			Ask the whois information to the server that <nickname> is
+			Ask the WHOIS information to the server that <nickname> is
 			connected to, effectively returning the user's idle time.
 		@description:
 			AWHOIS stands for Asynchronous WHOIS. It is used to obtain data for a specified
@@ -343,10 +343,10 @@ namespace KviKvsCoreCallbackCommands
 			$7 = channels (may be empty)[br]
 			$8 = server that provided the information[br]
 			$9 = away message (empty if user hasn't set an away message)[br]
-			$10 = magic string evaluated at awhois call (may be empty)[br]
+			$10 = magic string evaluated at AWHOIS call (may be empty)[br]
 			$11 = account the user is logged into (may be empty)[br]
 			$12 = additional, server-specific info (may be empty)[br]
-			If the -i switch is specified, the whois message is sent to the server
+			If the -i switch is specified, the WHOIS message is sent to the server
 			that the <nickname> user is connected to; in this way you will probably
 			get the idle time of the user too.[br]
 			If the server replies with a "No such nick/channel error message" the
@@ -423,7 +423,7 @@ namespace KviKvsCoreCallbackCommands
 			The button is added to the current window; if you want to add it to a different
 			window, use the [doc:command_rebinding]standard -r command rebinding[/doc] switch.[br]
 			The <callback_code> will be executed as reaction to a button press; the
-			code execution will be bound to the window that the button is attacched to.[br]
+			code execution will be bound to the window that the button is attached to.[br]
 			If a button with <name> already exists in the current window, its parameters are changed
 			according to the passed values (<image_id>, <label_text> and <callback_code>).[br]
 			[br]
@@ -889,7 +889,7 @@ namespace KviKvsCoreCallbackCommands
 					break;
 					case(4):
 					{
-						[comment]# Waiting for 354 (ok, go on)[/comment]
+						[comment]# Waiting for 354 (OK, go on)[/comment]
 						if($str.match("354*",$1))
 						{
 							%:state++
@@ -1076,7 +1076,7 @@ namespace KviKvsCoreCallbackCommands
 			The -p switch causes the timer to be persistent across the application and exists until
 			the last window has been closed: it is basically rebound to another (random) window when the
 			original window is destroyed.[br]
-			The -s switch cuases this timer to trigger only once: it will be automatically destroyed after that.[br]
+			The -s switch causes this timer to trigger only once: it will be automatically destroyed after that.[br]
 			The time has an associated set of [doc:data_structures]extended scope variables[/doc]:
 			the variables that begin with "%:" have their life extended to the whole "life" of the timer.[br]
 			Using a very low delay is a common method to perform some background processing: you
@@ -1085,7 +1085,7 @@ namespace KviKvsCoreCallbackCommands
 			KVIrc has some "idle time" to spend.
 			On the other hand, remember that timers are precious resources: many timers running
 			with a very low delay will cause KVIrc to slow down.[br]
-			Since all the kvirc timers share the same namespace it is a good idea to use
+			Since all the KVIrc timers share the same namespace it is a good idea to use
 			descriptive timer names: a timer named "a" is likely to be used by two or more scripts
 			at once causing one (or both) of them to fail.[br]
 			A timer can be stopped at any time by using the [cmd]killtimer[/cmd] command.

--- a/src/kvirc/kvs/KviKvsCoreFunctions_af.cpp
+++ b/src/kvirc/kvs/KviKvsCoreFunctions_af.cpp
@@ -647,14 +647,14 @@ namespace KviKvsCoreFunctions
 		@title:
 			$char
 		@short:
-			Returns a character specified by unicode
+			Returns a character specified by Unicode
 		@syntax:
 			<string> $char(<unicode_value:integer>)
 		@description:
-			Returns a character corresponding to the UNICODE code <unicode_value>.[br]
-			This function can not return NUL character (UNICODE 0). Basically
+			Returns a character corresponding to the Unicode code <unicode_value>.[br]
+			This function can not return NUL character (Unicode 0). Basically
 			you should never need it: if you do, drop me a mail.[br]
-			If the <unicode_code> is not a valid UNICODE code (or is 0), this function returns
+			If the <unicode_code> is not a valid Unicode code (or is 0), this function returns
 			an empty string.[br]
 		@seealso:
 			[fnc]$cr[/fnc], [fnc]$lf[/fnc], [fnc]$unicode[/fnc]
@@ -1168,7 +1168,7 @@ namespace KviKvsCoreFunctions
 			<string> $escape(<text:string>)
 		@description:
 			In KVS some characters in a string have special meanings: % marks the start of a variable name, $ the start of a function name, etc..[br]
-			Sometimes you could need to escape them using a \ character to avoid kvirc from interpreting the special meaning of these characters:
+			Sometimes you could need to escape them using a \ character to avoid KVIrc from interpreting the special meaning of these characters:
 			this function will to the dirty job for you, returning a correctly kvs-escaped version of the string passed as a parameter.[br]
 		@seealso:
 			[cmd]eval[/cmd]
@@ -1242,7 +1242,7 @@ namespace KviKvsCoreFunctions
 			<array> $features()
 			<boolean> $features(<test_feature:string>)
 		@description:
-			The parameterless form returns an array of feature descripton strings that this KVIrc executable supports.[br]
+			The parameterless form returns an array of feature description strings that this KVIrc executable supports.[br]
 			This function is useful when some part of your script depends on
 			an optional KVIrc feature (like SSL support or IPV6 support).[br]
 			The returned value may be assigned to a dictionary too: it will be used to simulate an array.[br]
@@ -1501,7 +1501,7 @@ namespace KviKvsCoreFunctions
 			to prevent the evaluation.[br]
 			You might also take a look at [doc:escape_sequences]the escape sequences documentation[/doc]
 			to learn more about how the links are implemented and how to create more powerful links (add
-			right and middle button actions, use predefined kvirc links etc...). Also take a look at [fnc]$link[/fnc]
+			right and middle button actions, use predefined KVIrc links etc...). Also take a look at [fnc]$link[/fnc]
 			which has related functionality.
 		@seealso:
 			[cmd]echo[/cmd], [doc:escape_sequences]the escape sequences documentation[/doc], [fnc]$link[/fnc]

--- a/src/kvirc/kvs/KviKvsCoreSimpleCommands_af.cpp
+++ b/src/kvirc/kvs/KviKvsCoreSimpleCommands_af.cpp
@@ -43,7 +43,7 @@
 
 #if defined(COMPILE_X11_SUPPORT) && defined(COMPILE_QX11INFO_SUPPORT)
 	#ifndef COMPILE_NO_X_BELL
-		#include "KviXlib.h" // XBell : THIS SHOULD BE INCLUDED AS LAST!
+		#include "KviXlib.h"  // XBell : THIS SHOULD BE INCLUDED AS LAST!
 		#include <unistd.h>   // for usleep();
 
 		#include <QX11Info>
@@ -309,7 +309,7 @@ namespace KviKvsCoreSimpleCommands
 			On Windows, the bell is always synchronous and it is not
 			event granted that the bell will be a bell at all... you might
 			get the system default sound instead...
-			On some security-enchanced Windows variants (2008 Server, Seven and possibly
+			On some security-enhanced Windows variants (2008 Server, Seven and possibly
 			some 64-bit Vista builds) the access to the PC speaker
 			may be silently denied so don't be surprised too much if you don't hear any
 			sound at all on such systems...[br][br]
@@ -709,7 +709,7 @@ namespace KviKvsCoreSimpleCommands
 			If the -s switch is used then the output is sent to the system console instead.
 			If the -c switch is used then the script's context name will be prepended to the output.
 			This is useful if you need to debug destructors of objects
-			or events that are triggered at kvirc shutdown.
+			or events that are triggered at KVIrc shutdown.
 		@seealso:
 	*/
 
@@ -866,7 +866,7 @@ namespace KviKvsCoreSimpleCommands
 			so, if use the -i switch, test your script 10 times before releasing it.
 			The -q switch causes the command to run a bit more silently: it still
 			complains if the parameter passed is not an object reference, but
-			it fails silently if the reference just points to an inexistant object (or is null).
+			it fails silently if the reference just points to an inexistent object (or is null).
 		@examples:
 			[example]
 			[/example]
@@ -1101,7 +1101,7 @@ namespace KviKvsCoreSimpleCommands
 			If the -d switch is used then the output is sent to a special
 			window called "Debug" (the window is created if not existing yet).
 			This is useful for script debugging purposes (you get the output
-			in Debug regardless of the window that the executed command is attacched to).
+			in Debug regardless of the window that the executed command is attached to).
 			The KVIrc view widgets support clickable links that can be realized by using special [doc:escape_sequences]escape sequences[/doc].[br]
 			The 'n' switch disables timestamping so you can output your own timestamp
 			or not timestamp at all.[br]
@@ -1131,7 +1131,7 @@ namespace KviKvsCoreSimpleCommands
 			{
 				QString szWnd;
 				v->asString(szWnd);
-				//#warning "FIXME: the window database is not unicode! (we even could keep integer window id's at this point!)"
+				//#warning "FIXME: the window database is not Unicode! (we even could keep integer window id's at this point!)"
 				pWnd = g_pApp->findWindow(szWnd.toUtf8().data());
 				if(!pWnd)
 				{
@@ -1144,7 +1144,7 @@ namespace KviKvsCoreSimpleCommands
 			{
 				if(!v->asInteger(iMsgType))
 				{
-					KVSCSC_pContext->warning(__tr2qs_ctx("The argument of the i switch did not evaluate to a number: using default","kvs"));
+					KVSCSC_pContext->warning(__tr2qs_ctx("The argument of the -i switch did not evaluate to a number: using default","kvs"));
 					iMsgType = KVI_OUT_NONE;
 				} else {
 					iMsgType = iMsgType % KVI_NUM_MSGTYPE_OPTIONS;

--- a/src/kvirc/kvs/KviKvsCoreSimpleCommands_mr.cpp
+++ b/src/kvirc/kvs/KviKvsCoreSimpleCommands_mr.cpp
@@ -68,10 +68,10 @@ namespace KviKvsCoreSimpleCommands
 		@short:
 			Sends a CTCP ACTION
 		@description:
-			Sends a CTCP ACTION to the current channel, query or dcc chat.[br]
+			Sends a CTCP ACTION to the current channel, query or DCC chat.[br]
 			If you execute it in any other window type, you will get an error.[br]
 			If you want to use this command in a window that is not a channel
-			query or dcc chat, you may use the [doc:command_rebinding]standard -r switch[/doc].
+			query or DCC chat, you may use the [doc:command_rebinding]standard -r switch[/doc].
 		@examples:
 			[example]
 			me is Hungry!
@@ -115,9 +115,9 @@ namespace KviKvsCoreSimpleCommands
 		@syntax:
 			mode <target> <modeflags> [mode parameters]
 		@short:
-			Sends a MODE irc message
+			Sends a MODE IRC message
 		@description:
-			Sends a MODE irc message to the server of the current IRC context.[br]
+			Sends a MODE IRC message to the server of the current IRC context.[br]
 			The parameters are not modified in any way by KVIrc: so
 			you should use the RFC1459 syntax.[br]
 			This command is [doc:connection_dependant_commands]connection dependant[/doc].
@@ -335,12 +335,12 @@ namespace KviKvsCoreSimpleCommands
 		@syntax:
 			openurl <url:string>
 		@short:
-			Opens an url
+			Opens an URL
 		@description:
 			Opens the specified <url> with an appropriate handler.<br>
-			The handlers for the supported url types are specified in the options dialog.<br>
-			Each handler is a kvirc commandline that the url will be passed to as the first parameter ($0).<br>
-			The supported url types are:<br>
+			The handlers for the supported URL types are specified in the options dialog.<br>
+			Each handler is a kvirc commandline that the URL will be passed to as the first parameter ($0).<br>
+			The supported URL types are:<br>
 			HTTP: http://&lt;url&gt; or sth that begins with "www." <br>
 			HTTPS: https://&lt;url&gt;<br>
 			FILE: file://&lt;url&gt;<br>
@@ -392,7 +392,7 @@ namespace KviKvsCoreSimpleCommands
 		{
 			if(KviIrcUrl::run(szUrl,KviIrcUrl::TryEveryContext | KviIrcUrl::DoNotPartChans,KVSCSC_pContext->console()) & KviIrcUrl::InvalidProtocol)
 			{
-				KVSCSC_pContext->warning(__tr2qs_ctx("Invalid IRC url (%Q)","kvs"),&szUrl);
+				KVSCSC_pContext->warning(__tr2qs_ctx("Invalid IRC URL (%Q)","kvs"),&szUrl);
 			}
 			return true;
 		} else if(KviQString::equalCIN(szUrl,"mailto",6))
@@ -438,7 +438,7 @@ namespace KviKvsCoreSimpleCommands
 					                 DLLs required to run this application was corrupt.
 					  21             Application requires Microsoft Windows 32-bit extensions.
 				*/
-				KVSCSC_pContext->warning(__tr2qs_ctx("The system handler for the url failed to execute: system error is %1","kvs").arg(iRet));
+				KVSCSC_pContext->warning(__tr2qs_ctx("The system handler for the URL failed to execute: system error is %1","kvs").arg(iRet));
 			}
 		} else {
 #endif
@@ -453,9 +453,9 @@ namespace KviKvsCoreSimpleCommands
 				KviKvsScript script(szName,szCommand);
 
 				if(!script.run(KVSCSC_pWindow,&vList,0,KviKvsScript::PreserveParams))
-					KVSCSC_pContext->warning(__tr2qs_ctx("The commandline for this url type seems to be broken (%Q)","kvs"),&szUrl);
+					KVSCSC_pContext->warning(__tr2qs_ctx("The commandline for this URL type seems to be broken (%Q)","kvs"),&szUrl);
 
-			} else KVSCSC_pContext->warning(__tr2qs_ctx("No commandline specified for this type of url (%Q)","kvs"),&szUrl);
+			} else KVSCSC_pContext->warning(__tr2qs_ctx("No commandline specified for this type of URL (%Q)","kvs"),&szUrl);
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
 		}
 #endif
@@ -514,27 +514,27 @@ namespace KviKvsCoreSimpleCommands
 			[b]MessageType[/b]: <optValue> is a comma separated list of message type properties:
 				<icon>,<foreground>,<background>,<logBoolean>,<level>: <icon> is the index of the internal
 				small icon that has to be shown with the message type, <foreground> is an integer
-				indicating the mirc color to be used for the message type text (0-15),
+				indicating the mIRC color to be used for the message type text (0-15),
 				<background> is similar to foreground and accepts also the value of 100 that means transparent.
-				<logBoolean> is a boolean value (0/1) that indicates wheter this message type has to be logged or not.
+				<logBoolean> is a boolean value (0/1) that indicates whether this message type has to be logged or not.
 				<level> is the message level (actually from 0 to 5).[br]
 			[b]Rectangle[/b]: <optValue> is a comma separated list of integer values that indicate <x>,<y>,<width> and <height>.[br]
 			[b]Pixmap[/b]: <optValue> must be an ABSOLUTE path of the image that you want to load.[br]
 			[b]Int[/b]: <optValue> must be an integer.[br]
 			[b]Uint[/b]: <optValue> must be an UNSIGNED positive integer.[br]
 			Almost all the options available in the option dialog can be set by this command.[br]
-			Some GUI options might require a KVIrc restart to work properly (altough I've tried to avoid that when possible).
+			Some GUI options might require a KVIrc restart to work properly (although I've tried to avoid that when possible).
 		@examples:
 			[example]
 				[comment]# List available options[/comment]
 				option
-				[comment]# Set the mdi mananger background image[/comment]
+				[comment]# Set the mdi manager background image[/comment]
 				option pixmapMdiBackground /home/pragma/myback1.png
 				[comment]# Set the frame caption text[/comment]
 				option stringFrameCaption KVIrc rulez!
 				[comment]# Enable verbose mode[/comment]
 				option boolBeVerbose 1
-				[comment]# Set the irc view font[/comment]
+				[comment]# Set the IRC view font[/comment]
 				option fontIrcView helvetica,24,5,1,50
 			[/example]
 		@seealso:
@@ -557,7 +557,7 @@ namespace KviKvsCoreSimpleCommands
 			// list available options
 			g_pApp->listAvailableOptions(KVSCSC_pWindow);
 		} else {
-			if(!g_pApp->setOptionValue(szName,szValue))KVSCSC_pContext->warning(__tr2qs_ctx("Option setting error: Unknown option or invalid value for option type","kvs"));
+			if(!g_pApp->setOptionValue(szName,szValue))KVSCSC_pContext->warning(__tr2qs_ctx("Option setting error: unknown option or invalid value for option type","kvs"));
 		}
 
 		return true;
@@ -630,7 +630,7 @@ namespace KviKvsCoreSimpleCommands
 			[/example]
 			[example]
 				[comment]# Here we are assuming that fetchdata.kvs returns a string[/comment]
-				[comment]# We evaluate the return value thru ${} and echo it[/comment]
+				[comment]# We evaluate the return value through ${} and echo it[/comment]
 				echo ${ parse -r /home/pragma/fetchdata.kvs; };
 			[/example]
 	*/
@@ -1000,7 +1000,7 @@ namespace KviKvsCoreSimpleCommands
 		@description:
 			Opens a query window for each user specified in <nickname list>
 			which is a [b]comma separated[/b] list of nicknames.[br]
-			If [text] is speficied, it is sent to the
+			If [text] is specified, it is sent to the
 			query window just as it would have been written in the query itself.
 			If a query with one of the specified targets already exists,
 			it is simply focused and the [text] is sent to the target.[br]
@@ -1084,7 +1084,7 @@ namespace KviKvsCoreSimpleCommands
 			quit [-f] [-u] [quit-message:string]
 		quit -q
 		@short:
-			Terminates the current IRC connection or the entier application
+			Terminates the current IRC connection or the entire application
 		@switches:
 			!sw: -q | --quit
 			Terminates this KVIrc application instance
@@ -1162,7 +1162,7 @@ namespace KviKvsCoreSimpleCommands
 		@short:
 			Raises the KVIrc frame window
 		@description:
-			Raises and activates the KVIrc frame window....assuming that your window manager supports it.[br]
+			Raises and activates the KVIrc frame window, assuming that your window manager supports it.[br]
 	*/
 
 	KVSCSC(raise)
@@ -1204,7 +1204,7 @@ namespace KviKvsCoreSimpleCommands
 			[example]
 			[comment]# Send a private message "by hand"[/comment]
 			raw PRIVMSG Pragma :hello!
-			[comment]# Send a private message thru another connection[/comment]
+			[comment]# Send a private message through another connection[/comment]
 			raw -r=[fnc]$console[/fnc]([fnc]$ic[/fnc](irc.otherserver.com,othernick)) PRIVMSG Pragma :heya on this side!
 			[/example]
 	*/
@@ -1255,7 +1255,7 @@ namespace KviKvsCoreSimpleCommands
 			[comment]# Try this example in a channel or query window[/comment][br]
 			[comment]# Remember the current window id[/comment][br]
 			%winid = $window[br]
-			[comment]# Rebind to the console of the current irc context[/comment][br]
+			[comment]# Rebind to the console of the current IRC context[/comment][br]
 			rebind $console[br]
 			echo "Hello from the console :)"[br]
 			echo "Hello again.. still in the console"[br]
@@ -1297,7 +1297,7 @@ namespace KviKvsCoreSimpleCommands
 			and stops the execution.[br]
 			This is more or less equivalent to calling [cmd]setreturn[/cmd] <string>
 			and then [cmd]halt[/cmd], but has no additional semantics in events.[br]
-			Starting from version 3.0.0 of kvirc you can also return
+			Starting from version 3.0.0 of KVIrc you can also return
 			arrays and hashes just like any other variable types.
 		@examples:
 			return $array(item1,item2,3213,itemX);

--- a/src/kvirc/kvs/KviKvsCoreSimpleCommands_sz.cpp
+++ b/src/kvirc/kvs/KviKvsCoreSimpleCommands_sz.cpp
@@ -68,7 +68,7 @@ namespace KviKvsCoreSimpleCommands
 			then the command is rebound to the window specified by <window_id>.
 			The main difference is that the variables and identifiers in <text>
 			are always parsed (when typing this happen only if the text is a command).[br]
-			The switch -x will make say evaluate and execute arbitary commands, too:
+			The switch -x will make say evaluate and execute arbitrary commands, too:
 			if <text> begins with a slash then it will be treated as a command
 			to be evaluated and executed (after parsing the identifiers etc.).[br]
 			If this happens, the executed command will not be send to the active channel.[br]
@@ -78,7 +78,7 @@ namespace KviKvsCoreSimpleCommands
 			will just print "foo".[br]
 			Please note that using /say -x with a <text> that isn't a constant
 			in the script but comes from some unidentified external source (e.g. the network)
-			is a potential security flaw as it enables anyone to execute arbitary commands:
+			is a potential security flaw as it enables anyone to execute arbitrary commands:
 			don't ever do it.[br]
 			When the -x switch is not used, the text is never interpreted as a command.
 			-q causes the command to run quietly.[br]
@@ -96,7 +96,7 @@ namespace KviKvsCoreSimpleCommands
 		if(KVSCSC_pSwitches->find('x',"allow-exec"))
 		{
 			// allow execution of commands
-			if(!KviUserInput::parse(szText,KVSCSC_pWindow,__tr2qs_ctx("say: injected commandline","kvs")))
+			if(!KviUserInput::parse(szText,KVSCSC_pWindow,__tr2qs_ctx("Say: injected commandline","kvs")))
 			{
 				if(!KVSCSC_pSwitches->find('q',"quiet"))
 					KVSCSC_pContext->warning(__tr2qs_ctx("Say parse error: Broken command","kvs"));
@@ -183,14 +183,14 @@ namespace KviKvsCoreSimpleCommands
 			[br]
 			If <server> is in the form "id:<some_string>" then <some_string>
 			is interpreted as the server's internal id (specified in the options dialog).
-			This is useful when you need to force kvirc to choose between multiple
+			This is useful when you need to force KVIrc to choose between multiple
 			server entries with the same hostname and port stored in the database.[br]
 			Please note that this form causes most of the switches to have no effect
 			since the entry in the database will override them. If no server
 			entry with the specified identifier is found then an error will be generated
 			and the connection attempt will stop.
 			[br]
-			If <server> doesn't seem to be a valid ip address or hostname (i.e. it contains no dots)
+			If <server> doesn't seem to be a valid IP address or hostname (i.e. it contains no dots)
 			and it doesn't look to be in the form "id:<some_string>" then
 			it is assumed to be a network name and if such a network is found
 			in the server list then the best server for that network is contacted.
@@ -847,7 +847,7 @@ namespace KviKvsCoreSimpleCommands
 			[example]
 			# Unban people on the current channel (say #kvirc)
 			unban Maxim,Gizmo!*@*,*!root@*
-			# Do the same but from another window belongin to this IRC context
+			# Do the same but from another window belonging to this IRC context
 			unban -r=[fnc]$channel[/fnc](#kvirc) Maxim,Gizmo!*@*,*!root@*
 			# Do the same from any window
 			unban -r=[fnc]$channel[/fnc](#kvirc,[fnc]$context[/fnc](irc.myirc.net,Pragma)) Maxim,Gizmo!*@*,*!root*@*
@@ -1057,7 +1057,7 @@ namespace KviKvsCoreSimpleCommands
 		@short:
 			Requests user information
 		@description:
-			Requests information about an irc user specified by <nickname>.[br]
+			Requests information about an IRC user specified by <nickname>.[br]
 			If [server] is specified, the request is directed to that one. [server]
 			may be a nickname so that the request is redirected to the server that
 			the user with that nickname is connected to.[br]

--- a/src/kvirc/kvs/KviKvsPopupMenu.cpp
+++ b/src/kvirc/kvs/KviKvsPopupMenu.cpp
@@ -820,7 +820,7 @@ void KviKvsPopupMenu::setupMenuContents()
 			if(m_bSetupDone)return;
 			// we have been called by doPopup
 			// the menu contents have been already cleared
-			if(m_pTopLevelData)qDebug("Ops.. something got messed in KviKvsPopupMenu activation system");
+			if(m_pTopLevelData)qDebug("Ooops... Something got messed in KviKvsPopupMenu activation system");
 			// Swap the top level data from temporary to the permanent
 			m_pTopLevelData = m_pTempTopLevelData;
 			m_pTempTopLevelData = 0;
@@ -838,7 +838,7 @@ void KviKvsPopupMenu::setupMenuContents()
 	KviKvsPopupMenuTopLevelData * d = topLevelData();
 	if(!d)
 	{
-		qDebug("Ops...menu contents changed behind my back!");
+		qDebug("Ooops... Menu contents changed behind my back!");
 		return;
 	}
 
@@ -933,9 +933,9 @@ void KviKvsPopupMenu::itemClicked(QAction *pAction)
 				// FIXME: should we print somethng if run() returns false ?
 				lock(KviKvsPopupMenuTopLevelData::Unlocked);
 			}
-		} else qDebug("oops....clicked something that is not an item at position %d",param);
+		} else qDebug("Oops.... Clicked something that is not an item at position %d",param);
 		// FIXME: #warning "Maybe tell that the window has changed"
-	} else qDebug("oops....no menu item at position %d",param);
+	} else qDebug("Oops.... No menu item at position %d",param);
 }
 
 

--- a/src/kvirc/kvs/KviKvsPopupMenu.cpp
+++ b/src/kvirc/kvs/KviKvsPopupMenu.cpp
@@ -738,7 +738,7 @@ void KviKvsPopupMenu::addExtPopup(const QString &szItemName,const QString &szPop
 void KviKvsPopupMenu::addItemInternal(KviKvsPopupMenuItem * it)
 {
 	if(isHardLocked())
-		qDebug("Ooops... KviKvsPopupMenu is locked in ::addItem()");
+		qDebug("Oops... KviKvsPopupMenu is locked in ::addItem()");
 	m_pItemList->append(it);
 }
 
@@ -820,7 +820,7 @@ void KviKvsPopupMenu::setupMenuContents()
 			if(m_bSetupDone)return;
 			// we have been called by doPopup
 			// the menu contents have been already cleared
-			if(m_pTopLevelData)qDebug("Ooops... Something got messed in KviKvsPopupMenu activation system");
+			if(m_pTopLevelData)qDebug("Oops... Something got messed in KviKvsPopupMenu activation system");
 			// Swap the top level data from temporary to the permanent
 			m_pTopLevelData = m_pTempTopLevelData;
 			m_pTempTopLevelData = 0;
@@ -838,7 +838,7 @@ void KviKvsPopupMenu::setupMenuContents()
 	KviKvsPopupMenuTopLevelData * d = topLevelData();
 	if(!d)
 	{
-		qDebug("Ooops... Menu contents changed behind my back!");
+		qDebug("Oops... Menu contents changed behind my back!");
 		return;
 	}
 
@@ -933,9 +933,9 @@ void KviKvsPopupMenu::itemClicked(QAction *pAction)
 				// FIXME: should we print somethng if run() returns false ?
 				lock(KviKvsPopupMenuTopLevelData::Unlocked);
 			}
-		} else qDebug("Oops.... Clicked something that is not an item at position %d",param);
+		} else qDebug("Oops... Clicked something that is not an item at position %d",param);
 		// FIXME: #warning "Maybe tell that the window has changed"
-	} else qDebug("Oops.... No menu item at position %d",param);
+	} else qDebug("Oops... No menu item at position %d",param);
 }
 
 

--- a/src/kvirc/kvs/KviKvsReport.cpp
+++ b/src/kvirc/kvs/KviKvsReport.cpp
@@ -202,9 +202,9 @@ void KviKvsReport::report(KviKvsReport * r,KviWindow * pOutput)
 	}
 
 	if(r->location().isEmpty())
-		pOutput->output(out,__tr2qs_ctx("[KVS]   in script context \"%Q\"","kvs"),&(r->context()));
+		pOutput->output(out,__tr2qs_ctx("[KVS]   In script context \"%Q\"","kvs"),&(r->context()));
 	else
-		pOutput->output(out,__tr2qs_ctx("[KVS]   in script context \"%Q\", %Q","kvs"),&(r->context()),&(r->location()));
+		pOutput->output(out,__tr2qs_ctx("[KVS]   In script context \"%Q\", %Q","kvs"),&(r->context()),&(r->location()));
 
 	if(pOutput == KviDebugWindow::instance())
 	{

--- a/src/kvirc/kvs/object/KviKvsObject.cpp
+++ b/src/kvirc/kvs/object/KviKvsObject.cpp
@@ -1731,9 +1731,9 @@ bool KviKvsObject::callFunction(
 	if(!h)
 	{
 		if(classOverride.isEmpty())
-			pContext->error(__tr2qs_ctx("Cannot find object function $%Q for object named '%Q' of class '%Q'","kvs"),&fncName,&m_szName,&(getClass()->name()));
+			pContext->error(__tr2qs_ctx("Can't find object function $%Q for object named '%Q' of class '%Q'","kvs"),&fncName,&m_szName,&(getClass()->name()));
 		else
-			pContext->error(__tr2qs_ctx("Cannot find object function $%Q::%Q for object named '%Q' of class '%Q'","kvs"),&classOverride,&fncName,&m_szName,&(getClass()->name()));
+			pContext->error(__tr2qs_ctx("Can't find object function $%Q::%Q for object named '%Q' of class '%Q'","kvs"),&classOverride,&fncName,&m_szName,&(getClass()->name()));
 		return false;
 	}
 
@@ -1741,7 +1741,7 @@ bool KviKvsObject::callFunction(
 	{
 		if(pCaller != this)
 		{
-			pContext->error(__tr2qs_ctx("Cannot call internal object function $%Q (for object named '%Q' of class '%Q') from this context","kvs"),&fncName,&m_szName,&(getClass()->name()));
+			pContext->error(__tr2qs_ctx("Can't call internal object function $%Q (for object named '%Q' of class '%Q') from this context","kvs"),&fncName,&m_szName,&(getClass()->name()));
 			return false;
 		}
 	}

--- a/src/kvirc/kvs/parser/KviKvsParser.cpp
+++ b/src/kvirc/kvs/parser/KviKvsParser.cpp
@@ -834,7 +834,7 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 			%anothersum = $sum3(12,%somevalue,%anothervalue)
 			...
 		[/example]
-		Ooops... I've used some variables without actually explaining them, hehe... please forgive me and read on.
+		Oops... I've used some variables without actually explaining them, hehe... please forgive me and read on.
 		This example is again really simple, but you might have more complex function-aliases.
 		The function-aliases are also normal aliases... you can use it as a command:
 		[example]
@@ -1237,7 +1237,7 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 			%anothersum = $sum3(12,%somevalue,%anothervalue)
 			...
 		[/example]
-		Ooops... I've used some variables without actually explaining them, hehe... please forgive me and read on.
+		Oops... I've used some variables without actually explaining them, hehe... please forgive me and read on.
 		This example is again really simple, but you might have complexer function-aliases.
 		The function-aliases are also normal aliases... you can use it as a command:
 		[example]

--- a/src/kvirc/kvs/parser/KviKvsParser.cpp
+++ b/src/kvirc/kvs/parser/KviKvsParser.cpp
@@ -370,7 +370,7 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 		Placing an instruction per line does not require a terminating character,
 		placing more instructions in a single line require them to be separated by ';'.
 		The most common instructions in KVS are [b]commands[/b]. A command is basically
-		a keyword followed by a list of space separater parameters.
+		a keyword followed by a list of space separator parameters.
 		The simplest (and the most useful) command in KVS is [cmd]echo[/cmd]; it prints
 		all its parameters to a KVIrc window.[br]
 		The following is an example of a valid script that uses only [cmd]echo[/cmd] commands.
@@ -590,7 +590,7 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 		You can't escape newline characters in this case.
 		(or better: escape characters have no meaning in comments...
 		maybe one day I'll implement it).[br]
-		Starting from version 3.0.0 kvirc supports also C++ single line and C multiline comments.[br]
+		Starting from version 3.0.0, KVIrc supports also C++ single line and C multiline comments.[br]
 		A C++ comment starts with two slashes '//' and terminates with a newline.
 		A multiline C comment starts with '/ *' and ends at the first '* /' encountered.
 		Since KVIrc has no pre-processor, the C/C++ comments usually can't be placed in the middle of a command:
@@ -605,7 +605,7 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 		read your script). A good indenting practice is the first step to become a great programmer :)
 		[note]
 		Please note that the command parameters should be separated by
-		space characters (ascii 32). Tabs are not granted to work as parameter separators.[br]
+		space characters (ASCII 32). Tabs are not granted to work as parameter separators.[br]
 		[/note]
 		[example]
 		{
@@ -645,7 +645,7 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 	@body:
 		[big]Introduction[/big]
 		[p]
-		Since you're here, you should already have readed about the [doc:kvs_basicconcepts]KVS basic concepts[/doc]
+		Since you're here, you should already have read about the [doc:kvs_basicconcepts]KVS basic concepts[/doc]
 		and have visited the [doc:commands]command index[/doc]. If you feel ready to take the next step
 		then read on.
 		[/p]
@@ -719,7 +719,7 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 
 
 		[big]Aliases[/big][br]
-		An alias is a user defined command. It can be used to rename the builtin kvirc commands or functions,
+		An alias is a user defined command. It can be used to rename the builtin KVIrc commands or functions,
 		to automate complex tasks or as a means for structured programming.
 		Aliases can be created or destroyed by using the scriptcenter (graphic interface)
 		or from the commandline (or script) by using the [cmd]alias[/cmd] command.
@@ -798,7 +798,7 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 		[/example]
 		The example above will first check the validity of the <nickname> passed to kb -
 		if no nickname was passed, it will warn the user and stop.
-		The next step will be the "ban <nickname>" call. Another enchancement is the "default reason" -
+		The next step will be the "ban <nickname>" call. Another enhancement is the "default reason" -
 		we first assign the remaining parameters ($1- means "from $1 to the end") to a temporary variable,
 		and if the variable is empty, a default kick reason is assigned.
 		Finally the "kick <nickname> <reason>" will be executed.
@@ -834,13 +834,13 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 			%anothersum = $sum3(12,%somevalue,%anothervalue)
 			...
 		[/example]
-		Oops.. I've used some variables without actually explaining them... hehe.. please forgive me and read on.
+		Ooops... I've used some variables without actually explaining them, hehe... please forgive me and read on.
 		This example is again really simple, but you might have more complex function-aliases.
-		The function-aliases are also normal aliases.... you can use it as a command:
+		The function-aliases are also normal aliases... you can use it as a command:
 		[example]
 			/sum3 1 2 3
 		[/example]
-		The above is a perfectly valid call.... however there will be no visible results
+		The above is a perfectly valid call, however there will be no visible results
 		(because a command call implies ignoring the return value.
 		In fact there is no difference at all between function-aliases and normal-aliases -
 		the caller makes the difference. By calling an alias as a command, the return value
@@ -868,7 +868,7 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 		[example]
 			$0 evaluates to the 1st positional parameter
 			$0-4 evaluates to the parameters from first to 5th
-			$41- evaluates to the parameters from 41st to the last avaiable
+			$41- evaluates to the parameters from 41st to the last available
 		[/example]
 		The function [b]$#[/b] evaluates to the number of positional parameters available.
 		The [b]positional parameter[/b] functions do not accept parameters.[br]
@@ -925,8 +925,8 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 			KVIrc window structure and the window naming conventions
 		@body:
 			[big]Introduction[/big][br]
-			Starting from the release 3.0.0 KVIrc window structure has
-			grown in complexity. Older releases allowed one connetion
+			Starting from the release 3.0.0, KVIrc window structure has
+			grown in complexity. Older releases allowed one connection
 			per "frame window" and thus had a dedicated command parser
 			for each connection. Finding a window in that scenario
 			was quite easy: it was enough to designate it by "name"
@@ -1005,7 +1005,7 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 			[/li]
 			[/ul]
 			[br]
-			A naming convention has becomed necessary to resolve ambiguities.[br]
+			A naming convention has become necessary to resolve ambiguities.[br]
 			[big]Basic assumptions[/big]
 			Every KVIrc window has four main properties:[br]
 			-[b]an unique numeric identifier[/b][br]
@@ -1024,9 +1024,9 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 			the logical name corresponds to the caption text. This will be discussed later.[br]
 			The [b]type identifier[/b] describes the properties of a certain window.
 			For channel windows the type identifier is "channel", for query windows is "query",
-			for console windows it is "console", etc..[br]
+			for console windows it is "console", etc.[br]
 
-			[big]Irc contexts[/big][br]
+			[big]IRC Contexts[/big][br]
 			The KVIrc frame windows are numbered starting from 0 and named
 			"frame_<number>". Each frame can contain an unlimited number of consoles.[br]
 			Each console is bound to an [b]IRC context[/b]. (The part "is bound to" could
@@ -1052,7 +1052,7 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 			window or the "list" window. KVIrc takes care of making them
 			unique inside the [b]IRC context[/b] namespace.[br]
 			Each [b]IRC context[/b] has its own unique [b]IRC context ID[/b] (see [fnc]$context[/fnc]).[br]
-			Since to a single [b]IRC context[/b] may correspond only a single irc connection,
+			Since to a single [b]IRC context[/b] may correspond only a single IRC connection,
 			when in connected state, the [b]IRC context[/b] may be referred also as [b]connection[/b]
 			or [b]connection context[/b], and the associated [b]IRC context Id[/b] can be
 			referred as [b]connection ID[/b] or [b]connection context ID[/b].[br]
@@ -1122,7 +1122,7 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 	@short:
 		Aliases : user definable command sequences
 	@body:
-		An alias is an user defined command.  It can be used to rename the builtin kvirc commands or functions,
+		An alias is an user defined command.  It can be used to rename the builtin KVIrc commands or functions,
 		to automatize complex tasks or as structured programming mean.
 		Aliases can be created or destroyed by using the scriptcenter (graphic interface)
 		or from the commandline (or script) by using the [cmd]alias[/cmd] command.
@@ -1201,7 +1201,7 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 		[/example]
 		The example above will first check the validity of the <nickname> passed to kb:
 		if no nickname was passed, it will warn the user and stop.
-		The next step will be the "ban <nickname>" call. Another enchancement is the "default reason":
+		The next step will be the "ban <nickname>" call. Another enhancement is the "default reason":
 		we first assign the remaining parameters ($1- means "from $1 to the end") to a temporary variable,
 		if the variable is empty, a default kick reason is assigned.
 		Finally the "kick <nickname> <reason>" will be executed.
@@ -1215,7 +1215,7 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 		Aliases are the way of writing the common tasks: they are equivalent to the "procedures"
 		or "functions" in many high-level programming languages.
 		The alias as a procedure (subroutine or sub-task) has been shown in the "kb" example above:
-		it might be commonly called from complexier scripts or other aliases in case that a
+		it might be commonly called from complexer scripts or other aliases in case that a
 		kick & ban action is needed.
 		[/p]
 		[p]
@@ -1237,19 +1237,19 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 			%anothersum = $sum3(12,%somevalue,%anothervalue)
 			...
 		[/example]
-		Ops.. I've used some variables without actually explaining them... hehe.. please forgive me and read on.
-		This example is again really simple, but you might have complexier function-aliases.
-		The function-aliases are also normal aliases.... you can use it as a command:
+		Ooops... I've used some variables without actually explaining them, hehe... please forgive me and read on.
+		This example is again really simple, but you might have complexer function-aliases.
+		The function-aliases are also normal aliases... you can use it as a command:
 		[example]
 			/sum3 1 2 3
 		[/example]
-		Is a perfectly valid call.... it's just that it will have no visible results
+		Is a perfectly valid call... it's just that it will have no visible results
 		(just because a command call implies ignoring the return value.
 		In fact there is no difference al all between function-aliases and normal-aliases:
 		the caller makes the difference: by calling an alias as a command the return value
 		just disappears in hyperspace, by calling an alias as a function, the return value
 		is propagated (and in fact "used").
-		(There are some "nice" exceptions to this rule...but you don't need to care about it, for now).
+		(There are some "nice" exceptions to this rule... but you don't need to care about it, for now).
 		If return is not called inside an alias body, the return value will be just a null value.
 		[/p]
 		[p]
@@ -1399,7 +1399,7 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 		[/p]
 		[p]
 		The toplevel directory should be named with your addon name and version.
-		Use no spaces in the directory entries (this will make the things simplier for
+		Use no spaces in the directory entries (this will make the things simpler for
 		people that want to use your addon).
 		[/p]
 		[p]
@@ -1568,7 +1568,7 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 		[big]The real addon work[/big]
 		[p]
 		The real addon work is done by the scripts contained in the src directory.
-		They will likely add aliases (maybe in a nice namespace named agains your addon),
+		They will likely add aliases (maybe in a nice namespace named against your addon),
 		register event handlers, create actions, timers, toolbars and object classes.
 		You should install all of this stuff from your addon source files.
 		Remember that your source files will NOT be parsed every time KVIrc starts up:
@@ -1606,7 +1606,7 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 		These apply to programming in general, not only to KVIrc scripting.[br]
 		[br]
 		1. [b]Comment your code[/b][br]
-		A well commented code is easy to mantain, and easy to read by others.[br]
+		A well commented code is easy to maintain, and easy to read by others.[br]
 		[br]
 		2. [b]Indent your code[/b][br]
 		Indentation increases the code readability; this is again for you and
@@ -1615,7 +1615,7 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 		3. [b]Use TABS to indent your code[/b][br]
 		...and use ONLY TABS to indent.[br]
 		Tabs are better than space since most code editors allow you
-		to set the tab sice and thus to have the indentation steps smaller or bigger.[br]
+		to set the tab since and thus to have the indentation steps smaller or bigger.[br]
 		This is really important since the indentation size is really a matter of personal taste.[br]
 		Mixing spaces and tabs is Evil (tm), since it makes the code look really
 		ugly in editors that have the tab size different than yours; in some cases the
@@ -1628,14 +1628,14 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 		is getting large.[br]
 		Obviously using "thisIsACounterVariable" as name for a simple counter
 		is also a suicide.[br]
-		A good convention on variable names can speed up writing, debugging and mantaining code.[br]
+		A good convention on variable names can speed up writing, debugging and maintaining code.[br]
 		Encoding the type of the variable in the variable name might be also a good idea,
 		but this is a matter of taste; personally I feel really well with that.[br]
 		Just as example, here go my fundamental convention rules for C++:[br]
 		[br]
 		- The type of the variable is encoded at the beginning of the variable name:[br]
 		[br]
-			- b prefix for the boolean varables[br]
+			- b prefix for the boolean variables[br]
 			- i prefix for signed integers[br]
 			- u prefix for unsigned integers[br]
 			- f and d prefixes for floating point stuff[br]
@@ -1694,15 +1694,15 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 		[/tr]
 		[tr]
 		[td]<space>[/td]
-		[td]' '['\'<newline>][<space>] (Ascii space character)[/td]
+		[td]' '['\'<newline>][<space>] (ASCII space character)[/td]
 		[/tr]
 		[tr]
 		[td]<tab>[/td]
-		[td]'\t' (Ascii horizontal tabulation character)[/td]
+		[td]'\t' (ASCII horizontal tabulation character)[/td]
 		[/tr]
 		[tr]
 		[td]<newline>[/td]
-		[td]'\n' (Ascii line feed (LF) character)[/td]
+		[td]'\n' (ASCII line feed (LF) character)[/td]
 		[/tr]
 		[tr]
 		[td]<command block>[/td]
@@ -1827,7 +1827,7 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 	@short:
 		Standard -r switch no longer supported
 	@body:
-		Starting from version 3.0.0 the standard -r switch to commands is no longer supported.
+		Starting from version 3.0.0, the standard -r switch to commands is no longer supported.
 		You should rebind your command sequences with [cmd]rebind[/cmd]
 */
 
@@ -1837,8 +1837,8 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 		language
 	@keyterms:
 		global variable, global variables, local variable, local variables,
-		variables, variable, array, hash, dictionary, global variables, local variables,variable evaluation,
-		associative arrays, scalars, data types, percent sign, extended scope
+		variables, variable, array, hash, dictionary, global variables, local variables, variable evaluation,
+		associative arrays, scalars, data types, percent sign and extended scope
 	@title:
 		Variables and Data types
 	@short:
@@ -1994,7 +1994,7 @@ KviKvsTreeNodeInstruction * KviKvsParser::parseAsParameter(const QChar * pBuffer
 
 		[p]
 		Be aware that by making such an assignment you implicitly consume some memory for
-		all the preceeding array items (even if they are unset). This means that
+		all the preceding array items (even if they are unset). This means that
 		a simple instruction like the following may eat a huge amount of memory at once:
 		[/p]
 

--- a/src/kvirc/kvs/parser/KviKvsParser_expression.cpp
+++ b/src/kvirc/kvs/parser/KviKvsParser_expression.cpp
@@ -113,7 +113,7 @@ KviKvsTreeNodeExpressionBinaryOperator * KviKvsParser::parseExpressionBinaryOper
 				KVSP_skipChar;
 				return new KviKvsTreeNodeExpressionBinaryOperatorEqualTo(KVSP_curCharPointer);
 			} else {
-				error(KVSP_curCharPointer,__tr2qs_ctx("Unknown binary operator '=%q': did you mean '==' ?","kvs"),KVSP_curCharPointer);
+				error(KVSP_curCharPointer,__tr2qs_ctx("Unknown binary operator '=%q': did you mean '=='?","kvs"),KVSP_curCharPointer);
 			}
 		break;
 		case '!':

--- a/src/kvirc/kvs/parser/KviKvsParser_specialCommands.cpp
+++ b/src/kvirc/kvs/parser/KviKvsParser_specialCommands.cpp
@@ -202,7 +202,7 @@ KviKvsTreeNodeCommand * KviKvsParser::parseSpecialCommandUnset()
 		@description:
 			Unsets the specified list of comma separated variables.
 			It is equivalent to assigning the default empty value
-			to each variable on its own: just does it all at aonce.
+			to each variable on its own: just does it all at once.
 			Note that KVIrc automatically frees the local variable memory
 			when they go out of scope and the global variable memory
 			when KVIrc terminates.
@@ -272,9 +272,9 @@ KviKvsTreeNodeCommand * KviKvsParser::parseSpecialCommandGlobal()
 		@description:
 			Declares a list of global variables.
 			Once a variable has been declared as global
-			it refers to the global kvirc instance for the scope of the script.
+			it refers to the global KVIrc instance for the scope of the script.
 			Global variables are shared between scripts and keep their
-			value until they are explicitly unset or kvirc quits.
+			value until they are explicitly unset or KVIrc quits.
 			This command can be used to override the default behaviour of
 			declaring global variables by starting them with an uppercase letter
 			and declaring local variables by starting them with a lowercase one.
@@ -351,7 +351,7 @@ KviKvsTreeNodeCommand * KviKvsParser::parseSpecialCommandClass()
 			from [class:object]object[/class].[br]
 			Note:[br]
 			The keywords "function" and "event" that were used in KVIrc versions
-			previous to 3.0.0 have been removed since "useless".[br]
+			previous to 3.0.0 have been removed since they are "useless".[br]
 			The function keyword, however, is still permitted.
 			The keyword "internal" is useful when you want to hide
 			certain function from the outside world. An internal function
@@ -366,15 +366,15 @@ KviKvsTreeNodeCommand * KviKvsParser::parseSpecialCommandClass()
 			It's rather dangerous to use this command inside an object
 			function handler: if the class definition <class> was already
 			existing and it is a parent of the object's class, you might
-			end up executing "inexistant" code.[br]
+			end up executing "inexistent" code.[br]
 			As a thumb rule, use this command only outside object function handlers.[br]
 			[br][br]
 			Only for the curious: implementing protected and private access
 			list on members would have a considerable runtime overhead because
 			of the strange nature of the KVS language. Object member calls
-			are resolved completly at runtime (and that permits a lot of funny tricks
+			are resolved completely at runtime (and that permits a lot of funny tricks
 			like [cmd]privateimpl[/cmd]) but unfortunately this also forces us
-			to check access lists at runtime. Ok, this would be a relatively small footprint for the "private"
+			to check access lists at runtime. OK, this would be a relatively small footprint for the "private"
 			keyword where we need to run UP the called object inheritance hierarchy
 			but would have a significant performance footprint for the "protected"
 			keyword where we would need to traverse the WHOLE inheritance tree of the called and calling
@@ -393,7 +393,7 @@ KviKvsTreeNodeCommand * KviKvsParser::parseSpecialCommandClass()
 
 					destructor
 					{
-						[cmd]echo[/cmd] Ops...being destroyed
+						[cmd]echo[/cmd] Ooops... being destroyed
 					}
 
 					sayHello(this function expects no parameters)
@@ -1324,7 +1324,7 @@ KviKvsTreeNodeCommand * KviKvsParser::parseSpecialCommandSwitch()
 			Please note that <command> must be either a single instruction or an instruction block [b]enclosed in braces[/b].
 			During or after <command> execution, if a [cmd]break[/cmd] statement is encountered the execution of the switch
 			is terminated, otherwise the next label is evaluated.[br]
-			If the -p (--passthrough) option is enabled, than the switch command will execute all the istructions blocks
+			If the -p (--passthrough) option is enabled, than the switch command will execute all the instructions blocks
 			until a [cmd]break[/cmd] statement is found.[br]
 			[b]match(<value>)[:]<command>[/b][br]
 			The <value> is expected to be a wildcard expression (wildcard characters being '*' and '?')
@@ -1355,7 +1355,7 @@ KviKvsTreeNodeCommand * KviKvsParser::parseSpecialCommandSwitch()
 				break;
 			}
 			[/example]
-			[comment]# A complexier example: change the 1 in 2 or 3[/comment]
+			[comment]# A complexer example: change the 1 in 2 or 3[/comment]
 			[example]
 			%tmp = 1
 			switch(%tmp)
@@ -1397,7 +1397,7 @@ KviKvsTreeNodeCommand * KviKvsParser::parseSpecialCommandSwitch()
 				case(%tmp)
 				{
 					# do not break here
-					echo "Yeah.. it's stupid.. \%tmp == \%tmp :D"
+					echo "Yeah... It's stupid... \%tmp == \%tmp :D"
 				}
 				match("*TEST"):
 					echo "Matched *TEST"

--- a/src/kvirc/kvs/parser/KviKvsParser_specialCommands.cpp
+++ b/src/kvirc/kvs/parser/KviKvsParser_specialCommands.cpp
@@ -393,7 +393,7 @@ KviKvsTreeNodeCommand * KviKvsParser::parseSpecialCommandClass()
 
 					destructor
 					{
-						[cmd]echo[/cmd] Ooops... being destroyed
+						[cmd]echo[/cmd] Oops... being destroyed
 					}
 
 					sayHello(this function expects no parameters)

--- a/src/kvirc/module/KviModuleManager.cpp
+++ b/src/kvirc/module/KviModuleManager.cpp
@@ -187,7 +187,7 @@ bool KviModuleManager::loadModule(const QString &modName)
 	KviModuleInfo * info = (KviModuleInfo *)pLibrary->resolve(KVIRC_MODULE_STRUCTURE_SYMBOL);
 	if(!info)
 	{
-		m_szLastError = __tr2qs("No %1 symbol exported: not a kvirc module ?").arg(QString::fromUtf8(KVIRC_MODULE_STRUCTURE_SYMBOL));
+		m_szLastError = __tr2qs("No %1 symbol exported: not a KVIrc module?").arg(QString::fromUtf8(KVIRC_MODULE_STRUCTURE_SYMBOL));
 		pLibrary->unload();
 		delete pLibrary;
 		return false;

--- a/src/kvirc/sparser/KviIrcServerParser_ctcp.cpp
+++ b/src/kvirc/sparser/KviIrcServerParser_ctcp.cpp
@@ -297,7 +297,7 @@ extern KVIRC_API KviCtcpPageDialog * g_pCtcpPageDialog;
 		[big]VERSION[/big][br]
 		[b]Syntax: <0x01>VERSION<0x01>[/b][br]
 		The VERSION request asks for information about another user's IRC client program.
-		The reply should be sent thru a NOTICE with the following syntax:[br]
+		The reply should be sent through a NOTICE with the following syntax:[br]
 		<0x01>VERSION <client_version_data><0x01>[br]
 		The preferred form for <client_version_data> is
 		"<client_name>:<client_version>:<client_enviroinement>", but historically
@@ -308,7 +308,7 @@ extern KVIRC_API KviCtcpPageDialog * g_pCtcpPageDialog;
 		[big]USERINFO[/big][br]
 		[b]Syntax: <0x01>USERINFO<0x01>[/b][br]
 		The USERINFO request asks for information about another user.
-		The reply should be sent thru a NOTICE with the following syntax:[br]
+		The reply should be sent through a NOTICE with the following syntax:[br]
 		<0x01>USERINFO <user_info_data><0x01>[br]
 		The <user_info_data> should be a human readable "user defined" string;
 
@@ -317,7 +317,7 @@ extern KVIRC_API KviCtcpPageDialog * g_pCtcpPageDialog;
 		The CLIENTINFO request asks for information about another user's IRC client program.
 		While VERSION requests the client program name and version, CLIENTINFO requests
 		information about CTCP capabilities.[br]
-		The reply should be sent thru a NOTICE with the following syntax:[br]
+		The reply should be sent through a NOTICE with the following syntax:[br]
 		<0x01>CLIENTINFO <client_info_data><0x01>[br]
 		The <client_info_data> should contain a list of supported CTCP request tags.
 		The CLIENTINFO reply is intended to be human readable.
@@ -325,7 +325,7 @@ extern KVIRC_API KviCtcpPageDialog * g_pCtcpPageDialog;
 		[big]FINGER[/big][br]
 		[b]Syntax: <0x01>FINGER<0x01>[/b][br]
 		The FINGER request asks for information about another IRC user.
-		The reply should be sent thru a NOTICE with the following syntax:[br]
+		The reply should be sent through a NOTICE with the following syntax:[br]
 		<0x01>FINGER <user_info_data><0x01>[br]
 		The <user_info_data> should be a human readable string containing
 		the system username and possibly the system idle time;
@@ -333,14 +333,14 @@ extern KVIRC_API KviCtcpPageDialog * g_pCtcpPageDialog;
 		[big]SOURCE[/big][br]
 		[b]Syntax: <0x01>SOURCE<0x01>[/b][br]
 		The SOURCE request asks for the client homepage or ftp site information.
-		The reply should be sent thru a NOTICE with the following syntax:[br]
+		The reply should be sent through a NOTICE with the following syntax:[br]
 		<0x01>VERSION <homepage_url_data><0x01>[br]
 		This CTCP reply is intended to be human readable, so any form is accepted.
 
 		[big]TIME[/big][br]
 		[b]Syntax: <0x01>TIME<0x01>[/b][br]
 		The TIME request asks for the user local time.
-		The reply should be sent thru a NOTICE with the following syntax:[br]
+		The reply should be sent through a NOTICE with the following syntax:[br]
 		<0x01>TIME <time and date string><0x01>[br]
 		This CTCP reply is intended to be human readable, so any form is accepted.
 

--- a/src/kvirc/sparser/KviIrcServerParser_literalHandlers.cpp
+++ b/src/kvirc/sparser/KviIrcServerParser_literalHandlers.cpp
@@ -1111,7 +1111,7 @@ void KviIrcServerParser::parseLiteralNotice(KviIrcMessage *msg)
 			if(KVI_OPTION_BOOL(KviOption_boolVerboseIgnore))
 			{
 				QString szMsg = msg->connection()->decodeText(msg->safeTrailing());
-				console->output(KVI_OUT_IGNORE,msg->serverTime(),__tr2qs("Ignoring Notice from \r!nc\r%Q\r [%Q@\r!h\r%Q\r]: %Q"),&szNick,&szUser,&szHost,&szMsg);
+				console->output(KVI_OUT_IGNORE,msg->serverTime(),__tr2qs("Ignoring NOTICE from \r!nc\r%Q\r [%Q@\r!h\r%Q\r]: %Q"),&szNick,&szUser,&szHost,&szMsg);
 			}
 			return;
 		}
@@ -1709,7 +1709,7 @@ void KviIrcServerParser::parseLiteralInvite(KviIrcMessage *msg)
 		{
 			KviWindow * pOut = KVI_OPTION_BOOL(KviOption_boolInvitesToActiveWindow) ?
 				msg->console()->activeWindow() : (KviWindow *)(msg->console());
-			QString szAction = KVI_OPTION_BOOL(KviOption_boolAutoJoinOnInvite) ? __tr2qs("autojoining") : __tr2qs("double-click the channel name to join");
+			QString szAction = KVI_OPTION_BOOL(KviOption_boolAutoJoinOnInvite) ? __tr2qs("auto joining") : __tr2qs("double-click the channel name to join");
 			pOut->output(KVI_OUT_INVITE,__tr2qs("\r!n\r%Q\r [%Q@\r!h\r%Q\r] invites you to channel \r!c\r%Q\r (%Q)"),
 				&szNick,&szUser,&szHost,&szChannel,&szAction);
 		}

--- a/src/kvirc/sparser/KviIrcServerParser_numericHandlers.cpp
+++ b/src/kvirc/sparser/KviIrcServerParser_numericHandlers.cpp
@@ -1885,7 +1885,7 @@ void KviIrcServerParser::parseNumericListEnd(KviIrcMessage *msg)
 	{
 		msg->console()->context()->listWindow()->control(EXTERNAL_SERVER_DATA_PARSER_CONTROL_ENDOFDATA);
 	} else {
-		msg->console()->output(KVI_OUT_LIST,__tr2qs("End of LIST"));
+		msg->console()->output(KVI_OUT_LIST,__tr2qs("End of list"));
 	}
 
 }
@@ -1924,7 +1924,7 @@ void KviIrcServerParser::parseNumericEndOfLinks(KviIrcMessage *msg)
 	} else {
 		if(!msg->haltOutput())
 		{
-			msg->console()->output(KVI_OUT_LINKS,__tr2qs("End of LINKS"));
+			msg->console()->output(KVI_OUT_LINKS,__tr2qs("End of links"));
 		}
 	}
 }
@@ -2311,10 +2311,10 @@ void KviIrcServerParser::parseNumericCannotSendColor(KviIrcMessage * msg)
 		KviChannelWindow * chan = msg->connection()->findChannel(szChan);
 		if(chan)
 		{
-			chan->output(KVI_OUT_GENERICERROR,__tr2qs("Cannot send to channel: %Q"),&szInfo);
+			chan->output(KVI_OUT_GENERICERROR,__tr2qs("Can't send to channel: %Q"),&szInfo);
 		} else {
 			KviWindow * pOut = (KviWindow *)(msg->console());
-			pOut->output(KVI_OUT_GENERICERROR,__tr2qs("Cannot send text to channel %Q: %Q"),&szChan,&szInfo);
+			pOut->output(KVI_OUT_GENERICERROR,__tr2qs("Can't send text to channel %Q: %Q"),&szChan,&szInfo);
 		}
 	}
 }
@@ -2329,10 +2329,10 @@ void KviIrcServerParser::parseNumericCannotSend(KviIrcMessage * msg)
 		KviChannelWindow * chan = msg->connection()->findChannel(szChan);
 		if(chan)
 		{
-			chan->output(KVI_OUT_GENERICERROR,__tr2qs("Cannot send to channel"));
+			chan->output(KVI_OUT_GENERICERROR,__tr2qs("Can't send to channel"));
 		} else {
 			KviWindow * pOut = (KviWindow *)(msg->console());
-			pOut->output(KVI_OUT_GENERICERROR,__tr2qs("Cannot send text to channel %Q"),&szChan);
+			pOut->output(KVI_OUT_GENERICERROR,__tr2qs("Can't send text to channel %Q"),&szChan);
 		}
 	}
 }
@@ -2551,7 +2551,7 @@ void KviIrcServerParser::parseNumericSaslFail(KviIrcMessage * msg)
 	{
 		KviWindow * pOut = (KviWindow *)(msg->console());
 		QString szParam=msg->connection()->decodeText(msg->safeTrailing());
-		pOut->output(KVI_OUT_SERVERINFO,__tr2qs("SASL Authentication error: %Q"),&szParam);
+		pOut->output(KVI_OUT_SERVERINFO,__tr2qs("SASL authentication error: %Q"),&szParam);
 	}
 
 	if(msg->connection()->stateData()->isInsideAuthenticate())

--- a/src/kvirc/ui/KviChannelWindow.cpp
+++ b/src/kvirc/ui/KviChannelWindow.cpp
@@ -989,7 +989,7 @@ void KviChannelWindow::getWindowListTipText(QString & szBuffer)
 		szNum.setNum(s.uIrcOp);
 		szBuffer += szNum;
 		szBuffer += szHtmlBoldEnd;
-		szBuffer += (s.uIrcOp == 1 ? __tr2qs("irc operator") : __tr2qs("irc operators"));
+		szBuffer += (s.uIrcOp == 1 ? __tr2qs("IRC operator") : __tr2qs("IRC operators"));
 		szBuffer += p10;
 	}
 

--- a/src/kvirc/ui/KviImageDialog.cpp
+++ b/src/kvirc/ui/KviImageDialog.cpp
@@ -157,7 +157,7 @@ KviImageDialog::KviImageDialog(QWidget * par,
 	connect(b,SIGNAL(clicked()),this,SLOT(cancelClicked()));
 	g->addWidget(b,3,1);
 
-	b = new QPushButton(__tr2qs("Ok"),this);
+	b = new QPushButton(__tr2qs("OK"),this);
 	connect(b,SIGNAL(clicked()),this,SLOT(okClicked()));
 	g->addWidget(b,3,2);
 

--- a/src/kvirc/ui/KviInput.cpp
+++ b/src/kvirc/ui/KviInput.cpp
@@ -242,7 +242,7 @@ void KviInput::keyPressEvent(QKeyEvent * e)
 								{
 									int nRet = QMessageBox::question(
 										this,
-										__tr2qs("Confirm Multiline Message"),
+										__tr2qs("Confirm Multi-line Message"),
 										__tr2qs("You're about to send a message with %1 lines of text.<br><br>" \
 											"There is nothing wrong with it, this warning is<br>" \
 											"here to prevent you from accidentally sending<br>" \

--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -1105,7 +1105,7 @@ void KviInputEditor::showContextPopup(const QPoint &pos)
 	pAction->setEnabled(hasSelection());
 	pAction = g_pInputPopup->addAction(__tr2qs("&Paste") + ACCEL_KEY(V),this,SLOT(pasteClipboardWithConfirmation()));
 	pAction->setEnabled(!szClip.isEmpty() && !m_bReadOnly);
-	pAction = g_pInputPopup->addAction(__tr2qs("Paste (Slowly)"),this,SLOT(pasteSlow()));
+	pAction = g_pInputPopup->addAction(__tr2qs("Paste Slowly"),this,SLOT(pasteSlow()));
 	if ((iType == KviWindow::Channel) || (iType == KviWindow::Query) || (iType == KviWindow::DccChat))
 	    pAction->setEnabled(!szClip.isEmpty() && !m_bReadOnly);
 	else
@@ -1134,7 +1134,7 @@ void KviInputEditor::showContextPopup(const QPoint &pos)
 	
 
 #ifdef COMPILE_ENCHANT_SUPPORT
-	// check if the cursor is in a spellcheckable block
+	// check if the cursor is in a spell-checkable block
 
 	KviPointerList<KviInputEditorSpellCheckerBlock> lBuffer;
 	splitTextIntoSpellCheckerBlocks(m_szTextBuffer,lBuffer);

--- a/src/kvirc/ui/KviIrcView.cpp
+++ b/src/kvirc/ui/KviIrcView.cpp
@@ -39,14 +39,14 @@
 // 23 Nov 1999,
 //      Well, not so bad...I seem to still remember how it works
 //      So just for fun, complicated the things a little bit more.
-//      Added precaclucaltion of the text blocks and word wrapping
+//      Added pre-calculation of the text blocks and word wrapping
 //      and a fast scrolling mode (3 lines at once) for consecutive
 //      appendText() calls.
 //      Now the code becomes really not understandable...:)
 
 // 29 Jun 2000 21:02,
 //      Here we go again... I have to adjust this stuff for 3.0.0
-//      Will I make this thingie work ?
+//      Will I make this thingie work?
 // 01 Jul 2000 04:20 (AM!),
 //      Yes....I got it to work just now
 //      and YES, complicated the things yet more.
@@ -197,7 +197,7 @@
 //
 //  <cr>!<escape_command><cr><visible parameters<cr>
 //
-//  <escape_command> ::= u        <--- url link
+//  <escape_command> ::= u        <--- URL link
 //  <escape_command> ::= n        <--- nick link
 //  <escape_command> ::= s        <--- server link
 //  <escape_command> ::= h        <--- host link
@@ -375,7 +375,7 @@ KviIrcView::~KviIrcView()
 	if(m_pToolWidget)
 		delete m_pToolWidget;
 
-	// don't forget the bacgkround pixmap!
+	// don't forget the background pixmap!
 	if(m_pPrivateBackgroundPixmap)
 		delete m_pPrivateBackgroundPixmap;
 
@@ -445,7 +445,7 @@ void KviIrcView::applyOptions()
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
-// The IrcView : DnD   //2005.Resurection by Grifisx & Noldor
+// The IrcView : DnD   //2005.Resurrection by Grifisx & Noldor
 //
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -1119,7 +1119,7 @@ void KviIrcView::paintEvent(QPaintEvent *p)
 	bool bLineMarkPainted = !KVI_OPTION_BOOL(KviOption_boolTrackLastReadTextViewLine);
 	int iLinesPerPage = 0;
 
-	// And loop thru lines until we not run over the upper bound of the view
+	// And loop through lines until we not run over the upper bound of the view
 	while((curBottomCoord >= KVI_IRCVIEW_VERTICAL_BORDER) && pCurTextLine)
 	{
 		//Paint pCurTextLine
@@ -1258,7 +1258,7 @@ void KviIrcView::paintEvent(QPaintEvent *p)
 // A couple of macros that could work well as functions...
 // but since there are really many params to be passed
 // and push & pop calls take clock cycles
-// my paranoic mind decided to go for the macro way.
+// my paranoid mind decided to go for the macro way.
 // This is NOT good programming
 //
 
@@ -1437,7 +1437,7 @@ no_selection_paint:
 						// recover it by displaying the "question mark" icon
 						daIcon = g_pIconManager->getSmallIcon(KviIconManager::Help); // must be there, eventually null pixmap :D
 					}
-					int moredown = 1; //used to center imager vertically (pixels which the image is moved more down)
+					int moredown = 1; //used to center image vertically (pixels which the image is moved more down)
 					moredown += ((m_iFontLineSpacing - daIcon->height()) / 2);
 					pa.drawPixmap(curLeftCoord + m_iIconSideSpacing,imageYPos + moredown,*(daIcon));
 
@@ -1738,7 +1738,7 @@ void KviIrcView::calculateLineWraps(KviIrcViewLine *ptr,int maxWidth)
 					curLineWidth+=IRCVIEW_WCHARWIDTH(*p);
 					uLoopedChars++;
 				} while((curLineWidth < maxWidth) && (curBlockLen < maxBlockLen));
-				// Now overrunned, go back 1 char (if we ran over at least 2 chars)
+				// Now overrun, go back 1 char (if we ran over at least 2 chars)
 				if(uLoopedChars>1)
 				{
 					p--;
@@ -1794,7 +1794,7 @@ bool KviIrcView::checkSelectionBlock(KviIrcViewLine * line,int bufIndex)
 	if(!m_pSelectionInitLine || !m_pSelectionEndLine)
 		return false;
 
-	//check if selection is bottom to top or viceversa
+	//check if selection is bottom to top or vice-versa
 	KviIrcViewLine *init, *end;
 	if(m_pSelectionInitLine->uIndex <= m_pSelectionEndLine->uIndex)
 	{
@@ -2155,7 +2155,7 @@ void KviIrcView::chooseBackground()
 	QPixmap p(f);
 	if(p.isNull())
 	{
-		QMessageBox::information(this,__tr2qs("Invalid image"),__tr2qs("Failed to load the selected image"),__tr2qs("Ok"));
+		QMessageBox::information(this,__tr2qs("Invalid image"),__tr2qs("Failed to load the selected image"),__tr2qs("OK"));
 		return;
 	}
 
@@ -2253,7 +2253,7 @@ void KviIrcView::ensureLineVisible(KviIrcViewLine * pLineToShow)
 		maxLineWidth -= KVI_IRCVIEW_PIXMAP_AND_SEPARATOR;
 	//Make sure that we have enough space to paint something...
 	if(maxLineWidth < m_iMinimumPaintWidth)return; // ugh
-	//And loop thru lines until we not run over the upper bound of the view
+	//And loop through lines until we not run over the upper bound of the view
 	KviIrcViewLine * pLine = m_pCurLine;
 	KviIrcViewLine * pCurLine = m_pCurLine;
 	while(pLine)

--- a/src/kvirc/ui/KviIrcView_getTextLine.cpp
+++ b/src/kvirc/ui/KviIrcView_getTextLine.cpp
@@ -63,7 +63,7 @@ void kvi_appendWCharToQStringWithLength(QString * qstrptr,const kvi_wchar_t * pt
 
 static const kvi_wchar_t * skip_to_end_of_url(const kvi_wchar_t * p)
 {
-	// p here points somewhere inside an url.
+	// p here points somewhere inside an URL.
 
 	// Now the question is what characters are and which aren't allowed inside an URL.
 
@@ -75,8 +75,8 @@ static const kvi_wchar_t * skip_to_end_of_url(const kvi_wchar_t * p)
 	// then the users will tend to write the links without the special encoding. ed2k links also use the | character
 	// and it's common for the file names to appear partially unencoded.
 
-	// There is also a very common case of urls being enclosed inside parentheses: (http://url.here).
-	// In this case the rightmost ')' is shouldn't be included in the url. On the other hand there are many links that
+	// There is also a very common case of URLs being enclosed inside parentheses: (http://url.here).
+	// In this case the rightmost ')' is shouldn't be included in the URL. On the other hand there are many links that
 	// actually contain the ')' character and have it exactly at the end. Wikipedia, for instance, has a lot of such links.
 
 	// So in the end, we just can't have an algorithm that pleases everybody. If we follow exactly the RFC1738
@@ -94,7 +94,7 @@ static const kvi_wchar_t * skip_to_end_of_url(const kvi_wchar_t * p)
 			return p; // no spaces and control characters below 32
 
 		if((*p == '{') || (*p == '}') || (*p == '<') || (*p == '>') || (*p == '"')) // || (*p == '\''))
-			return p; // never valid inside an url
+			return p; // never valid inside an URL
 
 		if(*p == '[')
 		{
@@ -265,7 +265,7 @@ const kvi_wchar_t * KviIrcView::getTextLine(
 
 /*
  * Profane description: this adds a block of text of known length to a already created chunk inside this line.
- * text is hidden (eg: we want to display an emoticon instead of the ":)" text, so we insert it hidden)
+ * text is hidden (e.g. we want to display an emoticon instead of the ":)" text, so we insert it hidden)
  */
 
 #define APPEND_LAST_TEXT_BLOCK_HIDDEN_FROM_NOW(__data_ptr,__data_len) \
@@ -300,18 +300,18 @@ const kvi_wchar_t * KviIrcView::getTextLine(
 
 /*
  * Some additional description for the profanes: we want a fast way to check the presence of "active objects we have to process" in lines of text;
- * such objects can be: EOF, urls, mirc control characters, emoticons, and so on. We implemented a jump table to accomplish this task very fast.
+ * such objects can be: EOF, URLs, mIRC control characters, emoticons, and so on. We implemented a jump table to accomplish this task very fast.
  * This jump table is an array[256] containing label addresses (imagine them as functions). So something like "goto array[4];" is valid construct
- * in C, that equivals to a function call to a function that starts on that label's line of code.
- * Imagine to parse the input line one character at once and match it (as a switch can do) agains this big array. Every 1-byte character corresponds
- * to an ascii integer between 0 and 255. If the array value for that integer key is defined and !=0, we jump to the corrispective label address.
+ * in C, that is equivalent to a function call to a function that starts on that label's line of code.
+ * Imagine to parse the input line one character at once and match it (as a switch can do) against this big array. Every 1-byte character corresponds
+ * to an ASCII integer between 0 and 255. If the array value for that integer key is defined and !=0, we jump to the corresponding label address.
  * Example, if we find a "H" (72) we'll "goto char_to_check_jump_table[72]", aka "goto check_http_url".
  * There exists two different versions of this tricky code, we switch them depending on the compiler abilities to accept our bad code :)
  */
 
 #ifdef COMPILE_USE_DYNAMIC_LABELS
 
-	// Herezy :)
+	// Heresy :)
 
 	// This is not only usage of the *Evil Goto(tm)*
 	// This is also a *rather unclear* use of the *Really Evil Goto(tm)*
@@ -503,7 +503,7 @@ check_char_loop:
 
 /*
  * Profane description:
- * Here the two different approches to the jump table ends. Following there's the list of all the possible
+ * Here the two different approaches to the jump table ends. Following there's the list of all the possible
  * codes found. The "check table" approach needs an additional switch to discriminate between different control codes,
  * while the "jump table" approach directly jumps to the right case.
  */
@@ -740,15 +740,15 @@ check_http_url:
 	{
 		/*
 		 * Profane description: we found an 'h' using the "jump/check table", now check for a 't' (we don't want to search directly for the
-		 * "http://" tag, it takes us more cpu time)
+		 * "http://" tag, it takes us more CPU time)
 		 */
 
 		//
 		if((*p == 't') || (*p == 'T'))
 		{
 			/*
-			 * Profane description: we found it! now there's an high probability we're in front of an http url. Relax, rewind the last
-			 * character and try to match the complete url protocol tag
+			 * Profane description: we found it! now there's an high probability we're in front of an http URL. Relax, rewind the last
+			 * character and try to match the complete URL protocol tag
 	 		 */
 			p--;
 
@@ -979,22 +979,22 @@ check_spotify_url:
 
 
 got_url:
-	//Url highlighting block
+	//URL highlighting block
 
 	/*
-	 * Profane description: we just found a tag that we suppose to be the start of a url.
-	 * p is the address of the start of our text buffer, partLen the length of the tag (eg. http:// = 7)
+	 * Profane description: we just found a tag that we suppose to be the start of a URL.
+	 * p is the address of the start of our text buffer, partLen the length of the tag (e.g. http:// = 7)
 	 * We want to check if it's valid and highlight it creating an ad-hoc chunk for it in this line.
-	 * The ascii value of the first character after the tag have to be >= 47, or we assume it as invalid
+	 * The ASCII value of the first character after the tag have to be >= 47, or we assume it as invalid
 	 */
 
 	if(*(p + partLen) < 47)
 	{
-		//invalid: append all the text up to the end of the false url tag
+		//invalid: append all the text up to the end of the false URL tag
 		p+=partLen;
 		APPEND_LAST_TEXT_BLOCK(data_ptr,p - data_ptr)
 	} else {
-		//valid: append all the text before the start of the url tag
+		//valid: append all the text before the start of the URL tag
 		APPEND_LAST_TEXT_BLOCK(data_ptr,p - data_ptr)
 		//create a new chunk
 		NEW_LINE_CHUNK(KviControlCodes::Escape)
@@ -1002,7 +1002,7 @@ got_url:
 
 		//	int urlLen = KVI_OPTION_STRING(KviOption_stringUrlLinkCommand).len() + 1;
 
-		//write into null-terminated char* szPayload an 'u' that means that this chunk represents an url
+		//write into null-terminated char* szPayload an 'u' that means that this chunk represents an URL
 		line_ptr->pChunks[iCurChunk].szPayload = (kvi_wchar_t *)KviMemory::allocate(2 * sizeof(kvi_wchar_t));
 		line_ptr->pChunks[iCurChunk].szPayload[0] = 'u';
 		line_ptr->pChunks[iCurChunk].szPayload[1] = 0x0;
@@ -1021,7 +1021,7 @@ got_url:
 			KVS_TRIGGER_EVENT_1(KviEvent_OnURL,m_pKviWindow,tmp);
 		}
 
-		//add all the text till the end of the url, then create a new "clean" chunk for the next cycle loop
+		//add all the text till the end of the URL, then create a new "clean" chunk for the next cycle loop
 		APPEND_LAST_TEXT_BLOCK(data_ptr,p - data_ptr)
 		NEW_LINE_CHUNK(KviControlCodes::UnEscape)
 
@@ -1098,10 +1098,10 @@ check_emoticon_char:
 				}
 				if(!*p || (*p == ' '))
 				{
-					// ok! this is an emoticon (sequence) !
+					// OK! this is an emoticon (sequence) !
 					// We lookup simplified versions of the emoticons...
 
-					// FIXME: this sould become UNICODE!!!
+					// FIXME: this should become UNICODE!!!
 					QString lookupstring;
 					kvi_wchar_t ng[3];
 					ng[0] = *begin;
@@ -1186,7 +1186,7 @@ void KviIrcView::reapplyMessageColors()
 	KviIrcViewLine * pLine = m_pFirstLine;
 	while(pLine)
 	{
-		pLine->iMaxLineWidth = -1; // force recompuation of blocks
+		pLine->iMaxLineWidth = -1; // force recomputation of blocks
 
 		if(pLine->uChunkCount > 0) // always true?
 		{

--- a/src/kvirc/ui/KviMaskEditor.cpp
+++ b/src/kvirc/ui/KviMaskEditor.cpp
@@ -84,7 +84,7 @@ KviMaskInputDialog::KviMaskInputDialog(const QString &szMask,KviMaskEditor* pEdi
 	m_pEdit=new QLineEdit(szMask,this);
 	g->addWidget(m_pEdit,1,0,1,4);
 
-	m_pOkButton= new QPushButton(__tr2qs("Ok"),this);
+	m_pOkButton= new QPushButton(__tr2qs("OK"),this);
 	connect(m_pOkButton,SIGNAL(clicked()), this, SLOT(accept()));
 	g->addWidget(m_pOkButton,2,1);
 	m_pOkButton->setIcon(*(g_pIconManager->getSmallIcon(KviIconManager::Accept)));

--- a/src/kvirc/ui/KviWindow.cpp
+++ b/src/kvirc/ui/KviWindow.cpp
@@ -470,7 +470,7 @@ void KviWindow::cryptControllerFinished()
 void KviWindow::cryptSessionInfoDestroyed()
 {
 #ifdef COMPILE_CRYPT_SUPPORT
-	output(KVI_OUT_SYSTEMERROR,__tr2qs("Ooops... I've accidentally lost the crypting engine."));
+	output(KVI_OUT_SYSTEMERROR,__tr2qs("Oops... I've accidentally lost the crypting engine."));
 	m_pCryptSessionInfo->m_pEngine = 0;
 	delete m_pCryptSessionInfo;
 	m_pCryptSessionInfo = 0;

--- a/src/kvirc/ui/KviWindow.cpp
+++ b/src/kvirc/ui/KviWindow.cpp
@@ -470,7 +470,7 @@ void KviWindow::cryptControllerFinished()
 void KviWindow::cryptSessionInfoDestroyed()
 {
 #ifdef COMPILE_CRYPT_SUPPORT
-	output(KVI_OUT_SYSTEMERROR,__tr2qs("Ops...I've accidentally lost the crypting engine..."));
+	output(KVI_OUT_SYSTEMERROR,__tr2qs("Ooops... I've accidentally lost the crypting engine."));
 	m_pCryptSessionInfo->m_pEngine = 0;
 	delete m_pCryptSessionInfo;
 	m_pCryptSessionInfo = 0;

--- a/src/modules/action/libkviaction.cpp
+++ b/src/modules/action/libkviaction.cpp
@@ -289,7 +289,7 @@ static bool action_kvs_cmd_destroy(KviKvsModuleCommandCall * c)
 
 		!sw: -l | --enable-at-login
 		Specifies that the action needs to be enabled at login time, that is
-		when a link to the server has been estabilished but the login
+		when a link to the server has been established but the login
 		operations haven't been carried out yet (and thus there is no real IRC connection).
 		This switch requires -c to work.
 
@@ -302,11 +302,11 @@ static bool action_kvs_cmd_destroy(KviKvsModuleCommandCall * c)
 		!sw: -s | --selected-only
 		Specifies that the action will be activated only if the active window
 		has selected users in the userlist. This switch requires -w with a combination
-		of flags 'q','c' and 'x' (it doesn't work for dcc chat).
+		of flags 'q','c' and 'x' (it doesn't work for DCC chat).
 
 		!sw: -t=<category> | --category=<category>
 		Causes the action to belong to the specified category.
-		<category> can be one of "irc","scripting","settings","gui","channel","tools" and "generic".
+		<category> can be one of "IRC","scripting","settings","GUI","channel","tools" and "generic".
 		If this switch is omitted the "generic" category is automatically assumed.
 		The actions failing in the "tools" category will appear in the "Tools" KVIrc menu too.
 
@@ -321,7 +321,7 @@ static bool action_kvs_cmd_destroy(KviKvsModuleCommandCall * c)
 		[/p]
 		[p]
 		Each action has an unique <name> that must not collide with any core action
-		(i.e. don't use the "kvirc." prefix).
+		(i.e. don't use the "KVIrc." prefix).
 		At any time you can check [cmd]action.list[/cmd] to verify that no core action
 		is already using your <name>. If the <name> was already used for a script action
 		then this action is simply replaced by the new one.
@@ -350,7 +350,7 @@ static bool action_kvs_cmd_destroy(KviKvsModuleCommandCall * c)
 		[p]
 		<action body> is the callback code snippet that will be triggered when this action is activated
 		either by the means of [cmd]action.trigger[/cmd], a toolbar button or a menu item selection.
-		An empty <action body> causes this command to behave like [cmd]action.destoy[/cmd] <name>.
+		An empty <action body> causes this command to behave like [cmd]action.destroy[/cmd] <name>.
 		[/p]
 	@seealso:
 		[cmd]action.destroy[/cmd], [cmd]action.trigger[/cmd]

--- a/src/modules/actioneditor/ActionEditor.cpp
+++ b/src/modules/actioneditor/ActionEditor.cpp
@@ -195,7 +195,7 @@ SingleActionEditor::SingleActionEditor(QWidget * par,ActionEditor * ed)
 	m_pNeedsContextCheck = new QCheckBox(__tr2qs_ctx("Needs IRC Context","editor"),tab);
 	connect(m_pNeedsContextCheck,SIGNAL(toggled(bool)),this,SLOT(needsContextCheckToggled(bool)));
 	m_pNeedsContextCheck->setToolTip(__tr2qs_ctx("Check this option if this action should be enabled only when " \
-		"the active window belongs to an irc context","editor"));
+		"the active window belongs to an IRC context","editor"));
 	gl->addWidget(m_pNeedsContextCheck,0,0,1,4);
 
 
@@ -216,7 +216,7 @@ SingleActionEditor::SingleActionEditor(QWidget * par,ActionEditor * ed)
 
 	m_pEnableAtLoginCheck = new QCheckBox(__tr2qs_ctx("Enable at Login","editor"),tab);
 	m_pEnableAtLoginCheck->setToolTip(__tr2qs_ctx("Check this option if this action should be enabled also during " \
-		"the login operations (so when the logical IRC connection hasn't been estabilished yet)","editor"));
+		"the login operations (so when the logical IRC connection hasn't been established yet)","editor"));
 	gl->addWidget(m_pEnableAtLoginCheck,2,2,1,2);
 
 	m_pSpecificWindowsCheck = new QCheckBox(__tr2qs_ctx("Enable Only in Specified Windows","editor"),tab);
@@ -261,7 +261,7 @@ SingleActionEditor::SingleActionEditor(QWidget * par,ActionEditor * ed)
 
 	m_pWindowDccChatCheck = new QCheckBox(__tr2qs_ctx("Enable in DCC Chat Windows","editor"),tab);
 	m_pWindowDccChatCheck->setToolTip(__tr2qs_ctx("Check this option if this action should be enabled only when " \
-		"the active window is a dcc chat","editor"));
+		"the active window is a DCC chat","editor"));
 	gl->addWidget(m_pWindowDccChatCheck,10,1,1,2);
 
 	l = new QLabel(tab);

--- a/src/modules/addon/AddonFunctions.cpp
+++ b/src/modules/addon/AddonFunctions.cpp
@@ -192,7 +192,7 @@ namespace AddonFunctions
 
 		hd.szCaption = __tr2qs_ctx("Install Addon Pack - KVIrc","addon");
 		hd.szUpperLabelText = beginCenter + __tr2qs_ctx("You're about to install the following addon package","addon") + endCenter;
-		hd.szLowerLabelText = beginCenter + __tr2qs_ctx("Do you want to proceed with the installation ?","addon") + endCenter;
+		hd.szLowerLabelText = beginCenter + __tr2qs_ctx("Do you want to proceed with the installation?","addon") + endCenter;
 		hd.szButton1Text = __tr2qs_ctx("Do Not Install","addon");
 		hd.szButton2Text = __tr2qs_ctx("Yes, Proceed","addon");
 		hd.iDefaultButton = 2;

--- a/src/modules/addon/AddonManagementDialog.cpp
+++ b/src/modules/addon/AddonManagementDialog.cpp
@@ -272,7 +272,7 @@ void AddonManagementDialog::uninstallScript()
 	if(!it)return;
 
 	QString txt = "<p>";
-	txt += __tr2qs_ctx("Do you really want to uninstall the addon \"%1\" ?","addon").arg(it->addon()->visibleName());
+	txt += __tr2qs_ctx("Do you really want to uninstall the addon \"%1\"?","addon").arg(it->addon()->visibleName());
 	txt += "</p>";
 
 	if(QMessageBox::question(

--- a/src/modules/aliaseditor/AliasEditorWindow.cpp
+++ b/src/modules/aliaseditor/AliasEditorWindow.cpp
@@ -442,7 +442,7 @@ void AliasEditorWidget::renameItem()
 			QMessageBox::information(this,
 				__tr2qs_ctx("Alias already exists","editor"),
 				__tr2qs_ctx("This name is already in use. Please choose another one.","editor"),
-				__tr2qs_ctx("Ok, Let me try again...","editor"));
+				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pAliasEditorModule->unlock();
 			return;
 		}
@@ -454,7 +454,7 @@ void AliasEditorWidget::renameItem()
 			QMessageBox::information(this,
 				__tr2qs_ctx("Namespace already exists","editor"),
 				__tr2qs_ctx("This name is already in use. Please choose another one.","editor"),
-				__tr2qs_ctx("Ok, Let me try again...","editor"));
+				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pAliasEditorModule->unlock();
 			return;
 		}
@@ -599,7 +599,7 @@ void AliasEditorWidget::customContextMenuRequested(const QPoint pnt)
 
 	m_pContextPopup->addAction(
 			*(g_pIconManager->getSmallIcon(KviIconManager::Search)),
-			__tr2qs_ctx("Find In Aliases...","editor"),
+			__tr2qs_ctx("Find in Aliases...","editor"),
             this,SLOT(slotFind()))
             ->setEnabled(bHasItems);
 
@@ -634,7 +634,7 @@ void AliasEditorWidget::slotFind()
 	bool bOk;
 
 	QString szSearch = QInputDialog::getText(this,
-		__tr2qs_ctx("Find In Aliases","editor"),
+		__tr2qs_ctx("Find in Aliases","editor"),
 		__tr2qs_ctx("Please enter the text to be searched for. The matching aliases will be highlighted.","editor"),
 		QLineEdit::Normal,
 		"",
@@ -1004,7 +1004,7 @@ QString AliasEditorWidget::askForAliasName(const QString &szAction,const QString
 			QMessageBox::warning(this,
 				__tr2qs_ctx("Missing Alias Name","editor"),
 				__tr2qs_ctx("You must specify a valid name for the alias","editor"),
-				__tr2qs_ctx("Ok, Let me try again...","editor"));
+				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pAliasEditorModule->unlock();
 			continue;
 		}
@@ -1017,7 +1017,7 @@ QString AliasEditorWidget::askForAliasName(const QString &szAction,const QString
 			QMessageBox::information(this,
 				__tr2qs_ctx("Bad Alias Name","editor"),
 				__tr2qs_ctx("Alias names can contain only letters, digits, underscores and '::' namespace separators","editor"),
-				__tr2qs_ctx("Ok, Let me try again...","editor"));
+				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pAliasEditorModule->unlock();
 			szNewName = "";
 			continue;
@@ -1030,8 +1030,8 @@ QString AliasEditorWidget::askForAliasName(const QString &szAction,const QString
 			g_pAliasEditorModule->lock();
 			QMessageBox::information(this,
 				__tr2qs_ctx("Bad Alias Name","editor"),
-				__tr2qs_ctx("Stray ':' character in alias name: did you mean ...<namespace>::<name> ?","editor"),
-				__tr2qs_ctx("Ok, Let me try again...","editor"));
+				__tr2qs_ctx("Stray ':' character in alias name: did you mean ...<namespace>::<name>?","editor"),
+				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pAliasEditorModule->unlock();
 			szNewName = "";
 			continue;
@@ -1042,7 +1042,7 @@ QString AliasEditorWidget::askForAliasName(const QString &szAction,const QString
 			QMessageBox::information(this,
 				__tr2qs_ctx("Bad Alias Name","editor"),
 				__tr2qs_ctx("Found an empty namespace in alias name","editor"),
-				__tr2qs_ctx("Ok, Let me try again...","editor"));
+				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pAliasEditorModule->unlock();
 			szNewName = "";
 			continue;
@@ -1072,7 +1072,7 @@ QString AliasEditorWidget::askForNamespaceName(const QString &szAction,const QSt
 			QMessageBox::warning(this,
 				__tr2qs_ctx("Missing Namespace Name","editor"),
 				__tr2qs_ctx("You must specify a valid name for the namespace","editor"),
-				__tr2qs_ctx("Ok, Let me try again...","editor"));
+				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pAliasEditorModule->unlock();
 			continue;
 		}
@@ -1085,7 +1085,7 @@ QString AliasEditorWidget::askForNamespaceName(const QString &szAction,const QSt
 			QMessageBox::information(this,
 				__tr2qs_ctx("Bad Namespace Name","editor"),
 				__tr2qs_ctx("Namespace names can contain only letters, digits, underscores and '::' namespace separators","editor"),
-				__tr2qs_ctx("Ok, Let me try again...","editor"));
+				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pAliasEditorModule->unlock();
 			szNewName = "";
 			continue;
@@ -1098,8 +1098,8 @@ QString AliasEditorWidget::askForNamespaceName(const QString &szAction,const QSt
 			g_pAliasEditorModule->lock();
 			QMessageBox::information(this,
 				__tr2qs_ctx("Bad Namespace Name","editor"),
-				__tr2qs_ctx("Stray ':' character in namespace name: did you mean ...<namespace>::<name> ?","editor"),
-				__tr2qs_ctx("Ok, Let me try again...","editor"));
+				__tr2qs_ctx("Stray ':' character in namespace name: did you mean ...<namespace>::<name>?","editor"),
+				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pAliasEditorModule->unlock();
 			szNewName = "";
 			continue;
@@ -1110,7 +1110,7 @@ QString AliasEditorWidget::askForNamespaceName(const QString &szAction,const QSt
 			QMessageBox::information(this,
 				__tr2qs_ctx("Bad Namespace Name","editor"),
 				__tr2qs_ctx("Found an empty namespace in namespace name","editor"),
-				__tr2qs_ctx("Ok, Let me try again...","editor"));
+				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pAliasEditorModule->unlock();
 			szNewName = "";
 			continue;

--- a/src/modules/avatar/libkviavatar.cpp
+++ b/src/modules/avatar/libkviavatar.cpp
@@ -183,7 +183,7 @@ void KviAsyncAvatarSelectionDialog::closeEvent(QCloseEvent * e)
 		avatar.set [avatar:string]
 	@description:
 		Sets your avatar in the current connection to <avatar>.
-		<avatar> may be a local filename or a http url.[br]
+		<avatar> may be a local filename or a http URL.[br]
 		If avatar is an empty string then an asynchronous dialog
 		will be opened that will allow choosing an avatar.[br]
 		Note that this command does NOT notify the avatar to
@@ -222,7 +222,7 @@ static bool avatar_kvs_cmd_set(KviKvsModuleCommandCall * c)
 	KviIrcUserEntry * e = c->window()->connection()->userDataBase()->find(c->window()->connection()->currentNickName());
 	if(!e)
 	{
-		c->warning(__tr2qs("Internal error: ain't I in the user database ?"));
+		c->warning(__tr2qs("Internal error: am I not in the user database?"));
 		return true;
 	}
 
@@ -303,7 +303,7 @@ static bool avatar_kvs_cmd_unset(KviKvsModuleCommandCall * c)
 	KviIrcUserEntry * e = c->window()->connection()->userDataBase()->find(c->window()->connection()->currentNickName());
 	if(!e)
 	{
-		c->warning(__tr2qs("Internal error: ain't I in the user database ?"));
+		c->warning(__tr2qs("Internal error: am I not in the user database?"));
 		return true;
 	}
 
@@ -336,11 +336,11 @@ static bool avatar_kvs_cmd_unset(KviKvsModuleCommandCall * c)
 		See the [doc:ctcp_avatar]avatar protocol documentation[/doc] for the
 		description of the protocol.[br]
 		This has the effect to notify your avatar image to the <target>.[br]
-		The CTCP is sent thru a NOTICE and the current avatar image
+		The CTCP is sent through a NOTICE and the current avatar image
 		is added to the public offer list for <timeout> seconds (or a default timeout if the -t switch is not used).[br]
-		If the -q switch is specified, the command executes in quet mode and
+		If the -q switch is specified, the command executes in quiet mode and
 		prints nothing in the current window.[br]
-		If you don't have an avatar set, the ctcp will unset the previous avatar
+		If you don't have an avatar set, the CTCP will unset the previous avatar
 		on the target side.[br]
 		[b]Warning:[/b] The implementation of the avatar protocol is actually
 		restricted to KVIrc clients only. In the future other clients may implement it.[br]
@@ -378,7 +378,7 @@ static bool avatar_kvs_cmd_notify(KviKvsModuleCommandCall * c)
 	KviIrcUserEntry * e = c->window()->connection()->userDataBase()->find(c->window()->connection()->currentNickName());
 	if(!e)
 	{
-		c->warning(__tr2qs("Internal error: ain't I in the user database ?"));
+		c->warning(__tr2qs("Internal error: am I not in the user database?"));
 		return true;
 	}
 
@@ -415,7 +415,7 @@ static bool avatar_kvs_cmd_notify(KviKvsModuleCommandCall * c)
 			{
 				// Don't delete o...it has been already deleted by g_pFileTrader
 				if(!c->switches()->find('q',"quiet"))
-					c->warning(__tr2qs("Can't add a file offer for file %Q (huh ? file not readable ?)"),&absPath);
+					c->warning(__tr2qs("Can't add a file offer for file %Q (huh? file not readable?)"),&absPath);
 				return true;
 			}
 

--- a/src/modules/chan/libkvichan.cpp
+++ b/src/modules/chan/libkvichan.cpp
@@ -1090,7 +1090,7 @@ static bool chan_kvs_fnc_modeParam(KviKvsModuleFunctionCall * c)
 		[example]
 			[comment]# Get the nickname list[/comment]
 			%test[] = $chan.users
-			[comment]# And loop thru the items[/comment]
+			[comment]# And loop through the items[/comment]
 			%i = 0
 			[comment]# %test[]# returns the number of elements in the array[/comment]
 			%count = %test[]#

--- a/src/modules/classeditor/ClassEditorWindow.cpp
+++ b/src/modules/classeditor/ClassEditorWindow.cpp
@@ -540,7 +540,7 @@ void ClassEditorWidget::renameFunction()
 			QMessageBox::information(this,
 			__tr2qs_ctx("Function already exists","editor"),
 			__tr2qs_ctx("This name is already in use. Please choose another one.","editor"),
-			__tr2qs_ctx("Ok, Let me try again...","editor"));
+			__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pClassEditorModule->unlock();
 			return;
 		}
@@ -602,7 +602,7 @@ void ClassEditorWidget::renameClass(ClassEditorTreeWidgetItem * pClassItem)
 		QMessageBox::information(this,
 			__tr2qs_ctx("Class already exists","editor"),
 			__tr2qs_ctx("This name is already in use. Please choose another one.","editor"),
-			__tr2qs_ctx("Ok, Let me try again...","editor"));
+			__tr2qs_ctx("OK, Let me try again...","editor"));
 		g_pClassEditorModule->unlock();
 		return;
 	}
@@ -612,7 +612,7 @@ void ClassEditorWidget::renameClass(ClassEditorTreeWidgetItem * pClassItem)
 		QMessageBox::information(this,
 			__tr2qs_ctx("Bad Namespace Name","editor"),
 			__tr2qs_ctx("Found an empty namespace in namespace name","editor"),
-			__tr2qs_ctx("Ok, Let me try again...","editor"));
+			__tr2qs_ctx("OK, Let me try again...","editor"));
 		g_pClassEditorModule->unlock();
 		szNewName = "";
 		continue;
@@ -686,12 +686,12 @@ void ClassEditorWidget::renameNamespace(ClassEditorTreeWidgetItem * pOldNamespac
 			QMessageBox::information(this,
 				__tr2qs_ctx("Name already exists as Class name","editor"),
 				__tr2qs_ctx("This name is already in use as Class name. Please choose another one.","editor"),
-				__tr2qs_ctx("Ok, Let me try again...","editor"));
+				__tr2qs_ctx("OK, Let me try again...","editor"));
 		} else {
 			QMessageBox::information(this,
 			__tr2qs_ctx("Namespace already exists","editor"),
 			__tr2qs_ctx("This name is already in use. Please choose another one.","editor"),
-			__tr2qs_ctx("Ok, Let me try again...","editor"));
+			__tr2qs_ctx("OK, Let me try again...","editor"));
 		}
 		g_pClassEditorModule->unlock();
 		return;
@@ -1521,7 +1521,7 @@ bool ClassEditorWidget::askForNamespaceName(const QString & szAction, const QStr
 			QMessageBox::warning(this,
 				__tr2qs_ctx("Missing Namespace Name","editor"),
 				__tr2qs_ctx("You must specify a valid name for the namespace","editor"),
-				__tr2qs_ctx("Ok, Let me try again...","editor"));
+				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pClassEditorModule->unlock();
 			continue;
 		}
@@ -1534,7 +1534,7 @@ bool ClassEditorWidget::askForNamespaceName(const QString & szAction, const QStr
 			QMessageBox::information(this,
 				__tr2qs_ctx("Bad Namespace Name","editor"),
 				__tr2qs_ctx("Namespace names can contain only letters, digits, underscores and '::' namespace separators","editor"),
-				__tr2qs_ctx("Ok, Let me try again...","editor"));
+				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pClassEditorModule->unlock();
 			szNewName = "";
 			continue;
@@ -1547,8 +1547,8 @@ bool ClassEditorWidget::askForNamespaceName(const QString & szAction, const QStr
 			g_pClassEditorModule->lock();
 			QMessageBox::information(this,
 				__tr2qs_ctx("Bad Namespace Name","editor"),
-				__tr2qs_ctx("Stray ':' character in namespace name: did you mean ...<namespace>::<name> ?","editor"),
-				__tr2qs_ctx("Ok, Let me try again...","editor"));
+				__tr2qs_ctx("Stray ':' character in namespace name: did you mean ...<namespace>::<name>?","editor"),
+				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pClassEditorModule->unlock();
 			szNewName = "";
 			continue;
@@ -1559,7 +1559,7 @@ bool ClassEditorWidget::askForNamespaceName(const QString & szAction, const QStr
 			QMessageBox::information(this,
 				__tr2qs_ctx("Bad Namespace Name","editor"),
 				__tr2qs_ctx("Found an empty namespace in namespace name","editor"),
-				__tr2qs_ctx("Ok, Let me try again...","editor"));
+				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pClassEditorModule->unlock();
 			szNewName = "";
 			continue;

--- a/src/modules/config/libkviconfig.cpp
+++ b/src/modules/config/libkviconfig.cpp
@@ -542,7 +542,7 @@ static bool config_kvs_cmd_close(KviKvsModuleCommandCall * c)
 			// we force a save here
 			if(!cfg->sync())
 				if(!c->hasSwitch('q',"quiet"))
-					c->warning(__tr2qs("An error has occured while trying to save the config file with id '%Q'"),&szId);
+					c->warning(__tr2qs("An error has occurred while trying to save the config file with id '%Q'"),&szId);
 		}
 		g_pConfigDict->remove(szId);
 	} else {
@@ -590,7 +590,7 @@ static bool config_kvs_cmd_flush(KviKvsModuleCommandCall * c)
 			c->warning(__tr2qs("The config file with id '%Q' is read only"),&szId);
 		else
 			if(!cfg->sync())
-				c->warning(__tr2qs("An error has occured while trying to save the config file with id '%Q'"),&szId);
+				c->warning(__tr2qs("An error has occurred while trying to save the config file with id '%Q'"),&szId);
 	} else {
 		c->warning(__tr2qs("The config file with id '%Q' is not open"),&szId);
 	}

--- a/src/modules/dcc/DccBroker.cpp
+++ b/src/modules/dcc/DccBroker.cpp
@@ -781,7 +781,7 @@ void DccBroker::renameOverwriteResume(DccDialog *box,DccDescriptor * dcc)
 							"and is larger than the offered one.<br>" \
 							"Do you wish to<br>" \
 							"<b>auto-rename</b> the new file, or<br>" \
-							"<b>overwrite</b> the existing file ?" \
+							"<b>overwrite</b> the existing file?" \
 						,"dcc" \
 					).arg(dcc->szLocalFileName);
 			}

--- a/src/modules/dcc/DccFileTransfer.cpp
+++ b/src/modules/dcc/DccFileTransfer.cpp
@@ -155,7 +155,7 @@ bool DccRecvThread::sendAck(int filePos,bool bTolerateErrors)
 #ifdef COMPILE_SSL_SUPPORT
 		if(m_pSSL)
 		{
-			// dropping ack when no serious ssl error occured
+			// dropping ack when no serious ssl error occurred
 			switch(m_pSSL->getProtocolError(iRet))
 			{
 				case KviSSL::ZeroReturn:

--- a/src/modules/dcc/libkvidcc.cpp
+++ b/src/modules/dcc/libkvidcc.cpp
@@ -2437,7 +2437,7 @@ static bool dcc_kvs_fnc_ircContext(KviKvsModuleFunctionCall * c)
 		{
 			c->returnValue()->setInteger(dcc->console()->context()->id());
 		} else {
-			c->error(__tr2qs_ctx("The irc context that originated the dcc doesn't exists anymore.","dcc"));
+			c->error(__tr2qs_ctx("The IRC context that originated the DCC doesn't exists anymore.","dcc"));
 			return false;
 		}
 	}

--- a/src/modules/dcc/requests.cpp
+++ b/src/modules/dcc/requests.cpp
@@ -315,15 +315,15 @@ static void dccModuleParseDccChat(KviDccRequest *dcc)
 			{
 				// hum.. not our tag
 
-				// FIXME: As segnaled by PRAEDO, ezbounce seems to send a fourth parameter in response to /quote ezb log
+				// FIXME: As signalled by PRAEDO, ezbounce seems to send a fourth parameter in response to /quote ezb log
 				// Pragma: That's a bug in ezbounce, it sends the filesize of the log as a DCC CHAT parameter...
 				//         The author probably copied and pasted the CTCP line from DCC SEND and forgot to remove the filesize.
-				//         We *could* add an option to ignore the last parameter and treat it as a standard dcc chat
+				//         We *could* add an option to ignore the last parameter and treat it as a standard DCC chat
 				//         request, but since we don't encourage bugs, we don't do it :D
 				//         Mail me at pragma at kvirc dot net if you really think it's necessary.
 				dcc->ctcpMsg->msg->console()->output(KVI_OUT_DCCMSG,
 					__tr2qs_ctx("The above request is broken: it looks like a zero port tag acknowledge but I have either never seen this tag or it was sent more than 120 seconds ago","dcc"));
-				dcc_module_request_error(dcc,__tr2qs_ctx("It seems that I haven't requested this dcc chat","dcc"));
+				dcc_module_request_error(dcc,__tr2qs_ctx("It seems that I haven't requested this DCC chat","dcc"));
 				delete d;
 				return;
 			} else {
@@ -335,7 +335,7 @@ static void dccModuleParseDccChat(KviDccRequest *dcc)
 		}
 	} else {
 		d->bAutoAccept       = KVI_OPTION_BOOL(KviOption_boolAutoAcceptDccChat);
-		d->bActive           = true; // we have to connct (standard active chat)
+		d->bActive           = true; // we have to connect (standard active chat)
 	}
 
 #ifdef COMPILE_SSL_SUPPORT
@@ -419,7 +419,7 @@ static void dccModuleParseDccSend(KviDccRequest *dcc)
 		} else {
 			// this should never happen since we always add
 			// a zero port tag for out outgoing requests
-			// but well... maybe the user did something behing our back...
+			// but well... maybe the user did something behind our back...
 			dcc->szParam4 = "0"; // no resume possible in this case
 		}
 

--- a/src/modules/dialog/libkvidialog.cpp
+++ b/src/modules/dialog/libkvidialog.cpp
@@ -170,7 +170,7 @@ void KviKvsCallbackMessageBox::done(int code)
 	@examples:
 		[example]
 		[comment]# Just a warning dialog[/comment]
-		dialog.message("Warning","You're being <b>warned</b>",warning,"Ok"){ echo The user clicked OK; }
+		dialog.message("Warning","You're being <b>warned</b>",warning,"OK"){ echo The user clicked OK; }
 		[comment]# A question[/comment]
 		dialog.message("And now ?","What do you want to do ?",information,"Go home","Watch TV","Scream")
 		{
@@ -468,7 +468,7 @@ void KviKvsCallbackTextInput::showEvent(QShowEvent *e)
 	@examples:
 		[example]
 		[comment]# We need a single line "reason"[/comment]
-		dialog.textinput -d="Working !" (Away,<center>Please enter the <h1>away message</h1></center>,"Ok","Cancel")
+		dialog.textinput -d="Working!" (Away,<center>Please enter the <h1>away message</h1></center>,"OK","Cancel")
 		{
 			switch($0)
 			{

--- a/src/modules/file/libkvifile.cpp
+++ b/src/modules/file/libkvifile.cpp
@@ -46,7 +46,7 @@
 
 #if defined(COMPILE_SSL_SUPPORT)
 
-	// Apple deprecated openssl since osx 10.7:
+	// Apple deprecated openSSL since OS X 10.7:
 
 	#ifdef DEPRECATED_IN_MAC_OS_X_VERSION_10_7_AND_LATER
 		#undef DEPRECATED_IN_MAC_OS_X_VERSION_10_7_AND_LATER
@@ -79,9 +79,9 @@
 		Makes a copy of the <source> file as <destination>.[br]
 		If the [-o] switch is used, the <destination> file is overwritten, if already exists.[br]
 		With no [-o] switch, this command does not overwrite files.[br]
-		The destination path must be already existing: if you want to ensure this, use [cmd]file.mkdir[/cmd] first.[br]
+		The destination path must already exist: if you want to ensure this, use [cmd]file.mkdir[/cmd] first.[br]
 		The paths (<source> and <destination>) are adjusted according to the system that KVIrc
-		is running on so you don't have to bother about portability: it *should* be automatically
+		is running on so you don't have to bother about portability: it [i]should[i/] be automatically
 		guaranteed. Just use UNIX style paths for them.[br]
 	@seealso:
 		[cmd]file.rename[/cmd], [fnc]$file.exists[/fnc]
@@ -1529,7 +1529,7 @@ static bool file_kvs_fnc_digest(KviKvsModuleFunctionCall * c)
 	{
 		qAlgo = QCryptographicHash::Md5;
 	} else {
-		c->warning(__tr2qs("KVIrc is compiled without Crypto++ or OpenSSL support. $file.digest supports only MD4, MD5 and SHA1."));
+		c->warning(__tr2qs("KVIrc is compiled without Crypto++ or SSL support. $file.digest supports only MD4, MD5 and SHA1."));
 		return true;
 	}
 

--- a/src/modules/fish/libkvifish.cpp
+++ b/src/modules/fish/libkvifish.cpp
@@ -103,7 +103,7 @@
 
 		return true;
 	#else
-		qDebug("%s",__tr2qs("FiSH has been compiled without ssl support, unable to proceed").toUtf8().data());
+		qDebug("%s",__tr2qs("FiSH has been compiled without SSL support, unable to proceed").toUtf8().data());
 		return false;
 	#endif
 	}
@@ -140,7 +140,7 @@
 		if(!fish_DH1080_gen(&szMyPubKey, pMyPubKeyLen))
 		{
 			#if !defined(COMPILE_SSL_SUPPORT)
-				c->warning(__tr2qs("FiSH has been compiled without ssl support, unable to proceed"));
+				c->warning(__tr2qs("FiSH has been compiled without SSL support, unable to proceed"));
 				return false;
 			#endif
 			return false;
@@ -217,7 +217,7 @@
 		BIGNUM *bn = BN_bin2bn((unsigned char *) szHisPubKey.data(), szHisPubKey.size(),NULL);
 		if(-1 == (secretLen = DH_compute_key(secret, bn, g_fish_dh)))
 		{
-			c->warning(__tr2qs("FiSH: error verificating peer public key (size=%1)").arg(szHisPubKey.size()));
+			c->warning(__tr2qs("FiSH: error verifying peer public key (size=%1)").arg(szHisPubKey.size()));
 			return false;
 		}
 		BN_zero(bn);
@@ -234,7 +234,7 @@
 
 		KviMemory::free(hashedSecret);
 		#else
-			c->warning(__tr2qs("FiSH has been compiled without ssl support, unable to proceed"));
+			c->warning(__tr2qs("FiSH has been compiled without SSL support, unable to proceed"));
 			return false;
 		#endif
 

--- a/src/modules/help/HelpWindow.cpp
+++ b/src/modules/help/HelpWindow.cpp
@@ -69,7 +69,7 @@ HelpWindow::HelpWindow(const char * name)
 	m_pBottomLayout->setVisible(false);
 
 	m_pIndexTab  = new KviTalVBox(m_pTabWidget);
-	m_pTabWidget->addTab(m_pIndexTab,__tr2qs("HelpIndex"));
+	m_pTabWidget->addTab(m_pIndexTab,__tr2qs("Help Index"));
 
 	KviTalHBox* pSearchBox = new KviTalHBox(m_pIndexTab);
 	m_pIndexSearch = new QLineEdit(pSearchBox);

--- a/src/modules/links/LinksWindow.cpp
+++ b/src/modules/links/LinksWindow.cpp
@@ -119,7 +119,7 @@ void LinksWindow::requestLinks()
 		outputNoFmt(KVI_OUT_SYSTEMMESSAGE,__tr2qs("Sent links request, waiting for reply..."));
 		m_pRequestButton->setEnabled(false);
 	} else {
-		outputNoFmt(KVI_OUT_SYSTEMERROR,__tr2qs("Cannot request links: No active connection"));
+		outputNoFmt(KVI_OUT_SYSTEMERROR,__tr2qs("Cannot request links: no active connection"));
 	}
 }
 
@@ -132,7 +132,7 @@ void LinksWindow::connectionStateChange()
 		QString szTmp = QString(__tr2qs("Connected to %1 (%2)")).arg(m_pConsole->connection()->currentServerName(),m_pConsole->currentNetworkName());
 		m_pInfoLabel->setText(szTmp);
 	} else {
-		m_pInfoLabel->setText(__tr2qs("Links cannot be requested: Not connected to a server"));
+		m_pInfoLabel->setText(__tr2qs("Links cannot be requested: not connected to a server"));
 	}
 }
 
@@ -296,7 +296,7 @@ void LinksWindow::endOfLinks()
 		output(KVI_OUT_LINKS,__tr2qs("Average hops: ~%d.%d"),avgHops / 100,avgHops % 100);
 	} else {
 		m_szRootServer = __tr2qs("(Unknown)");
-		outputNoFmt(KVI_OUT_LINKS,__tr2qs("Incomplete LINKS result, no stats available"));
+		outputNoFmt(KVI_OUT_LINKS,__tr2qs("Incomplete links result, no stats available"));
 	}
 	outputNoFmt(KVI_OUT_LINKS,"======================");
 

--- a/src/modules/links/libkvilinks.cpp
+++ b/src/modules/links/libkvilinks.cpp
@@ -44,15 +44,15 @@ KviPointerList<LinksWindow> * g_pLinksWindowList = 0;
 	@syntax:
 		links.open
 	@description:
-		Opens a "links" window attacched to the current irc context.[br]
+		Opens a "links" window attached to the current IRC context.[br]
 		The links window handles the RPL_LINKS server replies and shows
-		them in a Tree-View form: this is useful in vizualizing the
+		them in a Tree-View form: this is useful in visualizing the
 		current network connections.[br]
 		Please note that the total number of links received (and the
 		total count of servers displayed when all the links have been received)
-		may actually be less than the real number of irc servers in the network.
+		may actually be less than the real number of IRC servers in the network.
 		Servers that contain a wildcard in their name often act as gateways (hubs)
-		for a "local irc network"; if you're requesting links from a server that is
+		for a "local IRC network"; if you're requesting links from a server that is
 		external to the gateway, the servers internal to the network "behind the gateway"
 		will not be shown; in the extreme case you will see the gateway as leaf node (and it isn't).
 		To see the internal network server tree you might request LINKS from the gateway server.[br]
@@ -69,7 +69,7 @@ static bool links_kvs_cmd_open(KviKvsModuleCommandCall * c)
 		LinksWindow *w = new LinksWindow(c->window()->console());
 		g_pMainWindow->addWindow(w);
 	} else {
-		c->warning(__tr2qs("Links window alread open for this IRC context"));
+		c->warning(__tr2qs("Links window already open for this IRC context"));
 	}
 
 	return true;
@@ -101,7 +101,7 @@ static bool links_module_can_unload(KviModule *)
 }
 
 KVIRC_MODULE(
-	"Links",                                             // module name
+	"Links",                                                // module name
 	"4.0.0",                                                // module version
 	"Copyright (C) 2000-2010 Szymon Stefanek (pragma at kvirc dot net)", // author & (C)
 	"Links window extension",

--- a/src/modules/mircimport/libkvimircimport.cpp
+++ b/src/modules/mircimport/libkvimircimport.cpp
@@ -141,7 +141,7 @@ void KviMircServersIniImport::die()
 KviRemoteMircServerImportWizard::KviRemoteMircServerImportWizard(KviRemoteMircServersIniImport * f)
 : KviTalWizard(0)
 {
-	QString capt = __tr2qs("Remote mIRC servers.ini Import Wizard");
+	QString capt = __tr2qs("Remote mIRC servers.ini - Import Wizard");
 	setWindowTitle(capt);
 
 	setModal(true);

--- a/src/modules/my/libkvimy.cpp
+++ b/src/modules/my/libkvimy.cpp
@@ -44,12 +44,12 @@ Idle* g_pIdle;
 	if(!c->parameterList()->count()) \
 	{ \
 		if(c->window()->console()) wnd = c->window()->console(); \
-			else c->warning(__tr2qs("This window has no associated irc context")); \
+			else c->warning(__tr2qs("This window has no associated IRC context")); \
 	} \
 	else \
 	{ \
 		wnd = g_pApp->findConsole(uiWnd); \
-		if(!wnd)c->warning(__tr2qs("No such irc context (%d)"),uiWnd); \
+		if(!wnd)c->warning(__tr2qs("No such IRC context (%d)"),uiWnd); \
 	}
 /*
 	@doc: my.nick
@@ -62,8 +62,8 @@ Idle* g_pIdle;
 	@syntax:
 		<string> $my.nick([irc_context_id:uint])
 	@description:
-		Returns the nickname of the current irc context.[br]
-		If the irc context is not connected then an empty string is returned.[br]
+		Returns the nickname of the current IRC context.[br]
+		If the IRC context is not connected then an empty string is returned.[br]
 		If <irc_context_id> is specified this function returns acts as it was called
 		in that irc_context.[br]
 		Note that this function is different from [fnc]$me[/fnc] that will work also in a DCC CHAT.[br]

--- a/src/modules/objects/KvsObject_dialog.cpp
+++ b/src/modules/objects/KvsObject_dialog.cpp
@@ -44,10 +44,10 @@
 		[class]object[/class]
 		[class]widget[/class]
 	@description:
-		Rappresents a dialog object. The class is really
+		Represents a dialog object. The class is really
 		similar to the widget class, it has only a couple of minor differences.
 		A dialog is always a top-level widget, but if it has a parent, its default
-		location is centered on top of the parent. It will also share the parent's windowlist entry.
+		location is centered on top of the parent. It will also share the parent's window list entry.
 		!fn; setModal (<boolean>)
 		If you call $setModal(1) then the dialog will have non-blocking modal behaviour:
 		it will appear above its parent widget and block its input until it's closed.

--- a/src/modules/objects/KvsObject_file.cpp
+++ b/src/modules/objects/KvsObject_file.cpp
@@ -334,7 +334,7 @@ KVSO_CLASS_FUNCTION(file,putch)
 	KVSO_PARAMETERS_END(c)
 	if (szChar.length()>1)c->warning(__tr2qs_ctx("Argument too long, using only first char","objects"));
 	const char *ch=szChar.toUtf8().data();
-	if (!m_pFile->putChar(ch[0])) c->warning(__tr2qs_ctx("Write error occured!","objects"));
+	if (!m_pFile->putChar(ch[0])) c->warning(__tr2qs_ctx("Write error occurred!","objects"));
 	return true;
 }
 
@@ -343,7 +343,7 @@ KVSO_CLASS_FUNCTION(file,getch)
 	CHECK_INTERNAL_POINTER(m_pFile)
 	CHECK_FILE_IS_OPEN
 	char ch;
-	if (!m_pFile->getChar(&ch)) c->warning(__tr2qs_ctx("Read error occured!","objects"));	// c->error ?
+	if (!m_pFile->getChar(&ch)) c->warning(__tr2qs_ctx("Read error occurred!","objects"));	// c->error ?
 	QString szChar = QChar(ch);
 	c->returnValue()->setString(szChar);
 	return true;
@@ -354,7 +354,7 @@ KVSO_CLASS_FUNCTION(file,readByte)
 	CHECK_INTERNAL_POINTER(m_pFile)
 	CHECK_FILE_IS_OPEN
 	char ch;
-	if (!m_pFile->getChar(&ch)) c->warning(__tr2qs_ctx("Read error occured!","objects"));	// c->error ?
+	if (!m_pFile->getChar(&ch)) c->warning(__tr2qs_ctx("Read error occurred!","objects"));	// c->error ?
 	//QString szChar = QChar(ch);
 	c->returnValue()->setInteger((kvs_int_t) ch);
 	return true;

--- a/src/modules/objects/KvsObject_lineEdit.h
+++ b/src/modules/objects/KvsObject_lineEdit.h
@@ -29,7 +29,7 @@
 
 #include "KvsObject_widget.h"
 
-//#warning "Signals !"
+//#warning "Signals!"
 #include <QCompleter>
 #include "object_macros.h"
 

--- a/src/modules/objects/KvsObject_listWidget.cpp
+++ b/src/modules/objects/KvsObject_listWidget.cpp
@@ -352,7 +352,7 @@ KVSO_CLASS_FUNCTION(listWidget,setIcon)
 		pix=g_pIconManager->getImage(szPix);
 		if(!pix)
 		{
-			c->warning(__tr2qs_ctx("Error occured: the suitable file '%Q' is not of the correct format or it is not a valid icon number.","objects"),&szPix);
+			c->warning(__tr2qs_ctx("Error occurred: the suitable file '%Q' is not of the correct format or it is not a valid icon number.","objects"),&szPix);
 			return true;
 		}
 	}

--- a/src/modules/objects/KvsObject_tableWidget.cpp
+++ b/src/modules/objects/KvsObject_tableWidget.cpp
@@ -347,17 +347,17 @@ KVSO_CLASS_FUNCTION(tableWidget,setForeground)
 					color.setNamedColor(szColor);
 					if (!color.isValid())
 					{
-						// itsn't a color name: let try with an hex triplette
+						// isn't a color name: lets try with an hex triplet
 						color.setNamedColor("#"+szColor);
 						if (!color.isValid())
 						{
-							c->warning(__tr2qs_ctx("Not a valid color !","objects"));
+							c->warning(__tr2qs_ctx("Not a valid color!","objects"));
 							return true;
 						}
 					}
 				}
 				else {
-					c->warning(__tr2qs_ctx("Not a valid color !","objects"));
+					c->warning(__tr2qs_ctx("Not a valid color!","objects"));
 					return true;
 				}
 				QBrush brush(color);
@@ -499,7 +499,7 @@ KVSO_CLASS_FUNCTION(tableWidget,setIcon)
 			pix=g_pIconManager->getImage(szPix);
 			if(!pix)
 			{
-				c->warning(__tr2qs_ctx("Error occured: the suitable file '%Q' is not of the correct format or it is not a valid icon number.","objects"),&szPix);
+				c->warning(__tr2qs_ctx("Error occurred: the suitable file '%Q' is not of the correct format or it is not a valid icon number.","objects"),&szPix);
 				return true;
 			}
 	}

--- a/src/modules/objects/KvsObject_treeWidgeteItem.cpp
+++ b/src/modules/objects/KvsObject_treeWidgeteItem.cpp
@@ -420,7 +420,7 @@ KVSO_CLASS_FUNCTION(treeWidgetItem,setPixmap)
 		pix=g_pIconManager->getImage(szPix);
 		if(!pix)
 		{
-			c->warning(__tr2qs_ctx("Error occured: the suitable file '%Q' is not of the correct format or it is not a valid icon number.","objects"),&szPix);
+			c->warning(__tr2qs_ctx("Error occurred: the suitable file '%Q' is not of the correct format or it is not a valid icon number.","objects"),&szPix);
 			return true;
 		}
 	}

--- a/src/modules/objects/KvsObject_widget.cpp
+++ b/src/modules/objects/KvsObject_widget.cpp
@@ -1276,13 +1276,13 @@ KVSO_CLASS_FUNCTION(widget,setForegroundColor)
 						color.setNamedColor("#"+szColor);
 						if (!color.isValid())
 						{
-							c->warning(__tr2qs_ctx("Not a valid color !","objects"));
+							c->warning(__tr2qs_ctx("Not a valid color!","objects"));
 							return true;
 						}
 					}
 				}
 				else {
-					c->warning(__tr2qs_ctx("Not a valid color !","objects"));
+					c->warning(__tr2qs_ctx("Not a valid color!","objects"));
 					return true;
 				}
 				QPalette p = widget()->palette();
@@ -1358,13 +1358,13 @@ KVSO_CLASS_FUNCTION(widget,setBackgroundColor)
 						color.setNamedColor("#"+szColor);
 						if (!color.isValid())
 						{
-							c->warning(__tr2qs_ctx("Not a valid color !","objects"));
+							c->warning(__tr2qs_ctx("Not a valid color!","objects"));
 							return true;
 						}
 					}
 				}
 				else {
-					c->warning(__tr2qs_ctx("Not a valid color !","objects"));
+					c->warning(__tr2qs_ctx("Not a valid color!","objects"));
 					return true;
 				}
 				QPalette p = widget()->palette();

--- a/src/modules/objects/KvsObject_xmlreader.cpp
+++ b/src/modules/objects/KvsObject_xmlreader.cpp
@@ -66,7 +66,7 @@
 		obtain a descriptive error message.
 
 		!fn: <string> $lastError()
-		Returns the last error occured inside the parser.
+		Returns the last error occurred inside the parser.
 		You will typically call this function when $parse() above returns $false.
 
 		!fn: <boolean> $onDocumentStart()

--- a/src/modules/options/OptionsWidget_dcc.cpp
+++ b/src/modules/options/OptionsWidget_dcc.cpp
@@ -320,13 +320,13 @@ OptionsWidget_dccChat::OptionsWidget_dccChat(QWidget * parent)
 	connect(b2,SIGNAL(toggled(bool)),b1,SLOT(setNotEnabled(bool)));
 
 #if (defined(COMPILE_ON_WINDOWS) || defined(COMPILE_KDE_SUPPORT) || defined(COMPILE_ON_MINGW))
-	b2 = addBoolSelector(0,2,0,2,__tr2qs_ctx("Flash system taskbar on new dcc chat message","options"),KviOption_boolFlashDccChatWindowOnNewMessages);
+	b2 = addBoolSelector(0,2,0,2,__tr2qs_ctx("Flash system taskbar on new DCC chat message","options"),KviOption_boolFlashDccChatWindowOnNewMessages);
 		mergeTip(b2,
-			__tr2qs_ctx("<center>This option causes the system taskbar entry for KVIrc to flash when a new dcc chat message " \
+			__tr2qs_ctx("<center>This option causes the system taskbar entry for KVIrc to flash when a new DCC chat message " \
 				"is received and the KVIrc window is not the active.</center>","options"));
 #endif
 
-	b2 = addBoolSelector(0,3,0,3, __tr2qs_ctx("Popup notifier on new dcc chat message","options"),KviOption_boolPopupNotifierOnNewDccChatMessages);
+	b2 = addBoolSelector(0,3,0,3, __tr2qs_ctx("Popup notifier on new DCC chat message","options"),KviOption_boolPopupNotifierOnNewDccChatMessages);
 	mergeTip(b2,
 		__tr2qs_ctx("<center>This option causes a small notifier window to pop up " \
 			"in the low right corner of the screen when a new message is received " \

--- a/src/modules/options/OptionsWidget_ircView.cpp
+++ b/src/modules/options/OptionsWidget_ircView.cpp
@@ -160,7 +160,7 @@ OptionsWidget_ircViewFeatures::OptionsWidget_ircViewFeatures(QWidget * parent)
 	addBoolSelector(0,12,0,12,__tr2qs_ctx("Enable animated smiles","options"),KviOption_boolEnableAnimatedSmiles);
 
 	KviTalGroupBox * pGroup = addGroupBox(0,13,0,13,Qt::Horizontal,__tr2qs_ctx("Enable tooltips for:","options"));
-	addBoolSelector(pGroup,__tr2qs_ctx("Url links","options"),KviOption_boolEnableUrlLinkToolTip);
+	addBoolSelector(pGroup,__tr2qs_ctx("URL links","options"),KviOption_boolEnableUrlLinkToolTip);
 	addBoolSelector(pGroup,__tr2qs_ctx("Host links","options"),KviOption_boolEnableHostLinkToolTip);
 	addBoolSelector(pGroup,__tr2qs_ctx("Server links","options"),KviOption_boolEnableServerLinkToolTip);
 	addBoolSelector(pGroup,__tr2qs_ctx("Mode links","options"),KviOption_boolEnableModeLinkToolTip);

--- a/src/modules/options/OptionsWidget_servers.cpp
+++ b/src/modules/options/OptionsWidget_servers.cpp
@@ -800,7 +800,7 @@ IrcServerDetailsWidget::IrcServerDetailsWidget(QWidget * par,KviIrcServer * s)
 
 	iRow++;
 
-	l = new QLabel(__tr2qs_ctx("Proxy server:","options"),tab);
+	l = new QLabel(__tr2qs_ctx("Proxy Server:","options"),tab);
 	gl->addWidget(l,iRow,0);
 	m_pProxyEditor = new QComboBox(tab);
 	gl->addWidget(m_pProxyEditor,iRow,1);
@@ -915,7 +915,7 @@ IrcServerDetailsWidget::IrcServerDetailsWidget(QWidget * par,KviIrcServer * s)
 	pCapLayout->addWidget(m_pEnableCAPCheck,0,0);
 
 	KviTalToolTip::add(m_pEnableCAPCheck,__tr2qs_ctx("<center>This check will cause the connection to use the <b>Extended Capability</b> " \
-		"support. Obviously, this server must have support for this, too. Disable this for irc bouncers.</center>","options"));
+		"support. Obviously, this server must have support for this, too. Disable this for IRC bouncers.</center>","options"));
 	m_pEnableCAPCheck->setChecked(s->enabledCAP());
 
 
@@ -926,18 +926,18 @@ IrcServerDetailsWidget::IrcServerDetailsWidget(QWidget * par,KviIrcServer * s)
 
 	m_pEnableSASLCheck = new QCheckBox(__tr2qs_ctx("Authenticate via SASL extension","options"),pSASLGroup);
 	pSASLLayout->addWidget(m_pEnableSASLCheck,0,0,1,2);
-	KviTalToolTip::add(m_pEnableSASLCheck,__tr2qs_ctx("<center>This check enables the use of the <b>SASL</b> authentication procotol " \
-		"If you enable the proper global option in the Connection/SSL tab and fill the Sasl Nickname and Sasl Password fields in this page, the SASL protocol will be used for this server if available.</center>","options"));
+	KviTalToolTip::add(m_pEnableSASLCheck,__tr2qs_ctx("<center>This check enables the use of the <b>SASL</b> authentication protocol " \
+		"If you enable the proper global option in the Connection/SSL tab and fill the SASL Nickname and SASL Password fields in this page, the SASL protocol will be used for this server if available.</center>","options"));
 	m_pEnableSASLCheck->setChecked(s->enabledSASL());
 
-	l = new QLabel(__tr2qs_ctx("Sasl Nickname:","options"),pSASLGroup);
+	l = new QLabel(__tr2qs_ctx("SASL Nickname:","options"),pSASLGroup);
 	pSASLLayout->addWidget(l,1,0);
 	m_pSaslNickEditor = new QLineEdit(pSASLGroup);
 	m_pSaslNickEditor->setText(s->saslNick());
 	KviTalToolTip::add(m_pSaslNickEditor,__tr2qs_ctx("<center>If you want to enable SASL authentication, insert your nickname here.</center>","options"));
 	pSASLLayout->addWidget(m_pSaslNickEditor,1,1);
 
-	l = new QLabel(__tr2qs_ctx("Sasl Password:","options"),pSASLGroup);
+	l = new QLabel(__tr2qs_ctx("SASL Password:","options"),pSASLGroup);
 	pSASLLayout->addWidget(l,2,0);
 	m_pSaslPassEditor = new KviPasswordLineEdit(pSASLGroup); // <---- ?????
 	m_pSaslPassEditor->setText(s->saslPass());
@@ -950,7 +950,7 @@ IrcServerDetailsWidget::IrcServerDetailsWidget(QWidget * par,KviIrcServer * s)
 	iRow++;
 
 
-	l = new QLabel(__tr2qs_ctx("Link filter:","options"),tab);
+	l = new QLabel(__tr2qs_ctx("Link Filter:","options"),tab);
 	gl->addWidget(l,iRow,0);
 	m_pLinkFilterEditor = new QComboBox(tab);
 	m_pLinkFilterEditor->setEditable(true);

--- a/src/modules/options/OptionsWidget_tools.cpp
+++ b/src/modules/options/OptionsWidget_tools.cpp
@@ -36,7 +36,7 @@ OptionsWidget_tools::OptionsWidget_tools(QWidget * parent)
 	setObjectName("tools_options_widget");
 	createLayout();
 
-	addLabel(0,0,0,0,__tr2qs_ctx("This section contains irc tools "\
+	addLabel(0,0,0,0,__tr2qs_ctx("This section contains IRC tools "\
 		"like <b>away, lag and logging system</b>. ","options"));
 
 	addRowSpacer(0,1,0,1);

--- a/src/modules/options/OptionsWidget_urlHandlers.h
+++ b/src/modules/options/OptionsWidget_urlHandlers.h
@@ -32,7 +32,7 @@ class QRadioButton;
 #define KVI_OPTIONS_WIDGET_NAME_OptionsWidget_urlHandlers __tr2qs_no_lookup("URL handlers")
 #define KVI_OPTIONS_WIDGET_PARENT_OptionsWidget_urlHandlers OptionsWidget_general
 #define KVI_OPTIONS_WIDGET_PRIORITY_OptionsWidget_urlHandlers 70000
-#define KVI_OPTIONS_WIDGET_KEYWORDS_OptionsWidget_urlHandlers __tr2qs_no_lookup("url,programs")
+#define KVI_OPTIONS_WIDGET_KEYWORDS_OptionsWidget_urlHandlers __tr2qs_no_lookup("URL,programs")
 
 class OptionsWidget_urlHandlers : public KviOptionsWidget
 {

--- a/src/modules/rijndael/libkvirijndael.cpp
+++ b/src/modules/rijndael/libkvirijndael.cpp
@@ -45,7 +45,7 @@
 		The rijndael module
 	@body:
 		The rijndael module exports six [doc:crypt_engines]cryptographic engines[/doc] based
-		on the Advanced Encryptiong Standard algorithm called Rijndael. Rijndael was
+		on the Advanced Encryption Standard algorithm called Rijndael. Rijndael was
 		originally written by Joan Daemen and Vincent Rijmen. The original Rijndael
 		description is available at http://www.esat.kuleuven.ac.be/~rijmen/rijndael/.[br]
 		It is a private key block cipher that has been designed to replace
@@ -189,7 +189,7 @@
 	{
 		switch(errCode)
 		{
-			case RIJNDAEL_SUCCESS: setLastError(__tr2qs("Error 0: Success ?")); break;
+			case RIJNDAEL_SUCCESS: setLastError(__tr2qs("Error 0: success?")); break;
 			case RIJNDAEL_UNSUPPORTED_MODE: setLastError(__tr2qs("Unsupported crypt mode")); break;
 			case RIJNDAEL_UNSUPPORTED_DIRECTION: setLastError(__tr2qs("Unsupported direction")); break;
 			case RIJNDAEL_UNSUPPORTED_KEY_LENGTH: setLastError(__tr2qs("Unsupported key length")); break;
@@ -205,7 +205,7 @@
 	{
 		if(!m_pEncryptCipher)
 		{
-			setLastError(__tr2qs("Ops...encrypt cipher not initialized"));
+			setLastError(__tr2qs("Ooops... Encryption cipher not initialized"));
 			return KviCryptEngine::EncryptError;
 		}
 		int len = (int)kvi_strLen(plainText);
@@ -258,7 +258,7 @@
 	{
 		if(!m_pDecryptCipher)
 		{
-			setLastError(__tr2qs("Ops...decrypt cipher not initialized"));
+			setLastError(__tr2qs("Ooops... Decryption cipher not initialized"));
 			return KviCryptEngine::DecryptError;
 		}
 
@@ -616,7 +616,7 @@
 	{
 		if(*(encoded.ptr()) != '*')
 		{
-			qDebug("WARNING: Specified a CBC key but the incoming message doesn't seem to be a CBC one");
+			qDebug("WARNING: specified a CBC key but the incoming message doesn't seem to be a CBC one");
 			return doDecryptECB(encoded,plain);
 		}
 		encoded.cutLeft(1);
@@ -667,10 +667,10 @@ static bool rijndael_module_init(KviModule * m)
 	g_pEngineList->setAutoDelete(false);
 
 	QString szFormat = __tr2qs("Cryptographic engine based on the Advanced Encryption Standard (AES) algorithm called Rijndael. " \
-		"<br/>The text is first encrypted with rijndael and then converted to %1 notation. " \
+		"<br/>The text is first encrypted with Rijndael and then converted to %1 notation. " \
 		"The keys used are %2 bit long and will be padded with zeros if you provide shorter ones. " \
 		"If only one key is provided, this engine will use it for both encrypting and decrypting. " \
-		"See the rijndael module documentation for more info on the algorithm used. " \
+		"See the Rijndael module documentation for more info on the algorithm used. " \
 		"<br/>This engine works in CBC mode by default: other modes are considered INSECURE and should be avoided. " \
 		"The old pseudo-CBC mode used in KVIrc &lt; 4.2 is still available prefixing your key(s) with \"old:\"; " \
 		"if you want to use ECB mode you must prefix your key(s) with \"ecb:\".");

--- a/src/modules/rijndael/libkvirijndael.cpp
+++ b/src/modules/rijndael/libkvirijndael.cpp
@@ -205,7 +205,7 @@
 	{
 		if(!m_pEncryptCipher)
 		{
-			setLastError(__tr2qs("Ooops... Encryption cipher not initialized"));
+			setLastError(__tr2qs("Oops... Encryption cipher not initialized"));
 			return KviCryptEngine::EncryptError;
 		}
 		int len = (int)kvi_strLen(plainText);
@@ -258,7 +258,7 @@
 	{
 		if(!m_pDecryptCipher)
 		{
-			setLastError(__tr2qs("Ooops... Decryption cipher not initialized"));
+			setLastError(__tr2qs("Oops... Decryption cipher not initialized"));
 			return KviCryptEngine::DecryptError;
 		}
 

--- a/src/modules/setup/SetupWizard.cpp
+++ b/src/modules/setup/SetupWizard.cpp
@@ -196,7 +196,7 @@ SetupWizard::SetupWizard()
 	g_pApp->getGlobalKvircDirectory(szLicensePath,KviApplication::License,"COPYING");
 	if(!KviFileUtils::loadFile(szLicensePath,szLicense))
 	{
-		szLicense = __tr("Oops... can't find the license file.\n" \
+		szLicense = __tr("Ooops... Can't find the license file.\n" \
 			"It MUST be included in the distribution...\n" \
 			"Please report to <pragma at kvirc dot net>");
 	}
@@ -316,7 +316,7 @@ SetupWizard::SetupWizard()
 
 	m_pIdentity = new SetupPage(this);
 
-	m_pIdentity->m_pTextLabel->setText(__tr2qs("Please choose a Nickname.<br><br>" \
+	m_pIdentity->m_pTextLabel->setText(__tr2qs("Please choose a nickname.<br><br>" \
 		"Your nickname is the name that other IRC users will know you by. " \
 		"It can't contain spaces or punctuation. Some IRC networks will shorten your nickname if it is more than 32 characters " \
 		"long.<br><br>"
@@ -494,7 +494,7 @@ SetupWizard::SetupWizard()
 	addPage(m_pDesktopIntegration,__tr2qs("Desktop Integration"));
 
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
-	m_pCreateUrlHandlers = new QCheckBox(__tr2qs("Make KVIrc default IRC client"),m_pDesktopIntegration->m_pVBox);
+	m_pCreateUrlHandlers = new QCheckBox(__tr2qs("Make KVIrc the default IRC client"),m_pDesktopIntegration->m_pVBox);
 	m_pCreateUrlHandlers->setChecked(true);
 #endif
 #ifdef COMPILE_KDE_SUPPORT

--- a/src/modules/setup/SetupWizard.cpp
+++ b/src/modules/setup/SetupWizard.cpp
@@ -196,7 +196,7 @@ SetupWizard::SetupWizard()
 	g_pApp->getGlobalKvircDirectory(szLicensePath,KviApplication::License,"COPYING");
 	if(!KviFileUtils::loadFile(szLicensePath,szLicense))
 	{
-		szLicense = __tr("Ooops... Can't find the license file.\n" \
+		szLicense = __tr("Oops... Can't find the license file.\n" \
 			"It MUST be included in the distribution...\n" \
 			"Please report to <pragma at kvirc dot net>");
 	}

--- a/src/modules/spaste/libkvispaste.cpp
+++ b/src/modules/spaste/libkvispaste.cpp
@@ -221,7 +221,7 @@ static bool spaste_kvs_cmd_stop(KviKvsModuleCommandCall * c)
 		)
 		{
 			QString szWinId = c->window()->id();
-			c->warning(__tr2qs("The specified window (%Q) is not a channel/query/dcc"),&szWinId);
+			c->warning(__tr2qs("The specified window (%Q) is not a Channel/Query/DCC"),&szWinId);
 			return false;
 		} else {
 			while( (item = it.current()) != 0)
@@ -283,7 +283,7 @@ static bool spaste_kvs_cmd_list(KviKvsModuleCommandCall * c)
 	@title:
 		spaste.setdelay
 	@short:
-		Sets the delay time in miliseconds for the spaste module command delay
+		Sets the delay time in milliseconds for the spaste module command delay
 	@syntax:
 		spaste.setdelay <time_in_msecs:integer>
 	@description:
@@ -332,8 +332,8 @@ static bool spaste_module_can_unload(KviModule *)
 }
 
 KVIRC_MODULE(
-	"SPaste",                                                 // module name
-	"4.0.0",                                                // module version
+	"SPaste",                                     // module name
+	"4.0.0",                                      // module version
 	"(C) 2002 Juanjo Alvarez (juanjux@yahoo.es)", // author & (C)
 	"Delayed paste commands",
 	spaste_module_init,

--- a/src/modules/str/libkvistr.cpp
+++ b/src/modules/str/libkvistr.cpp
@@ -840,11 +840,11 @@ static bool str_kvs_fnc_stripright(KviKvsModuleFunctionCall * c)
 	@title:
 		$str.stripcolors
 	@short:
-		Returns a mirc color codes stripped string
+		Returns a mIRC color codes stripped string
 	@syntax:
 		<string> $str.stripcolors(<string:string>)
 	@description:
-		Removes all mirc color codes from a string, including also bold, underline, reverse,
+		Removes all mIRC color codes from a string, including also bold, underline, reverse,
 		icon, crypting and ctcp control codes.
 */
 static bool str_kvs_fnc_stripcolors(KviKvsModuleFunctionCall * c)
@@ -1418,7 +1418,7 @@ static bool str_kvs_fnc_digest(KviKvsModuleFunctionCall * c)
 	{
 		qAlgo = QCryptographicHash::Md5;
 	} else {
-		c->warning(__tr2qs("KVIrc is compiled without Crypto++ or OpenSSL support. $str.digest supports only MD4, MD5 and SHA1."));
+		c->warning(__tr2qs("KVIrc is compiled without Crypto++ or SSL support. $str.digest supports only MD4, MD5 and SHA1."));
 		return true;
 	}
 
@@ -2224,7 +2224,7 @@ static bool str_kvs_fnc_evpSign(KviKvsModuleFunctionCall * c)
 
 		if(!pKey)
 		{
-			c->warning(__tr2qs("Can not read private key while trying to use the default private key certificate %s"),KVI_OPTION_STRING(KviOption_stringSSLPrivateKeyPath).toUtf8().data());
+			c->warning(__tr2qs("Can't read private key while trying to use the default private key certificate %s"),KVI_OPTION_STRING(KviOption_stringSSLPrivateKeyPath).toUtf8().data());
 			c->returnValue()->setString("");
 			return true;
 		}
@@ -2237,7 +2237,7 @@ static bool str_kvs_fnc_evpSign(KviKvsModuleFunctionCall * c)
 
 		if(!pKey)
 		{
-			c->warning(__tr2qs("Can not read private key while trying to use the provided certificate (wrong password?)"));
+			c->warning(__tr2qs("Can't read private key while trying to use the provided certificate (wrong password?)"));
 			c->returnValue()->setString("");
 			return true;
 		}
@@ -2256,7 +2256,7 @@ static bool str_kvs_fnc_evpSign(KviKvsModuleFunctionCall * c)
 		c->returnValue()->setString(szSign.toBase64().data());
 		return true;
 	}
-	c->warning(__tr2qs("An error occured while signing the message."));
+	c->warning(__tr2qs("An error occurred while signing the message."));
 	c->returnValue()->setString("");
 	return true;
 
@@ -2278,7 +2278,7 @@ static bool str_kvs_fnc_evpSign(KviKvsModuleFunctionCall * c)
 	@syntax:
 		<bool> $str.evpVerify(<message:string>,<signature:string>[,<certificate:string>[,<password:string>]])
 	@description:
-		This function verifies the signature for a message against a publick key contained in a certificate.[br]
+		This function verifies the signature for a message against a public key contained in a certificate.[br]
 		The signature has to be base64-encoded, as the one returned by [fnc]$str.evpSign[/fnc].[br]
 		If the <certificate> parameter is omitted, the public key certificate specified in the
 		kvirc options will be used.[br]
@@ -2365,7 +2365,7 @@ static bool str_kvs_fnc_evpVerify(KviKvsModuleFunctionCall * c)
 
 		if(!pKey)
 		{
-			c->warning(__tr2qs("Can not read public key while trying to use the default public key certificate %s"),KVI_OPTION_STRING(KviOption_stringSSLCertificatePath).toUtf8().data());
+			c->warning(__tr2qs("Can't read public key while trying to use the default public key certificate %s"),KVI_OPTION_STRING(KviOption_stringSSLCertificatePath).toUtf8().data());
 			c->returnValue()->setString("");
 			return true;
 		}
@@ -2386,7 +2386,7 @@ static bool str_kvs_fnc_evpVerify(KviKvsModuleFunctionCall * c)
 
 		if(!pKey)
 		{
-			c->warning(__tr2qs("Can not read public key from the provided certificate."));
+			c->warning(__tr2qs("Can't read public key from the provided certificate."));
 			c->returnValue()->setBoolean(false);
 			return true;
 		}
@@ -2406,7 +2406,7 @@ static bool str_kvs_fnc_evpVerify(KviKvsModuleFunctionCall * c)
 			c->returnValue()->setBoolean(true);
 			return true;
 		default:
-			c->warning(__tr2qs("An error occured during signature verification."));
+			c->warning(__tr2qs("An error occurred during signature verification."));
 			c->returnValue()->setBoolean(false);
 			return true;
 	}

--- a/src/modules/theme/ThemeFunctions.cpp
+++ b/src/modules/theme/ThemeFunctions.cpp
@@ -273,7 +273,7 @@ namespace ThemeFunctions
 
 		hd.szCaption = __tr2qs_ctx("Install Theme Pack - KVIrc","theme");
 		hd.szUpperLabelText = beginCenter + __tr2qs_ctx("You're about to install the following theme package","theme") + endCenter;
-		hd.szLowerLabelText = beginCenter + __tr2qs_ctx("Do you want to proceed with the installation ?","theme") + endCenter;
+		hd.szLowerLabelText = beginCenter + __tr2qs_ctx("Do you want to proceed with the installation?","theme") + endCenter;
 		hd.szButton1Text = __tr2qs_ctx("Do Not Install","theme");
 		hd.szButton2Text = __tr2qs_ctx("Yes, Proceed","theme");
 		hd.iDefaultButton = 2;

--- a/src/modules/toolbareditor/CustomizeToolBarsDialog.cpp
+++ b/src/modules/toolbareditor/CustomizeToolBarsDialog.cpp
@@ -263,7 +263,7 @@ void CustomToolBarPropertiesDialog::okClicked()
 			if(QMessageBox::information(this,__tr2qs_ctx("Duplicate ToolBar Id","editor"),
 				__tr2qs_ctx("The specified ToolBar Id already exists.<br>" \
 					"Would you like KVIrc to assign it automatically (so it doesn't "
-					"collide with any other toolbar) or you prefer to do it manually ?","editor"),
+					"collide with any other toolbar) or you prefer to do it manually?","editor"),
 				__tr2qs_ctx("Manually","editor"),__tr2qs_ctx("Automatically","editor")) == 0)return;
 			m_szId = KviCustomToolBarManager::instance()->idForNewToolBar(m_szLabel);
 		}
@@ -379,7 +379,7 @@ void CustomizeToolBarsDialog::deleteToolBar()
 	if(!t)return;
 	if(QMessageBox::question(this,
 			__tr2qs_ctx("Confirm ToolBar Deletion","editor"),
-			__tr2qs_ctx("Do you really want to delete toolbar \"%1\" ?","editor").arg(t->windowTitle()),
+			__tr2qs_ctx("Do you really want to delete toolbar \"%1\"?","editor").arg(t->windowTitle()),
 			QMessageBox::Yes | QMessageBox::No,
 			QMessageBox::No) != QMessageBox::Yes)return;
 	KviCustomToolBarManager::instance()->destroyDescriptor(t->descriptor()->id());
@@ -403,7 +403,7 @@ void CustomizeToolBarsDialog::exportToolBar()
 
 	int ret = QMessageBox::question(this,
 			__tr2qs_ctx("ToolBar Export","editor"),
-			__tr2qs_ctx("Do you want the associated actions to be exported with the toolbar ?","editor"),
+			__tr2qs_ctx("Do you want the associated actions to be exported with the toolbar?","editor"),
 			__tr2qs_ctx("Yes","editor"),
 			__tr2qs_ctx("No","editor"),
 			__tr2qs_ctx("Cancel","editor"));

--- a/src/modules/trayicon/libkvitrayicon.cpp
+++ b/src/modules/trayicon/libkvitrayicon.cpp
@@ -167,7 +167,7 @@ static const char * idlemsgs[NIDLEMSGS]=
 	__tr("Nothing is happening..."),
 	__tr("Just idling..."),
 	__tr("Dum de dum de dum..."),
-	__tr("Hey man... do something!"),
+	__tr("Hey man... Do something!"),
 	__tr("Umpf!"),
 	__tr("Silence speaking"),
 	__tr("Are ya here?"),
@@ -175,9 +175,9 @@ static const char * idlemsgs[NIDLEMSGS]=
 	__tr("Everything is all right"),
 	__tr("idle()"),
 	__tr("It's so cold here..."),
-	__tr("Do not disturb... watching TV"),
+	__tr("Do not disturb... Watching TV"),
 	__tr("Just vegetating"),
-	__tr("Hey... are ya sure that your network is up?"),
+	__tr("Hey... Are ya sure that your network is up?"),
 	__tr("Seems like the world has stopped spinning"),
 	__tr("This silence is freaking me out!"),
 	__tr("Mieeeeeowww!"),
@@ -583,16 +583,16 @@ void KviTrayIconWidget::updateIcon()
 	@description:
 		Shows the tray icon (sometimes called dock widget).[br]
 		The tray icon is a small widget that docks in the window manager panel.[br]
-		It shows a small kvirc icon and eventually displays four squares
+		It shows a small KVIrc icon and eventually displays four squares
 		that cover this icon: the bottom left square appears when there is some new
 		text in any console window, the square becomes red if the text is highlighted.[br]
 		The bottom right square appears when there is some new text in any channel window,
 		and it becomes red when the text is highlighted.[br] The upper right square refers to
-		query windows and the upper left one to any other kind of window (dcc, links...).[br]
+		query windows and the upper left one to any other kind of window (DCC, links...).[br]
 		If you move the mouse over the tray icon a tooltip will show you the last lines
 		of the "new" text in all these windows.[br]
 		This is useful when you keep the main KVIrc window minimized and you're working on something else:
-		if the tray icon shows nothing but the kvirc icon, nothing is happening in the main KVIrc window.
+		if the tray icon shows nothing but the KVIrc icon, nothing is happening in the main KVIrc window.
 		If the tray icon shows one or more white (or red) squares, you can move the mouse over
 		and check what's happened exactly and eventually bring up the main KVIrc window by clicking on the icon.[br]
 	@seealso:

--- a/src/modules/url/libkviurl.cpp
+++ b/src/modules/url/libkviurl.cpp
@@ -127,7 +127,7 @@ void UrlDialogTreeWidget::paintEvent(QPaintEvent * event)
 
 	delete p;
 
-	//call paint on all childrens
+	//call paint on all children
 	QTreeWidget::paintEvent(event);
 }
 
@@ -140,7 +140,7 @@ UrlDialog::UrlDialog(KviPointerList<KviUrl> *)
 
 	m_pUrlList = new UrlDialogTreeWidget(this);
 
-	m_pMenuBar = new KviTalMenuBar(this,"url menu");
+	m_pMenuBar = new KviTalMenuBar(this,"URL menu");
 	//m_pUrlList = new KviListView(this,"list");
 	KviConfigurationFile cfg(szConfigPath,KviConfigurationFile::Read);
 /*
@@ -673,21 +673,21 @@ void loadBanList()
 	@title:
 		url.list
 	@short:
-		Opens url list
+		Opens URL list
 	@syntax:
 		url.list
 	@description:
-		This command opens a window containing the urls' list.
+		This command opens a window containing the URLs' list.
 		In the list there is other information:[br]
-		[U]Window[/U] : window where the url has been shown last[br]
-		[U]Count[/U] : number of urls shown[br]
-		[U]Timestamp[/U] : date/time when the url has been shown first[br]
-		Clicking right on the url column of the list a menu will popup, through it
-		you can remove the selected item, find the url in the window it appeared last, and
-		say it to: [I]@Console, Channels, Querys, DCC Chats[/I] and [I]User windows[/I].[br]
+		[U]Window[/U] : window where the URL has been shown last[br]
+		[U]Count[/U] : number of URLs shown[br]
+		[U]Timestamp[/U] : date/time when the URL has been shown first[br]
+		Clicking right on the URL column of the list a menu will popup, through it
+		you can remove the selected item, find the URL in the window it appeared last, and
+		say it to: [I]@Console, Channels, Queries, DCC Chats[/I] and [I]User windows[/I].[br]
 		The list is saved to file when you click on the menu item or when you unload the plugin
 		on condition that you have checked the relative checkbox in configuration dialog.[br]
-		You can also open the url in your web browser double clicking on it in the url list window.[br][br]
+		You can also open the URL in your web browser double clicking on it in the URL list window.[br][br]
 
   */
 
@@ -734,12 +734,12 @@ UrlDlgList *findFrame()
 	@description:
 		This command opens a configuration window where it is possible
 		to setup plugin's parameters. You can also open this window by
-		using popup menu in the url list window<BR><BR>
+		using popup menu in the URL list window<BR><BR>
 		<H3>Configure dialog options:</H3>
 		There is also a ban list widget, which allows to have a list of words that plugin mustn't catch.<BR><BR>
 		<I>E.g.<BR>
 		<blockquote>if the word "ftp" is inserted in the ban list and if in a window there is an output like "ftp.kvirc.net",
-		the url will not be catched.</blockquote></I>
+		the URL will not be caught.</blockquote></I>
 		<HR>
 */
 
@@ -749,7 +749,7 @@ static bool url_kvs_cmd_config(KviKvsModuleCommandCall *)
 	return true;
 }
 
-int check_url(KviWindow *w,const QString &szUrl) // return 0 if no occurence of the url were found
+int check_url(KviWindow *w,const QString &szUrl) // return 0 if no occurrence of the URL were found
 {
 	int tmp = 0;
 
@@ -833,7 +833,7 @@ bool urllist_module_event_onUrl(KviKvsModuleEventCall * c)
 	@syntax:
 		url.load
 	@description:
-		Loads the URL list module which keeps track of all urls shown in kvirc windows.
+		Loads the URL list module which keeps track of all URLs shown in KVIrc windows.
 */
 
 
@@ -901,23 +901,23 @@ void url_module_config()
 	@type:
 		module
 	@short:
-		The URL list module: keeps track of all urls shown in kvirc windows
+		The URL list module: keeps track of all URLs shown in KVIrc windows
 	@title:
 		The URL list module
 	@body:
-		This plugin keeps track of all urls shown in kvirc windows.
+		This plugin keeps track of all URLs shown in KVIrc windows.
 		<H3>Exported commands:</H3>
-		<B>/url.list</B> : this command opens a window containing the urls' list.
+		<B>/URL.list</B> : this command opens a window containing the URLs' list.
 		In the list there is other information:<BR>
-		<U>Window</U> : window where the url has been shown last<BR>
-		<U>Count</U> : number of urls shown<BR>
-		<U>Timestamp</U> : date/time when the url has been shown first<BR>
-		Clicking right on the url column of the list a menu will popup, through it
-		you can remove the selected item, find the url in the window it appeared last, and
-		say it to: <I>@Console, Channels, Querys, DCC Chats</I> and <I>User windows</I>.<BR>
+		<U>Window</U> : window where the URL has been shown last<BR>
+		<U>Count</U> : number of URLs shown<BR>
+		<U>Timestamp</U> : date/time when the URL has been shown first<BR>
+		Clicking right on the URL column of the list a menu will popup, through it
+		you can remove the selected item, find the URL in the window it appeared last, and
+		say it to: <I>@Console, Channels, Queries, DCC Chats</I> and <I>User windows</I>.<BR>
 		The list is saved to file when you click on the menu item or when you unload the plugin
 		on condition that you have checked the relative checkbox in configuration dialog.<BR>
-		You can also open the url in your web browser double clicking on it in the url list window.<BR><BR>
+		You can also open the URL in your web browser double clicking on it in the URL list window.<BR><BR>
 
 		Mail me if you have any suggestion or you want to notice a bug.<BR>
 		<B>Andrea 'YaP' Parrella</B> &lt;anandrea@iname.com&gt;<BR><BR>
@@ -931,7 +931,7 @@ KVIRC_MODULE(
 	"URL",
 	"4.0.0",
 	"Copyright (C) 2002 Andrea Parrella <yap@yapsoft.it>",
-	"url list module for KVIrc",
+	"URL list module for KVIrc",
 	url_module_init,
 	url_module_can_unload,
 	0,

--- a/src/modules/url/libkviurl.h
+++ b/src/modules/url/libkviurl.h
@@ -76,7 +76,7 @@ public:
 private:
 	KviTalMenuBar *m_pMenuBar;
 	QMenu *m_pListPopup;	// dynamic popup menu
-	QString m_szUrl;		// used to pass urls to sayToWin slot
+	QString m_szUrl;		// used to pass URLs to sayToWin slot
 protected:
 	QPixmap *myIconPtr();
 	void resizeEvent(QResizeEvent *);

--- a/src/modules/window/libkviwindow.cpp
+++ b/src/modules/window/libkviwindow.cpp
@@ -1004,7 +1004,7 @@ static bool window_kvs_fnc_open(KviKvsModuleFunctionCall * c)
 	QPixmap *pPix=g_pIconManager->getImage(szIcon);
 	if(!pPix){
 
-	    c->warning(__tr2qs("The specified Icon does not exist: switching to 'none'"));
+	    c->warning(__tr2qs("The specified icon does not exist: switching to 'none'"));
 	    szIcon.prepend("$icon(");
 	    szIcon.append(")");
 	}
@@ -1248,7 +1248,7 @@ static bool window_kvs_cmd_setBackground(KviKvsModuleCommandCall * c)
 			return true;
 			}
 		if(!ob->inherits("KviScriptPixmapObject")){
-			c->warning(__tr("Pixmap objects required !"));
+			c->warning(__tr("Pixmap objects required!"));
 			return true;
 		}
 		QVariant pix1= ob->property("pixmap");


### PR DESCRIPTION
Here you will find as bests as possible broken down commits grouped into (as best possible) related fixes

I have as much as possible tried to make this as non intrusive and as plain as I could but if the translations suffer here they suffer the minimally possible.

By no means is this finished but KVIrc is a huge program and I rather do this in chunks that in one go as that is impossible in any foreseeable future.
