### PR TITLE
Split from #1631: cpp more strings and doc typos and fixes - need helpfull feedback

### DIFF
--- a/src/kvilib/config/kvi_shortcuts.h
+++ b/src/kvilib/config/kvi_shortcuts.h
@@ -221,10 +221,10 @@
 	@short:
 		The list of the common keyboard shortcuts
 	@body:
-		This list contains the key sequences associated to some common actions (like selecting text, etc). Since KVIrc 4.2 the shortcuts are dinamic:
+		This list contains the key sequences associated to some common actions (e.g. selecting text). Since KVIrc 4.2 the shortcuts are dynamic:
 		[ul]
 		[li]more shortcuts can trigger the same actions: Cut is both Ctrl+X and Shift+Del[/li]
-		[li]shortcuts can be adapted to the os: Help is F1 under Windows and Linux, Ctrl+? on Mac OSX[/li]
+		[li]shortcuts can be adapted to the OS: Help is F1 under Windows and Linux, Ctrl+? on Mac OSX[/li]
 		[/ul]
 		A full list of available combinations is available at the [anchorlink:http://doc.qt.nokia.com/latest/qkeysequence.html#standard-shortcuts] Qt documentation[/anchorlink]
 		[br]
@@ -300,7 +300,7 @@
 		[b]Ctrl+Backspace:[/b] Delete last word[br]
 		[b]Ctrl+<digit>:[/b] Script accelerators (see OnAccelKeyPressed)[br]
 		[b]F2-F12, Shift+(F1-F12):[/b] Script accelerators (see OnAccelKeyPressed)[br]
-		[b]Ctrl+B:[/b] nsert the 'bold' mIRC text control character[br]
+		[b]Ctrl+B:[/b] Insert the 'bold' mIRC text control character[br]
 		[b]Ctrl+K:[/b] Insert the 'color' mIRC text control character[br]
 		[b]Ctrl+R:[/b] Insert the 'reverse' mIRC text control character[br]
 		[b]Ctrl+U:[/b] Insert the 'underline' mIRC text control character[br]
@@ -317,7 +317,7 @@
 		[b]RightArrow:[/b] Move the cursor to the right[br]
 		[b]Shift+LeftArrow:[/b] Move the selection to the left[br]
 		[b]Shift+RightArrow:[/b] Move the selection to the right[br]
-		[b]Alt+Enter:[/b] Show/hide the multiline editor[br]
+		[b]Alt+Enter:[/b] Show/hide the multi-line editor[br]
 		[b]Ctrl+Enter:[/b] Send message as plain text, ignoring / commands[br]
 		[b]Shift+Enter:[/b] Send message as a kvs command[br]
 		[b]Alt+<numeric_sequence>:[/b] Insert the character by ASCII/Unicode code[br]

--- a/src/kvilib/core/KviError.cpp
+++ b/src/kvilib/core/KviError.cpp
@@ -70,20 +70,20 @@ const char * g_errorTable[KviError::ErrorCount]=
 	__tr_no_lookup("Unexpected character"),                                     // 020: unexpectedCharacter
 	__tr_no_lookup("Unknown operator"),                                         // 021: unknownOperator
 	__tr_no_lookup("No host to resolve"),                                       // 022
-	__tr_no_lookup("(DNS Internal) Unsupported address family"),                // 023
+	__tr_no_lookup("(DNS internal) Unsupported address family"),                // 023
 	__tr_no_lookup("Valid name but the host has no IP address"),                // 024
-	__tr_no_lookup("Unrecoverable nameserver error (crashed ?)"),               // 025
-	__tr_no_lookup("Dns temporaneous fault (try again)"),                       // 026
-	__tr_no_lookup("(DNS Internal) Bad flags"),                                 // 027
-	__tr_no_lookup("(DNS Internal) Out of memory"),                             // 028
-	__tr_no_lookup("(DNS Internal) Service not supported"),                     // 029
+	__tr_no_lookup("Unrecoverable nameserver error (crashed?)"),                // 025
+	__tr_no_lookup("DNS temporary fault (try again)"),                          // 026
+	__tr_no_lookup("(DNS internal) Bad flags"),                                 // 027
+	__tr_no_lookup("(DNS internal) Out of memory"),                             // 028
+	__tr_no_lookup("(DNS internal) Service not supported"),                     // 029
 	__tr_no_lookup("Unknown node (host not found)"),                            // 030
-	__tr_no_lookup("(DNS Internal) Unsupported socket type"),                   // 031
-	__tr_no_lookup("Dns query failed"),                                         // 032
-	__tr_no_lookup("This KVIrc executable has no IPV6 support"),                // 033
+	__tr_no_lookup("(DNS internal) Unsupported socket type"),                   // 031
+	__tr_no_lookup("DNS query failed"),                                         // 032
+	__tr_no_lookup("This KVIrc executable has no IPv6 support"),                // 033
 	__tr_no_lookup("Host not found"),                                           // 034
-	__tr_no_lookup("(DNS Internal) IPC failure (slave data corrupted)"),        // 035
-	__tr_no_lookup("Another connection in progress"),                           // 036
+	__tr_no_lookup("(DNS internal) IPC failure (slave data corrupted)"),        // 035
+	__tr_no_lookup("Another connection is in progress"),                        // 036
 	__tr_no_lookup("Invalid IP address"),                                       // 037
 	__tr_no_lookup("Socket creation failed"),                                   // 038
 	__tr_no_lookup("Failed to put the socket in non blocking mode"),            // 039
@@ -96,8 +96,8 @@ const char * g_errorTable[KviError::ErrorCount]=
 	__tr_no_lookup("Broken pipe"),                                              // 046
 	__tr_no_lookup("Invalid proxy address"),                                    // 047
 	__tr_no_lookup("Remote end has closed the connection"),                     // 048
-	__tr_no_lookup("Invalid irc context id"),                                   // 049
-	__tr_no_lookup("Error in loading module"),                                  // 050
+	__tr_no_lookup("Invalid IRC context id"),                                   // 049
+	__tr_no_lookup("Error loading module"),                                     // 050
 	__tr_no_lookup("No such module command"),                                   // 051
 	__tr_no_lookup("No such module function"),                                  // 052
 	__tr_no_lookup("Left operand is not a dictionary reference"),               // 053
@@ -117,10 +117,10 @@ const char * g_errorTable[KviError::ErrorCount]=
 	__tr_no_lookup("The SOCKSv4 protocol lacks IPv6 support"),                  // 067
 	__tr_no_lookup("Unrecognized proxy reply"),                                 // 068
 	__tr_no_lookup("Proxy response: auth failed: access denied"),
-	__tr_no_lookup("Proxy response: No acceptable auth method: request rejected"),
+	__tr_no_lookup("Proxy response: no acceptable auth method: request rejected"),
 	__tr_no_lookup("Proxy response: request failed"),
-	__tr_no_lookup("Proxy response: ident failed"),
-	__tr_no_lookup("Proxy response: ident not matching"),
+	__tr_no_lookup("Proxy response: Ident failed"),
+	__tr_no_lookup("Proxy response: Ident not matching"),
 	__tr_no_lookup("Proxy response: general SOCKS failure"),
 	__tr_no_lookup("Proxy response: connection not allowed"),
 	__tr_no_lookup("Proxy response: network unreachable"),
@@ -149,7 +149,7 @@ const char * g_errorTable[KviError::ErrorCount]=
 	__tr_no_lookup("Unexpected characters in array index"),
 	__tr_no_lookup("Unexpected end in expression"),
 	__tr_no_lookup("Unexpected end in array index"),
-	__tr_no_lookup("Connection thru HTTP proxy failed"),
+	__tr_no_lookup("Connection through HTTP proxy failed"),
 	__tr_no_lookup("Case, match, regexp, default or break keyword expected"),
 	__tr_no_lookup("Access denied"),
 	__tr_no_lookup("Address already in use"),

--- a/src/kvilib/core/KviMemory.cpp
+++ b/src/kvilib/core/KviMemory.cpp
@@ -113,7 +113,7 @@ namespace KviMemory
 			}
 			e = e->next;
 		}
-		fprintf(stderr,"Attempt to realloc an inexistant pointer (%p) (called from %p (%p))\n",ptr,__builtin_return_address(1),__builtin_return_address(2));
+		fprintf(stderr,"Attempt to realloc a non-existent pointer (%p) (called from %p (%p))\n",ptr,__builtin_return_address(1),__builtin_return_address(2));
 		return realloc(ptr,size);
 	}
 
@@ -142,7 +142,7 @@ namespace KviMemory
 			}
 			e = e->next;
 		}
-		fprintf(stderr,"Attempt to free an inexistant pointer (%p) (called from %p (%p))\n",ptr,__builtin_return_address(1),__builtin_return_address(2));
+		fprintf(stderr,"Attempt to free a non-existent pointer (%p) (called from %p (%p))\n",ptr,__builtin_return_address(1),__builtin_return_address(2));
 	}
 
 	void kvi_memory_profile() __attribute__((destructor));
@@ -192,7 +192,7 @@ namespace KviMemory
 	void outOfMemory()
 	{
 		//What a cool message :)
-		fprintf(stderr,"Virtual memory exhausted in malloc call....bye!\n");
+		fprintf(stderr,"Virtual memory exhausted in malloc call... bye!\n");
 		exit(-1);
 	}
 

--- a/src/kvilib/ext/KviCryptEngine.cpp
+++ b/src/kvilib/ext/KviCryptEngine.cpp
@@ -36,7 +36,7 @@
 	@type:
 		generic
 	@keyterms:
-		cryptography, privacy, private key, text transformation
+		cryptography, encryption, privacy, private key, text transformation
 	@title:
 		Cryptography and text transformation
 	@short:
@@ -45,62 +45,62 @@
 		[big]Introduction[/big][br]
 		Well, there is a concrete background noise about security around the net.
 		And I've thought that adding a little cryptography support to KVIrc wasn't
-		a bad idea. So I've first comed out with the "crypt engines", that
-		allowed to have secure conversations on channels, queries and dcc chats;
+		a bad idea. So I first came up with the "crypt engines", that
+		allowed secure conversations in channels, queries and DCC chats;
 		then found out that the realized structure was perfect to be "generalized"
 		into "text transformation" support.[br]
 		[big]The concept[/big][br]
 		In few words, the "text transformation" engine is a layer between the user and the
 		IRC connection. You type some text in the input line of a query window (for example),
 		the engine transforms the text in some way and then sends it to the remote target.
-		The trick works also in the reverse way: some data come from the remote target,
-		the engine retransforms the text in some other way and displays it to the local user.[br]
+		The trick works also in the reverse way: some data comes from the remote target,
+		the engine re-transforms the text in some other way and displays it to the local user.[br]
 		The "incoming" transformation is usually the inverse of the "outgoing" one, but it
 		is not mandatory. It will become clear in few sentences that some engines will do no "incoming"
-		transformation at all. The original use of the transformation engines was to crypt the
+		transformation at all. The original use of the transformation engines was to encrypt the
 		outgoing data and to decrypt the incoming data; anyway, the engines can perform
-		other funky tasks. One of them is remapping the local charset to a "standardized" one
+		other funky tasks. One of them is remapping the local charset to a standardized one
 		when sending text to a channel (or some other target) and doing the inverse map on
 		the way back. A totally "fantastic" usage of this concept could be an "on-the-fly translator";
 		it could translate for example Italian to English while sending to a channel
-		and English to Italian on the way back...the implementation of a such engine is left
+		and English to Italian on the way back... the implementation of a such engine is left
 		to the reader as exercise :) Another (maybe less interesting) usage is to
 		colorize the outgoing text, or transform it
 		in a way that it is still readable but has a different look. This engine
 		would not require a back transformation (so no "decrypt stage"). A "symmetric"
 		idea could be an engine that strips the color codes from the incoming text: this
-		engine would not require a "crypting" stage.[br]
+		engine would not require an encrypting stage.[br]
 
-		[big]The name of this stuf[/big][br]
-		Initially all this stuff was named "cryptography support".
-		Then the "cryptography" comed out to be not "enough" to describe
+		[big]The name of this stuff[/big][br]
+		Initially all this was named "cryptography support".
+		Then "cryptography" was no longer enough to describe
 		the framework, so "text transformation" is a more generic term.
 		Anyway, both terms were used in the documentation and the source.
 		Just as example, the "text transformation engine" is called
 		KviCryptEngine in the sources. So actually the terms "crypt"
-		and "text transformations" refer to the "same thing".
+		and text transformation refer to the same thing.
 		You will often find the term "encrypt" standing for "outgoing text
 		transformation" and "decrypt" standing for "incoming text transformation".[br]
 
-		[big]Yes, but why cryptography (on IRC) ?[/big][br]
+		[big]Yes, but why cryptography (on IRC)?[/big][br]
 		Because it MAY be useful. More than once people have asked me to add some
-		crypting support to the dcc chats. Yes, I know that there are other
+		encryption support to the DCC chats. Yes, I know that there are other
 		"secure communication" tools, but actually I can't find one that is able to
 		implement a "secure real time conversation". And what about a MULTIPLE real
-		time secure conversation ? This can be done on an IRC channel now.[br]
+		time secure conversation? This can be done on an IRC channel now.[br]
 
 		[big]The working things[/big][br]
-		KVIrc can use a text transformation engine on irc channels, in the queries
-		and the dcc chats. At the time I am writing, only the [module:rijndael]Rijndael[/module] crypt engine
+		KVIrc can use a text transformation engine on IRC channels, in the queries
+		and the DCC chats. At the time I am writing, only the [module:rijndael]Rijndael[/module] crypt engine
 		is available: this is a private key encryption algorithm that assures
 		a "pretty good" security level. More engines will be surely available
 		at the time of the 3.0.0 release of KVIrc. The engines
 		can be activated by the dedicated dialog that can be accessed from the "button bar"
 		of the window. Once an engine has been enabled all the text that you type
 		in the input line (that is not a command obviously) is encrypted
-		and sent to the remote endpoint. If you want to sent a non crypted message
-		while an engine is working you can use the CTRL+P escape: by placing
-		that character as the FIRST CHARACTER of the line you will avoid crypting.
+		and sent to the remote endpoint. If you want to send a non-encrypted message
+		while an engine is working, you can use the CTRL+P escape: by placing
+		that character as the FIRST CHARACTER of the line you will avoid encrypting.
 		Every engine has different capabilities: some can both encrypt
 		and decrypt, other perform only half of the operations. Some engines
 		need a key (the crypt engines obviously), or two keys (you can specify
@@ -109,13 +109,13 @@
 		Obviously (with the current implementations) all the conversation endpoints
 		must agree on the engine (or better algorithm) used and on the key(s).
 		The key is user specified, so you have to find a secure way to negotiate
-		it with your communication engpoints. If you can meet the persons in the "real life",
-		this is the best way to exchange the keys, otherwise you can use mail & pgp.
-		Yes, this is a "miss" of the crypt protocol: it is missing a public key handshake.[br]
+		it with your communication endpoints. If you can meet these people in real life,
+		this is the best way to exchange the keys, otherwise you can use mail & PGP.
+		Yes, this is a shortcoming of the crypt protocol: it is missing a public key handshake.[br]
 
 		[big]The first test[/big][br]
-		A cool way to test a crypting engine is to use a "self query": connect to
-		any irc server, and execute [cmd]query[/cmd] <yournickname>; a query window
+		A cool way to test an encryption engine is to use a "self query": connect to
+		any IRC server, and execute [cmd]query[/cmd] <yournickname>; a query window
 		with you both as source and target will popup; activate a crypt engine
 		and enable both encryption and decryption; specify the same key for
 		bot directions and then type some text in the input line: you will see
@@ -128,25 +128,25 @@
 		[big]The protocol[/big][br]
 		Well, there is no protocol actually, only the existing implementations, that
 		can be accessed by anyone that want to reproduce them. There are only some
-		points relating to the crypting engines that need to be cleared:[br]
-		The crypted text must be suitable to be sent through an IRC connection;
-		this means that some characters can not appear in the crypted text (e.g. CR,LF,NULL....).
-		KVIrc solves it in a simple way: the crypted binary data is encoded,
-		either as hexadecimal numeric string or in base64.[br]
-		An escape character has been defined to identify messages that are "crypted" from the
-		ones that are not: this character has ascii code 30 (decimal).[br]
+		points relating to the encryption engines that need to be cleared:[br]
+		The encrypted text must be suitable to be sent through an IRC connection;
+		this means that some characters can not appear in the encrypted text (e.g. CR,LF,NULL....).
+		KVIrc solves it in a simple way: the encrypted binary data is encoded,
+		either as a hexadecimal numeric string or in base64.[br]
+		An escape character has been defined to identify messages that are "encrypted" from the
+		ones that are not: this character has ASCII code 30 (decimal).[br]
 		The encoding is used in private messages only and has the following format:[br]
 		PRIVMSG <target> :<escape_char_ascii_30><encrypted message>[br]
 		ASCII 30 does not correspond to any widely used escape sequence and allows
-		mixing encrypted and plain text messages in a conversation...Well, this is not
-		so pretty but you can exchange crypted messages with one or two friends while
-		talking on a normal IRC channel: nobody else than your friends will be able
-		to understand the message; others will see senseless sequences of characters.
+		mixing encrypted and plain text messages in a conversation, well, this is not
+		so pretty but you can exchange encrypted messages with one or two friends while
+		talking on a normal IRC channel, nobody else other than your friends will be able
+		to understand the message, others will see senseless sequences of characters.
 		You will be still able to read the unencrypted messages of the other people
 		on the channel.[br] The escape character is not needed if the engine
-		performs non-crypting tasks: a charset mapper will produce text that
-		is meant to be readed by anyone on the channel, a text colorizer will
-		act in a similar way too. So the escape character is used for the "crypting"
+		performs non-encrypting tasks: a charset mapper will produce text that
+		is meant to be read by anyone on the channel, a text colorizer will
+		act in a similar way too. So the escape character is used for the encryption
 		engines only.
 
 		[big]An idea for the future implementations[/big][br]
@@ -157,7 +157,7 @@
 	KviCryptEngine::KviCryptEngine()
 	{
 #ifdef COMPILE_CRYPT_SUPPORT
-		setLastError(__tr2qs("Invalid crypt engine"));
+		setLastError(__tr2qs("Invalid encryption engine"));
 		m_iMaxEncryptLen = -1; // unlimited
 		m_deallocFunc = 0;
 #endif //COMPILE_CRYPT_SUPPORT

--- a/src/kvilib/ext/KviRegisteredUserDataBase.cpp
+++ b/src/kvilib/ext/KviRegisteredUserDataBase.cpp
@@ -43,7 +43,7 @@
 		user properties, notify property, avatar property
 	@body:
 		[big]Introduction[/big][br]
-		The "registered user database" is basically a set of users with associated
+		The registered user database is basically a set of users with associated
 		[doc:irc_masks]irc-masks[/doc] and properties.[br]
 		It is used to recognize users on IRC and associate properties to them.[br]
 		This works more or less like the IRC ban list, K-Line list, or invite list.[br]
@@ -53,7 +53,7 @@
 		or any other string (even with spaces). The name is an "internal identifier" for the user entry:
 		each name maps to a single entry and each entry has a single name.[br]
 		Each entry has a set of registration [doc:irc_masks]irc-masks[/doc]: these masks
-		are used to recognize the user on irc.[br]
+		are used to recognize the user on IRC.[br]
 		[br]
 		[big]Registration masks[/big][br]
 		The masks have the common IRC mask format: [b]<nick>!<user>@<host>[/b][br]
@@ -71,7 +71,7 @@
 		For this reason putting wildcards in nicknames could become a problem
 		if not used carefully (but may also be used to achieve interesting tricks).[br]
 		If you don't use wildcards in nicknames you are sure that
-		in a single irc connection, a mask will always refer to a single user.[br]
+		in a single IRC connection, a mask will always refer to a single user.[br]
 		You will commonly use the following format:[br]
 		<nick>!*<username>@*.<host>.<top>[br]
 		or[br]
@@ -79,7 +79,7 @@
 		In this way you can be 95% sure that the mask will really match the correct user.[br]
 		[br]
 		[big]Example of registration and lookups[/big]
-		Assume that you want to registere a friend of yours: Derek Riggs.[br]
+		Assume that you want to register a friend of yours: Derek Riggs.[br]
 		Derek often uses "Eddie" as his nickname
 		"stranger" as username and has a dial-up connection that makes his IP address appear as
 		<variable-number>.somewhere.in.time.org.[br]
@@ -94,16 +94,16 @@
 		On the other hand, if you dislike the users with the nickname Eddie that come from .org
 		and you're implementing an auto-kick system, the correct mask to register is "Eddie!*@*.org".[br]
 		[br]
-		KVirc ties to be smart, and always find the most correct match for an user:
+		KVIrc tries to be smart, and always find the most correct match for an user:
 		If you have two masks registered: Pragma!*xor@*.myisp.it and *!*@*.myisp.it,
-		kvirc will match Pragma!~xor@233-dyn.myisp.it with the first one even if the second
-		one matches too; the firs one is a best match.[br]
+		KVIrc will match Pragma!~xor@233-dyn.myisp.it with the first one even if the second
+		one matches too; the first one is a best match.[br]
 		[br]
 		[big]Properties[/big][br]
 		A registered user has an (eventually empty) set of properties
 		defined by name/value pairs. (In versions prior to 3.0.0 flags were used instead,
 		but revealed to be insufficient).[br]
-		KVirc recognizes some of these proprietes and associates semantic actions to it; other properties
+		KVIrc recognizes some of these properties and associates semantic actions to it; other properties
 		are left for scripting extension. Property names are case insensitive.[br]
 		One of the recognized properties is the "[doc:notify_list]notify[/doc]" property.
 		When an user is found to have this property set to a special value
@@ -238,7 +238,7 @@ KviRegisteredUser * KviRegisteredUserDataBase::addMask(KviRegisteredUser * u,Kvi
 			l->setAutoDelete(true);
 			if(!u->addMask(mask))
 			{
-				qDebug(" Ops...got an incoherent regusers action...recovered ?");
+				qDebug(" Oops! Received an incoherent regusers action, recovered?");
 				delete l;
 				l = 0;
 			} else {
@@ -251,7 +251,7 @@ KviRegisteredUser * KviRegisteredUserDataBase::addMask(KviRegisteredUser * u,Kvi
 	// Ok...add it
 	if(!u->addMask(mask))
 	{
-		qDebug("ops...got an incoherent regusers action...recovered ?");
+		qDebug("Oops! Received an incoherent regusers action, recovered?");
 		return 0; // ops...already there ?
 	}
 	append_mask_to_list(l,u,mask);
@@ -311,7 +311,7 @@ bool KviRegisteredUserDataBase::removeUser(const QString & name)
 	while(KviIrcMask * mask = u->maskList()->first())
 	{
 		if(!removeMaskByPointer(mask))
-			qDebug("Ops... removeMaskByPointer(%s) failed ?",name.toUtf8().data());
+			qDebug("Oops! removeMaskByPointer(%s) has failed",name.toUtf8().data());
 	}
 	emit(userRemoved(name));
 	m_pUserDict->remove(name);

--- a/src/kvilib/ext/KviSharedFilesManager.cpp
+++ b/src/kvilib/ext/KviSharedFilesManager.cpp
@@ -66,14 +66,14 @@
 		use an additional "size" parameter in the DCC GET request.[br]
 		[big]Security issues[/big]
 		This is a nice but unsecure method of sharing files.[br]
-		The user mask is a good protection but you have to use it properly!.[br]
+		The user mask is a good protection but you have to use it properly![br]
 		Setting the user mask to Nick!*@* can be easily exploited (just by making an user disconnect
 		in one of the well known ways and then by using his nickname).[br]
 		On the other side, the remote end must know exactly the visible name of the offer to request
-		and noone but you will tell him that name.[br]
+		and no one but you will tell him that name.[br]
 		In sum:[br]
 		Don't share any really important files: this *might* be like putting it on your webpage :D[br]
-		Please don't send complains if someone stoles your /etc/passwd : it is because you have permitted that.[br]
+		Please don't send complaints if someone steals your /etc/passwd : it is because you have permitted that.[br]
 */
 
 

--- a/src/kvilib/irc/KviAvatar.cpp
+++ b/src/kvilib/irc/KviAvatar.cpp
@@ -51,17 +51,17 @@
 		The user that wants to offer a digital representation of himself
 		will be called "source user". The ones that will receive the notification
 		will be called "target users".
-		Every irc user can be either a source user or target user.
+		Every IRC user can be either a source user or target user.
 		[big]The idea[/big]
-		Every irc user has a client-side property called AVATAR. Let's say that there
+		Every IRC user has a client-side property called AVATAR. Let's say that there
 		are two users: A and B.[br]
 		When user A wants to see the B's avatar he simply sends a CTCP AVATAR request
-		to B (the request is sent through a PRIVMSG irc command).[br]
-		User B replies with a CTCP AVATAR notification (sent through a NOTICE irc command)
-		with the name or url of his avatar.[br]
+		to B (the request is sent through a PRIVMSG IRC command).[br]
+		User B replies with a CTCP AVATAR notification (sent through a NOTICE IRC command)
+		with the name or URL of his avatar.[br]
 		The actual syntax for the notification is:[br]
 		[b]AVATAR <avatar_file> [<filesize>][/b]
-		The <avatar_file> may be either the name of a B's local image file or an url
+		The <avatar_file> may be either the name of a B's local image file or a URL
 		pointing to an image on some web server.[br]
 		The optional <filesize> parameter is sent only if <avatar_file> is
 		stored on the B's machine and there will be more info on that later.[br]
@@ -70,15 +70,15 @@
 		If the file can be found
 		and loaded then it is simply displayed in some way near the B's nickname
 		otherwise A must download the avatar from some place.
-		If the <avatar_file> contains a leading url prefix (http://) then
-		A fetches the image from the specified url and after that displays
+		If the <avatar_file> contains a leading URL prefix (http://) then
+		A fetches the image from the specified URL and after that displays
 		it near the B's nickname. If the <avatar_file> does not contain the
-		leading url prefix then it is assumed that B offers this file for
+		leading URL prefix then it is assumed that B offers this file for
 		downloading via DCC from his machine. In this case A may also avoid
 		requesting the file if the <filesize> is too large and the transfer
 		would occupy too much bandwidth (for example).
 		The DCC download is initiated by issuing a DCC GET <avatar_file> request to B.
-		B may then reply with a standard DCC SEND or a DCC RSEND (kvirc's extension).[br]
+		B may then reply with a standard DCC SEND or a DCC RSEND (KVIrc's extension).[br]
 		The implementation of the DCC GET protocol is defined by other documents here around :).[br]
 		[br]
 		The CTCP AVATAR messages can be sent to a single user, a set of users or a channel:
@@ -90,7 +90,7 @@
 		since it allows good compression rates without compromising the image quality.
 		Other formats may be accepted as well (Theoretically this protocol could be
 		extended to allow movies or 3D images).
-		The "preferred" image size may grow with time, as the network transmission speed grows.
+		The preferred image size may grow with time, as the network transmission speed grows.
 */
 
 KviAvatar::KviAvatar(

--- a/src/kvilib/irc/KviIrcMask.cpp
+++ b/src/kvilib/irc/KviIrcMask.cpp
@@ -1,6 +1,6 @@
 //=============================================================================
 //
-//   File : kvi_ircuser.cpp
+//   File : KviIrcMask.cpp
 //   Creation date : Fri Jan 8 1999 20:56:07 by Szymon Stefanek
 //
 //   This file is part of the KVIrc irc client distribution
@@ -29,40 +29,40 @@
 /*
 	@doc: irc_masks
 	@title:
-		Irc masks
+		IRC masks
 	@type:
 		generic
 	@short:
-		Decription of the standard IRC masks
+		Description of the standard IRC masks
 	@keyterms:
 		irc masks, nickname, username, hostname, wildcard
 	@body:
 		[big]Simple masks[/big][br]
-		An irc mask is a string in a special format that identifies an user on irc.[br]
+		An IRC mask is a string in a special format that identifies an user on IRC.[br]
 		The standard basic format is:[br]
 		[b]<nick>!<username>@<host>[/b][br]
 		The <nick> part contains the nickname with that the user is widely known across the network.[br]
-		The nickname format is generally restricted by the irc network rules: usually it has a maximum
+		The nickname format is generally restricted by the IRC network rules: usually it has a maximum
 		length (9 on actual IrcNet servers for example), and can contain only a defined set of characters.
 		Just as example, the character '!' obviously can't be included in a nickname.[br]
 		The <username> part is the machine username of the remote user: this is usually
-		retrieved by the irc server at connect time by contacting the ident service on the user's machine.
+		retrieved by the IRC server at connect time by contacting the Ident service on the user's machine.
 		Some IRC servers allow specifying this username inside the login messages and do not connect
-		to the ident service at all.[br]
-		The <username> often has a special prefix character added by the irc server:[br]
+		to the Ident service at all.[br]
+		The <username> often has a special prefix character added by the IRC server:[br]
 		this is rather server specific protocol, but the prefixes are somewhat standardized and
 		the common meanings of them are:[br]
-		noprefix: I line with ident[br]
-		^: I line with OTHER type ident[br]
-		~: I line, no ident[br]
-		+: i line with ident[br]
-		=: i line with OTHER type ident[br]
-		-: i line, no ident[br]
+		noprefix: I line with Ident[br]
+		^: I line with OTHER type Ident[br]
+		~: I line, no Ident[br]
+		+: i line with Ident[br]
+		=: i line with OTHER type Ident[br]
+		-: i line, no Ident[br]
 		So finally you can find <username> strings like "~pragma" or "^pragma", where "pragma"
 		is the system username of the irc-user and ~ and ^ are prefixes.[br]
 		The <host> part is the hostname of the remote user.[br]
 		In most cases it is the human-readable format of the host name, but sometimes
-		it happens to be an IP-address (when the host has no reverse dns entry).[br]
+		it happens to be an IP-address (when the host has no reverse DNS entry).[br]
 		The IP address can be either in IPV4 format or in IPV6 format.[br]
 		Some (weird from my point of view) servers hide certain parts of the IP address to
 		prevent attacks to the user's machine.[br]

--- a/src/kvilib/locale/KviLocale.cpp
+++ b/src/kvilib/locale/KviLocale.cpp
@@ -267,10 +267,10 @@ public:
 			g_pUtf8TextCodec = QTextCodec::codecForName("UTF-8");
 			if(!g_pUtf8TextCodec)
 			{
-				qDebug("Can't find the global utf8 text codec!");
+				qDebug("Can't find the global UTF-8 text codec!");
 				g_pUtf8TextCodec = QTextCodec::codecForLocale(); // try anything else...
 				if(!g_pUtf8TextCodec)
-					qDebug("Aargh.. got no UTF-8 text codec: we're in trouble.");
+					qDebug("Argh! Have no UTF-8 text codec: we're in trouble.");
 			}
 		}
 

--- a/src/kvilib/locale/KviMessageCatalogue.cpp
+++ b/src/kvilib/locale/KviMessageCatalogue.cpp
@@ -203,7 +203,7 @@ bool KviMessageCatalogue::load(const QString & szName)
 
 	if(iStringsNum >= 9972)
 	{
-		qDebug("Number of strings too big...sure that it is a KVIrc catalog file ?");
+		qDebug("Number of strings too big... sure that it is a KVIrc catalog file?");
 		iStringsNum = 9972;
 	}
 
@@ -259,9 +259,9 @@ bool KviMessageCatalogue::load(const QString & szName)
 	for(int i = 0; i < iStringsNum; i++)
 	{
 		// FIXME: "Check for NULL inside strings here ?"
-		//qDebug("original seems to be at %u and %u byttes long",KVI_SWAP_IF_NEEDED(bMustSwap,pOrigDescriptor[i].offset),
+		//qDebug("original seems to be at %u and %u bytes long",KVI_SWAP_IF_NEEDED(bMustSwap,pOrigDescriptor[i].offset),
 		//	KVI_SWAP_IF_NEEDED(bMustSwap,pOrigDescriptor[i].length));
-		//qDebug("translated seems to be at %u and %u byttes long",KVI_SWAP_IF_NEEDED(bMustSwap,pTransDescriptor[i].offset),
+		//qDebug("translated seems to be at %u and %u bytes long",KVI_SWAP_IF_NEEDED(bMustSwap,pTransDescriptor[i].offset),
 		//	KVI_SWAP_IF_NEEDED(bMustSwap,pTransDescriptor[i].length));
 
 		KviTranslationEntry * e = new KviTranslationEntry(
@@ -311,7 +311,7 @@ bool KviMessageCatalogue::load(const QString & szName)
 	if(!m_pTextCodec)
 	{
 		qDebug("The message catalogue does not have a \"charset\" header");
-		qDebug("Assuming utf8"); // FIXME: or codecForLocale() ?
+		qDebug("Assuming UTF-8"); // FIXME: or codecForLocale() ?
 		m_pTextCodec = QTextCodec::codecForName("UTF-8");
 	}
 
@@ -336,7 +336,7 @@ const QString & KviMessageCatalogue::translateToQString(const char * pcText)
 		pAux->m_pTranslation = new QString(m_pTextCodec->toUnicode(pAux->m_szEncodedTranslation.ptr()));
 		return *(pAux->m_pTranslation);
 	}
-	// no translation is available: let's avoid continous string decoding
+	// no translation is available: let's avoid continuous string decoding
 	pAux = new KviTranslationEntry(pcText);
 	m_pMessages->insert(pAux->m_szKey.ptr(),pAux);
 	pAux->m_pTranslation = new QString(m_pTextCodec->toUnicode(pAux->m_szEncodedTranslation.ptr()));

--- a/src/kvilib/net/KviDnsResolver.cpp
+++ b/src/kvilib/net/KviDnsResolver.cpp
@@ -370,7 +370,7 @@ KviDnsResolver::~KviDnsResolver()
 	if(m_pSlaveThread)
 	{
 		if(!m_pSlaveThread->wait(30000))
-			qDebug("Failed to wait for the slave dns thread: we're probably going to crash!");
+			qDebug("Failed to wait for the slave DNS thread: we're probably going to crash!");
 		delete m_pSlaveThread; // will eventually terminate it (but it will also block us!!!)
 	}
 

--- a/src/kvilib/net/KviHttpRequest.cpp
+++ b/src/kvilib/net/KviHttpRequest.cpp
@@ -190,7 +190,7 @@ bool KviHttpRequest::start()
 	if(m_connectionUrl.host().isEmpty())
 	{
 		resetInternalStatus();
-		m_szLastError = __tr2qs("Invalid URL: Missing hostname");
+		m_szLastError = __tr2qs("Invalid URL: missing hostname");
 		return false;
 	}
 
@@ -235,7 +235,7 @@ void KviHttpRequest::slotSocketDisconnected()
 			emit binaryData(*m_p->pBuffer);
 		break;
 		case Blocks:
-			// an unprocessed block ?.. should never happend.. but well :D
+			// an unprocessed block ?.. should never happened.. but well :D
 			if(m_p->pBuffer->size() > 0)
 				emit binaryData(*m_p->pBuffer);
 		break;

--- a/src/kvilib/system/KviThread.cpp
+++ b/src/kvilib/system/KviThread.cpp
@@ -169,7 +169,7 @@ void KviThreadManager::globalDestroy()
 KviThreadManager::KviThreadManager()
 : QObject()
 {
-	if(g_pThreadManager)qDebug("Hey...what are ya doing ?");
+	if(g_pThreadManager)qDebug("Hey... what are ya doing?");
 
 	m_pMutex = new KviMutex();
 	m_pThreadList = new KviPointerList<KviThread>;
@@ -186,17 +186,17 @@ KviThreadManager::KviThreadManager()
 
 	if(pipe(m_fd) != 0)
 	{
-		qDebug("Ops...thread manager pipe creation failed (%s)",KviError::getDescription(KviError::translateSystemError(errno)).toUtf8().data());
+		qDebug("Oops! Thread manager pipe creation failed (%s)",KviError::getDescription(KviError::translateSystemError(errno)).toUtf8().data());
 	}
 
 	if(fcntl(m_fd[KVI_THREAD_PIPE_SIDE_SLAVE],F_SETFL,O_NONBLOCK) == -1)
 	{
-		qDebug("Ops...thread manager slave pipe initialisation failed (%s)",KviError::getDescription(KviError::translateSystemError(errno)).toUtf8().data());
+		qDebug("Oops! Thread manager slave pipe initialisation failed (%s)",KviError::getDescription(KviError::translateSystemError(errno)).toUtf8().data());
 	}
 
 	if(fcntl(m_fd[KVI_THREAD_PIPE_SIDE_MASTER],F_SETFL,O_NONBLOCK) == -1)
 	{
-		qDebug("Ops...thread manager master pipe initialisation failed (%s)",KviError::getDescription(KviError::translateSystemError(errno)).toUtf8().data());
+		qDebug("Oops! Thread manager master pipe initialisation failed (%s)",KviError::getDescription(KviError::translateSystemError(errno)).toUtf8().data());
 	}
 
 	m_pSn = new QSocketNotifier(m_fd[KVI_THREAD_PIPE_SIDE_MASTER],QSocketNotifier::Read);
@@ -346,7 +346,7 @@ void KviThreadManager::postSlaveEvent(QObject *o,QEvent *e)
 		{
 			// ops.. failed to write down the event..
 			// this is quite irritating now...
-			qDebug("Ops.. failed to write down the trigger");
+			qDebug("Oops! Failed to write down the trigger");
 			// FIXME: maybe a single shot timer ?
 		} else {
 			m_iTriggerCount++;
@@ -418,7 +418,7 @@ void KviThreadManager::threadLeftWaitState()
 	m_iWaitingThreads--;
 	if(m_iWaitingThreads < 0)
 	{
-		qDebug("Ops.. got a negative number of waiting threads ?");
+		qDebug("Oops! Do I have a negative number of waiting threads?");
 		m_iWaitingThreads = 0;
 	}
 	m_pMutex->unlock();

--- a/src/kvirc/kernel/KviApplication.cpp
+++ b/src/kvirc/kernel/KviApplication.cpp
@@ -946,7 +946,7 @@ Let's see the scheme to understand which is choosen:
 			if(reply.type() == QDBusMessage::ErrorMessage)
 			{
 				QDBusError err = reply;
-				qDebug("DBus notify error\nID: %u\nName: %s\nMessage: %s\n",reply.arguments().first().toUInt(),qPrintable(err.name()),qPrintable(err.message()));
+				qDebug("D-Bus notify error\nID: %u\nName: %s\nMessage: %s\n",reply.arguments().first().toUInt(),qPrintable(err.name()),qPrintable(err.message()));
 			}
 		} else {
 #endif // COMPILE_DBUS_SUPPORT
@@ -1134,7 +1134,7 @@ void KviApplication::checkSuggestRestoreDefaultScript()
 
 	switch(
 		QMessageBox::question(0,__tr2qs("Installation problems?"),
-			__tr2qs("<b>Ooops...</b><br><br>" \
+			__tr2qs("<b>Oops...</b><br><br>" \
 				"<b>There are some reasons that make me think that your KVIrc installation is incomplete.</b><br><br>" \
 				"I might be wrong, but you seem to miss some of the features that the default KVIrc script provides." \
 				"This may happen because you have upgraded to an unstable Git version, " \
@@ -1347,7 +1347,7 @@ void KviApplication::fileDownloadTerminated(
 	} else {
 		if((!_OUTPUT_MUTE) && (!bQuiet))
 		{
-			pAvatar->pConsole->output(KVI_OUT_AVATAR,__tr2qs("Avatar download failed for %Q!%Q@%Q and url %Q: %Q"),
+			pAvatar->pConsole->output(KVI_OUT_AVATAR,__tr2qs("Avatar download failed for %Q!%Q@%Q and URL %Q: %Q"),
 				&(pAvatar->szNick),&(pAvatar->szUser),&(pAvatar->szHost),&(szRemoteUrl),&(szError));
 		}
 	}

--- a/src/kvirc/kernel/KviApplication_setup.cpp
+++ b/src/kvirc/kernel/KviApplication_setup.cpp
@@ -3,7 +3,7 @@
 //   File : KviApplication_setup.cpp
 //   Creation date : Fri Apr 2 1999 02:38:05 by Szymon Stefanek
 //
-//   This file is part of the Kvirc irc client distribution
+//   This file is part of the KVIrc irc client distribution
 //   Copyright (C) 1999-2010 Szymon Stefanek (pragma at kvirc dot net)
 //
 //   This program is FREE software. You can redistribute it and/or
@@ -42,7 +42,7 @@
 	#include <shlwapi.h>
 #else
 	#include <stdlib.h> // for getenv()
-	#include <unistd.h> // for symlink() <-- unused ?
+	#include <unistd.h> // for symlink() <-- unused?
 
 	#ifdef COMPILE_KDE_SUPPORT
 		#include <kconfig.h>
@@ -60,8 +60,8 @@ static QLibrary * g_pSetupLibrary = 0;
 
 //
 // Things launched at startup:
-// - Attempt to find the global Kvirc directory
-// - Attempt to find the local Kvirc directory
+// - Attempt to find the global KVIrc directory
+// - Attempt to find the local KVIrc directory
 //   and if it is not found, ask the user to choose one
 //
 
@@ -567,7 +567,7 @@ void KviApplication::findGlobalKvircDirectory()
 	if(checkGlobalKvircDirectory(m_szGlobalKvircDir))
 		return;
 
-	KviMessageBox::warning("Unable to find the shared Kvirc directory.\n"\
+	KviMessageBox::warning("Unable to find the shared KVIrc directory.\n"\
 		"I have tried %Q, but it seemed to fail\n" \
 		"Trying to run anyway...\n",&m_szGlobalKvircDir);
 #else
@@ -590,13 +590,13 @@ void KviApplication::findGlobalKvircDirectory()
 	// AND THE LOCALE IS NOT INITIALIZED AT ALL
 
 	#ifdef COMPILE_KDE_SUPPORT
-		KviMessageBox::warning("Unable to find the shared Kvirc directory.\n"\
+		KviMessageBox::warning("Unable to find the shared KVIrc directory.\n"\
 			"The usual path for this directory is $KDEDIR/share/apps/kvirc.\n"\
-			"Are you sure that 'make install' worked correctly ?\n"\
+			"Are you sure that 'make install' worked correctly?\n"\
 			"Please make sure that you have the read permission to that directory\n"\
 			"and you have set KDEDIR correctly. You may also try to rerun 'make install'.\n"\
-			"A detailed explaination of the Kvirc directory system is in the INSTALL document\n"\
-			"shipped with the kvirc source dirstribution.\n"\
+			"A detailed explanation of the KVIrc directory system is in the INSTALL document\n"\
+			"shipped with the KVIrc source distribution.\n"\
 			"Trying to run anyway...");
 	#elif defined(COMPILE_ON_MAC)
 		KviMessageBox::warning("Unable to find the shared KVIrc directory.\n"\
@@ -607,11 +607,11 @@ void KviApplication::findGlobalKvircDirectory()
 	#else //!defined(COMPILE_KDE_SUPPORT) && !defined(COMPILE_ON_MAC)
 		KviMessageBox::warning("Unable to find the shared KVIrc directory.\n"\
 			"The usual path for this directory is /usr/local/share/kvirc.\n"\
-			"Are you sure that 'make install' worked correctly ?\n"\
+			"Are you sure that 'make install' worked correctly?\n"\
 			"Please make sure that you have the read permission to that directory.\n"\
 			"You may also need to rerun 'make install'.\n"\
-			"A detailed explaination of the KVIrc directory system is in the INSTALL document\n"\
-			"shipped with the kvirc source dirstribution.\n"\
+			"A detailed explanation of the KVIrc directory system is in the INSTALL document\n"\
+			"shipped with the KVIrc source distribution.\n"\
 			"Trying to run anyway...\n");
 	#endif //!COMPILE_ON_MAC
 #endif
@@ -693,7 +693,7 @@ void KviApplication::loadDirectories()
 	szLocalePath.append("locale");
 	szLocalePath.append(KVI_PATH_SEPARATOR);
 
-	//__debug_1arg("Global Kvirc directory is %s",m_szGlobalKvircDir.ptr());
+	//__debug_1arg("Global KVIrc directory is %s",m_szGlobalKvircDir.ptr());
 	// Now look for the local (writable) one
 	m_bFirstTimeRun = !findLocalKvircDirectory();
 
@@ -736,7 +736,7 @@ void KviApplication::setupBegin()
 	g_pSetupLibrary = new QLibrary(szSetupLib);
 	if(!g_pSetupLibrary->load())
 	{
-		KviMessageBox::warning(__tr2qs("Ops...it looks like I can't load modules on this sytem.\n" \
+		KviMessageBox::warning(__tr2qs("Oops! It looks like I can't load modules on this system.\n" \
 			"I have been looking for the %s library but I haven't been able to load it\n" \
 			"due to the following error: \"%s\"\nAborting."),szSetupLib.toUtf8().data(),g_pSetupLibrary->errorString().toUtf8().data());
 #if defined(COMPILE_ON_WINDOWS)
@@ -751,7 +751,7 @@ void KviApplication::setupBegin()
 	bool (*sfunc)() = (bool(*)())g_pSetupLibrary->resolve("setup_begin");
 	if(!sfunc)
 	{
-		KviMessageBox::warning(__tr2qs("Ops...it looks like you have a broken distribution.\n" \
+		KviMessageBox::warning(__tr2qs("Oops! It looks like you have a broken distribution.\n" \
 			"The setup module does not export the \"setup_begin\" function.\n" \
 			"Aborting!"));
 #if defined(COMPILE_ON_WINDOWS)
@@ -786,14 +786,14 @@ void KviApplication::setupFinish()
 {
 	if(!g_pSetupLibrary)
 	{
-		qDebug("Oops... lost the setup library ?");
+		qDebug("Oops! Lost the setup library?");
 		return;
 	}
 
 	void (*sfunc)() = (void(*)())g_pSetupLibrary->resolve("setup_finish");
 	if(!sfunc)
 	{
-		KviMessageBox::warning(__tr2qs("Ops...it looks like you have a broken distribution.\n" \
+		KviMessageBox::warning(__tr2qs("Oops! It looks like you have a broken distribution.\n" \
 			"The setup module does not export the \"setup_finish\" function.\n" \
 			"Trying to continue anyway..."));
 	}

--- a/src/kvirc/kernel/KviIconManager.cpp
+++ b/src/kvirc/kernel/KviIconManager.cpp
@@ -48,7 +48,7 @@
 	@title:
 		The image identifier
 	@keyterms:
-		image identifier, using builtin images, how kvirc locates image files
+		image identifier, using builtin images, how KVIrc locates image files
 	@type:
 		language
 	@short:
@@ -57,7 +57,7 @@
 		Some KVIrc commands and functions accept
 		the <image_id> as a parameter.
 		The <image_id> indicates an image to be displayed
-		by some gui element. Since KVIrc has a set of
+		by some GUI element. Since KVIrc has a set of
 		builtin icons, we want the user to be able to use it :).[br]
 		The <image_id> can be either a signed integer number
 		or a filename.[br]
@@ -1206,11 +1206,11 @@ KviAvatar * KviIconManager::getAvatar(const QString & szLocalPath, const QString
 			return 0;
 		if(KviQString::equalCIN("http://",szName,7))
 		{
-			// it's an url, cache it locally
+			// it's a URL, cache it locally
 			szN = szName;
 			urlToCachedFileName(szN);
 			g_pApp->getLocalKvircDirectory(szP,KviApplication::Avatars,szN);
-			szN = szName; // keep the remote url as name
+			szN = szName; // keep the remote URL as name
 		} else {
 			//locally cached avatar, called only by its szName
 			szN = KviFileUtils::extractFileName(szName);

--- a/src/kvirc/kernel/KviIrcContext.cpp
+++ b/src/kvirc/kernel/KviIrcContext.cpp
@@ -464,7 +464,7 @@ void KviIrcContext::connectToCurrentServer()
 		{
 			// !m_pAsynchronousConnectionData->szServer.isEmpty()
 			// ok, have a server to look for in the db
-			// FIXME: this is a bit ugly... could it be managed in some completly different and nicer way ?
+			// FIXME: this is a bit ugly... could it be managed in some completely different and nicer way ?
 			KviIrcServerDefinition d;
 			d.szServer = m_pAsynchronousConnectionData->szServer;
 			d.bPortIsValid = m_pAsynchronousConnectionData->bPortIsOk;
@@ -484,7 +484,7 @@ void KviIrcContext::connectToCurrentServer()
 				destroyAsynchronousConnectionData();
 				return;
 			}
-		} // else we just connect to the globally selected irc server in the options dialog
+		} // else we just connect to the globally selected IRC server in the options dialog
 	}
 
 	KviIrcNetwork * net = g_pServerDataBase->currentNetwork();
@@ -505,7 +505,7 @@ void KviIrcContext::connectToCurrentServer()
 	if(!net)
 	{
 		// BUG
-		m_pConsole->outputNoFmt(KVI_OUT_SYSTEMERROR,__tr2qs("Ooops.. you've hit a bug in the servers database... I have found a server but not a network..."));
+		m_pConsole->outputNoFmt(KVI_OUT_SYSTEMERROR,__tr2qs("Oops! You've hit a bug in the servers database... I have found a server but not a network..."));
 		destroyAsynchronousConnectionData();
 		return;
 	}
@@ -705,7 +705,7 @@ void KviIrcContext::connectionEstabilished()
 			connection()->target()->server()->port());
 	}
 
-	// Add to recent server list (build the url of type irc[6]://<server>:<port>
+	// Add to recent server list (build the URL of type irc[6]://<server>:<port>
 	QString url;
 	KviIrcUrl::join(url,connection()->target()->server());
 	g_pApp->addRecentServer(url);
@@ -734,7 +734,7 @@ void KviIrcContext::connectionTerminated()
 	connection()->requestQueue()->clearAll();
 
 	// we consider it unexpected when we haven't sent a QUIT message and we're connected
-	// or alternatively when a simulation of such a termination is requested (this is used to keep the queries open etc..)
+	// or alternatively when a simulation of such a termination is requested (this is used to keep the queries open etc.)
 	bool bUnexpectedDisconnect = (
 			(!(connection()->stateData()->sentQuit())) &&
 			(

--- a/src/kvirc/kernel/KviIrcLink.cpp
+++ b/src/kvirc/kernel/KviIrcLink.cpp
@@ -94,7 +94,7 @@ void KviIrcLink::linkFilterDestroyed()
 {
 	m_pLinkFilter = 0;
 	m_pConsole->output(KVI_OUT_SYSTEMWARNING,
-		__tr2qs("Ops... for some reason the link filter object has been destroyed"));
+		__tr2qs("Oops! For some reason the link filter object has been destroyed"));
 }
 
 void KviIrcLink::destroySocket()
@@ -135,7 +135,7 @@ void KviIrcLink::createSocket(const QString & szLinkFilterName)
 	{
 		connect(m_pLinkFilter,SIGNAL(destroyed()),this,SLOT(linkFilterDestroyed()));
 		m_pConsole->output(KVI_OUT_SYSTEMMESSAGE,
-			__tr2qs("Using filtered IRC protocol: Link filter is \"%Q\""),&szLinkFilterName);
+			__tr2qs("Using filtered IRC protocol: link filter is \"%Q\""),&szLinkFilterName);
 		return;
 	}
 
@@ -178,7 +178,7 @@ void KviIrcLink::resolverTerminated()
 {
 	if(!m_pResolver)
 	{
-		qDebug("Oops... resoverTerminated() triggered without a resolver ?");
+		qDebug("Oops! The resolverTerminated() was triggered without a resolver");
 		return;
 	}
 
@@ -257,15 +257,15 @@ void KviIrcLink::processData(char * buffer, int iLen)
 			m_uReadPackets++;
 
 			// FIXME: actually it can happen that the socket gets disconnected
-			// in a incomingMessage() call.
-			// The problem might be that some other parts of kvirc assume
-			// that the irc context still exists after a failed write to the socket
+			// in an incomingMessage() call.
+			// The problem might be that some other parts of KVIrc assume
+			// that the IRC context still exists after a failed write to the socket
 			// (some parts don't even check the return value!)
 			// If the problem presents itself again then the solution is:
 			//   disable queue flushing for the "incomingMessage" call
 			//   and just call queue_insertMessage()
 			//   then after the call terminates flush the queue (eventually detecting
-			//   the disconnect and thus destroying the irc context).
+			//   the disconnect and thus destroying the IRC context).
 			// For now we try to rely on the remaining parts to handle correctly
 			// such conditions. Let's see...
 			if(*cMessageBuffer != 0)
@@ -312,10 +312,10 @@ void KviIrcLink::processData(char * buffer, int iLen)
 			m_pReadBuffer =(char *)KviMemory::allocate(m_uReadBufferLen);
 			KviMemory::move(m_pReadBuffer,cBeginOfCurData,m_uReadBufferLen);
 		}
-		//The m_pReadBuffer contains at max 1 irc message...
+		//The m_pReadBuffer contains at max 1 IRC message...
 		//that can not be longer than 510 bytes (the message is not CRLF terminated)
 		// FIXME: Is this limit *really* valid on all servers ?
-		if(m_uReadBufferLen > 510) qDebug("WARNING: Receiving an invalid irc message from server.");
+		if(m_uReadBufferLen > 510) qDebug("WARNING: receiving an invalid IRC message from server.");
 	}
 	KviMemory::free(cMessageBuffer);
 }
@@ -386,7 +386,7 @@ void KviIrcLink::socketStateChange()
 					m_pConnection->linkTerminated();
 				break;
 				default: // currently can be only Idle
-					qDebug("Ooops... got a KviIrcSocket::Idle state change when KviIrcLink::m_eState was Idle");
+					qDebug("Oops! Received a KviIrcSocket::Idle state change when KviIrcLink::m_eState was idle");
 				break;
 			}
 		}

--- a/src/kvirc/kernel/KviIrcSocket.cpp
+++ b/src/kvirc/kernel/KviIrcSocket.cpp
@@ -269,7 +269,7 @@ void KviIrcSocket::raiseError(KviError::Code eError)
 
 KviError::Code KviIrcSocket::startConnection(KviIrcServer * pServer, KviProxy * pProxy, const char * pcBindAddress)
 {
-	// Attempts to estabilish an IRC connection
+	// Attempts to establish an IRC connection
 	// to the server specified by *srv.
 	// Uses the proxy *prx if not 0
 	if(m_state != Idle)
@@ -325,7 +325,7 @@ KviError::Code KviIrcSocket::startConnection(KviIrcServer * pServer, KviProxy * 
 
 	if(bNeedServerIp)
 	{
-		// check the irc host ip
+		// check the IRC host IP
 #ifdef COMPILE_IPV6_SUPPORT
 		if(m_pIrcServer->isIPv6())
 		{
@@ -392,12 +392,12 @@ KviError::Code KviIrcSocket::startConnection(KviIrcServer * pServer, KviProxy * 
 
 	if(!kvi_socket_connect(m_sock,sa.socketAddress(),((int)(sa.addressLength()))))
 	{
-		// ops...
+		// Oops!
 		int iErr = kvi_socket_error();
 
 		if(!kvi_socket_recoverableConnectError(iErr))
 		{
-			// Ops...
+			// Oops!
 			int iSockError = iErr;
 			if(iSockError == 0)
 			{
@@ -476,7 +476,7 @@ void KviIrcSocket::writeNotifierFired(int)
 	delete m_pWsn;
 	m_pWsn = 0;
 
-	//Succesfully connected...
+	//Successfully connected...
 	connectionEstabilished();
 }
 
@@ -1073,7 +1073,7 @@ void KviIrcSocket::proxyHandleV5MethodReply(unsigned char cReply)
 	if(cReply == 0)
 	{
 		if(_OUTPUT_VERBOSE)
-			outputProxyMessage(__tr2qs("Proxy response: Auth method OK: using method 0 (no auth)"));
+			outputProxyMessage(__tr2qs("Proxy response: auth method OK: using method 0 (no auth)"));
 		proxySendTargetDataV5();
 		return;
 	}
@@ -1081,7 +1081,7 @@ void KviIrcSocket::proxyHandleV5MethodReply(unsigned char cReply)
 	if(cReply == 2)
 	{
 		if(_OUTPUT_VERBOSE)
-			outputProxyMessage(__tr2qs("Proxy response: Auth method OK: using method 2 (user/pass)"));
+			outputProxyMessage(__tr2qs("Proxy response: auth method OK: using method 2 (user/pass)"));
 		proxyAuthUserPassV5();
 		return;
 	}
@@ -1179,7 +1179,7 @@ void KviIrcSocket::proxyHandleV4FinalReply(unsigned char cReply)
 	//
 	//        90: request granted
 	//        91: request rejected or failed
-	//        92: request rejected becasue SOCKS server cannot connect to
+	//        92: request rejected because SOCKS server cannot connect to
 	//            identd on the client
 	//        93: request rejected because the client program and identd
 	//            report different user-ids
@@ -1336,7 +1336,7 @@ void KviIrcSocket::doSSLHandshake(int)
 
 	if(!m_pSSL)
 	{
-		qDebug("Ops... Have I lost the SSL class ?");
+		qDebug("Oops! Have I lost the SSL class?");
 		reset();
 		return; // ops ?
 	}
@@ -1393,7 +1393,7 @@ void KviIrcSocket::doSSLHandshake(int)
 	}
 
 #else //COMPILE_SSL_SUPPORT
-	qDebug("Ops.. SSL handshake without SSL support! Aborting!");
+	qDebug("Oops! SSL handshake without SSL support. Aborting!");
 	exit(-1);
 #endif //COMPILE_SSL_SUPPORT
 }
@@ -1410,7 +1410,7 @@ void KviIrcSocket::linkUp()
 	if(m_sock == KVI_INVALID_SOCKET)
 		return; // ops...disconnected in setState() ????
 
-	// ok.. it seems that we're really up and running now!
+	// OK.. it seems that we're really up and running now!
 	if(m_pWsn)
 	{
 		delete m_pWsn;
@@ -1568,15 +1568,15 @@ void KviIrcSocket::processData(char * buffer,int)
 			m_uReadPackets++;
 
 			// FIXME: actually it can happen that the socket gets disconnected
-			// in a incomingMessage() call.
-			// The problem might be that some other parts of kvirc assume
-			// that the irc context still exists after a failed write to the socket
+			// in an incomingMessage() call.
+			// The problem might be that some other parts of KVIrc assume
+			// that the IRC context still exists after a failed write to the socket
 			// (some parts don't even check the return value!)
 			// If the problem presents itself again then the solution is:
 			//   disable queue flushing for the "incomingMessage" call
 			//   and just call queue_insertMessage()
 			//   then after the call terminates flush the queue (eventually detecting
-			//   the disconnect and thus destroying the irc context).
+			//   the disconnect and thus destroying the IRC context).
 			// For now we try to rely on the remaining parts to handle correctly
 			// such conditions. Let's see...
 
@@ -1764,7 +1764,7 @@ void KviIrcSocket::flushSendQueue()
 	if(m_pFlushTimer->isActive())
 		m_pFlushTimer->stop();
 
-	// Ok...have something to send...
+	// OK...have something to send...
 	KVI_ASSERT(m_state != Idle);
 
 	struct timeval curTime;
@@ -1799,7 +1799,7 @@ void KviIrcSocket::flushSendQueue()
 #endif
 		if(iResult == (int)m_pSendQueueHead->pData->size())
 		{
-			// Succesfull send...remove this data buffer
+			// Successful send...remove this data buffer
 			m_uSentPackets++;
 			m_uSentBytes += iResult;
 			//if(m_pConsole->hasMonitors())outgoingMessageNotifyMonitors((char *)(m_pSendQueueHead->pData->data()),result);

--- a/src/kvirc/kernel/KviMain.cpp
+++ b/src/kvirc/kernel/KviMain.cpp
@@ -94,7 +94,7 @@ int parseArgs(ParseArgs * a)
 			szMessage += KviBuildInfo::buildDate();
 			szMessage += "\n";
 
-			KviQString::appendFormatted(szMessage,"Home page: http://www.kvirc.net/\n");
+			KviQString::appendFormatted(szMessage,"Homepage: http://www.kvirc.net/\n");
 
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
 			MessageBox(0,szMessage.toLocal8Bit().data(),"KVIrc",0);
@@ -257,7 +257,7 @@ int parseArgs(ParseArgs * a)
 			idx++;
 			if(idx >= a->argc)
 			{
-				qDebug("Option --external requires n irc:// url");
+				qDebug("Option --external requires an irc:// URL");
 				return KVI_ARGS_RETCODE_ERROR;
 			}
 			p = a->argv[idx];

--- a/src/kvirc/kernel/KviNotifyList.cpp
+++ b/src/kvirc/kernel/KviNotifyList.cpp
@@ -67,7 +67,7 @@
 		entry.[br]
 		The property is called "notify", and you have to set it to the nickname
 		that you want to look for.[br]
-		So for example, assume to register a frend of yours like Szymon:[br]
+		So for example, assume to register a friend of yours like Szymon:[br]
 		[example]
 			[cmd:reguser.add]reguser.add[/cmd] Szymon
 			[cmd:reguser.addmask]reguser.addmask[/cmd] Szymon Pragma!*@*.it
@@ -91,7 +91,7 @@
 		The "stupid ISON method" will assume that Szymon is online if any user with nickname
 		Pragma (or [Pragma] in the second example) gets online; this means that also Pragma!someuser@somehost.com will be
 		assumed to be "Szymon" and will be shown in the notify list.[br]
-		This might be a false assumption (since somehod.com does not even match *.it),
+		This might be a false assumption (since somehost.com does not even match *.it),
 		but it is the best result that the "stupid ISON method" can achieve.[br]
 		The "intelligent ISON method" will also check the Pragma's username and hostname
 		and match it in the registered masks; so in the example above, you will be notified if

--- a/src/kvirc/kernel/KviOptions.cpp
+++ b/src/kvirc/kernel/KviOptions.cpp
@@ -751,13 +751,13 @@ KviMessageTypeSettingsOption g_msgtypeOptionsTable[KVI_NUM_MSGTYPE_OPTIONS]=
 	MSGTYPE_OPTION("SocketWarning",__tr_no_lookup("Socket warning"),KviIconManager::SocketWarning,KVI_MSGTYPE_LEVEL_3),
 	MSGTYPE_OPTION_SPEC("SocketError",__tr_no_lookup("Socket error"),KviIconManager::SocketError,KviControlCodes::Red,KviControlCodes::Transparent,KVI_MSGTYPE_LEVEL_3),
 	MSGTYPE_OPTION_SPEC("SystemError",__tr_no_lookup("System error"),KviIconManager::SystemError,KviControlCodes::Red,KviControlCodes::Transparent,KVI_MSGTYPE_LEVEL_3),
-	MSGTYPE_OPTION("Raw",__tr_no_lookup("Raw data to server"),KviIconManager::Raw,KVI_MSGTYPE_LEVEL_1),
+	MSGTYPE_OPTION("Raw",__tr_no_lookup("RAW data to server"),KviIconManager::Raw,KVI_MSGTYPE_LEVEL_1),
 	MSGTYPE_OPTION("Connection",__tr_no_lookup("Connection status"),KviIconManager::World,KVI_MSGTYPE_LEVEL_1),
 	MSGTYPE_OPTION("SystemWarning",__tr_no_lookup("System warning"),KviIconManager::SystemWarning,KVI_MSGTYPE_LEVEL_3),
 	MSGTYPE_OPTION("SystemMessage",__tr_no_lookup("System message"),KviIconManager::SystemMessage,KVI_MSGTYPE_LEVEL_1),
 	MSGTYPE_OPTION("UnhandledReply",__tr_no_lookup("Unhandled server reply"),KviIconManager::UnHandled,KVI_MSGTYPE_LEVEL_1),
 	MSGTYPE_OPTION("ServerInfo",__tr_no_lookup("Server information"),KviIconManager::ServerInfo,KVI_MSGTYPE_LEVEL_1),
-	MSGTYPE_OPTION("Motd",__tr_no_lookup("Server Message of the Day"),KviIconManager::Motd,KVI_MSGTYPE_LEVEL_1),
+	MSGTYPE_OPTION("Motd",__tr_no_lookup("Server message of the day"),KviIconManager::Motd,KVI_MSGTYPE_LEVEL_1),
 	MSGTYPE_OPTION("ServerPing",__tr_no_lookup("Server ping"),KviIconManager::ServerPing,KVI_MSGTYPE_LEVEL_1),
 	MSGTYPE_OPTION("Join",__tr_no_lookup("Join message"),KviIconManager::Join,KVI_MSGTYPE_LEVEL_1),
 	MSGTYPE_OPTION("Part",__tr_no_lookup("Part message"),KviIconManager::Part,KVI_MSGTYPE_LEVEL_1),
@@ -796,11 +796,11 @@ KviMessageTypeSettingsOption g_msgtypeOptionsTable[KVI_NUM_MSGTYPE_OPTIONS]=
 	MSGTYPE_OPTION("DccMsg",__tr_no_lookup("DCC message"),KviIconManager::DccMsg,KVI_MSGTYPE_LEVEL_2),
 	MSGTYPE_OPTION("DccError",__tr_no_lookup("DCC error"),KviIconManager::DccError,KVI_MSGTYPE_LEVEL_3),
 	MSGTYPE_OPTION("NicknameProblem",__tr_no_lookup("Nickname problem"),KviIconManager::NickNameProblem,KVI_MSGTYPE_LEVEL_3),
-	MSGTYPE_OPTION("WhoisUser",__tr_no_lookup("Whois user reply"),KviIconManager::WhoisUser,KVI_MSGTYPE_LEVEL_3),
-	MSGTYPE_OPTION("WhoisChannels",__tr_no_lookup("Whois channels reply"),KviIconManager::WhoisChannels,KVI_MSGTYPE_LEVEL_3),
-	MSGTYPE_OPTION("WhoisIdle",__tr_no_lookup("Whois idle reply"),KviIconManager::WhoisIdle,KVI_MSGTYPE_LEVEL_3),
-	MSGTYPE_OPTION("WhoisServer",__tr_no_lookup("Whois server reply"),KviIconManager::WhoisServer,KVI_MSGTYPE_LEVEL_3),
-	MSGTYPE_OPTION("WhoisOther",__tr_no_lookup("Whois other reply"),KviIconManager::WhoisOther,KVI_MSGTYPE_LEVEL_3),
+	MSGTYPE_OPTION("WhoisUser",__tr_no_lookup("WHOIS user reply"),KviIconManager::WhoisUser,KVI_MSGTYPE_LEVEL_3),
+	MSGTYPE_OPTION("WhoisChannels",__tr_no_lookup("WHOIS channels reply"),KviIconManager::WhoisChannels,KVI_MSGTYPE_LEVEL_3),
+	MSGTYPE_OPTION("WhoisIdle",__tr_no_lookup("WHOIS idle reply"),KviIconManager::WhoisIdle,KVI_MSGTYPE_LEVEL_3),
+	MSGTYPE_OPTION("WhoisServer",__tr_no_lookup("WHOIS server reply"),KviIconManager::WhoisServer,KVI_MSGTYPE_LEVEL_3),
+	MSGTYPE_OPTION("WhoisOther",__tr_no_lookup("WHOIS other reply"),KviIconManager::WhoisOther,KVI_MSGTYPE_LEVEL_3),
 	MSGTYPE_OPTION("CreationTime",__tr_no_lookup("Channel creation time reply"),KviIconManager::Time,KVI_MSGTYPE_LEVEL_1),
 	MSGTYPE_OPTION("NotifyOnLine",__tr_no_lookup("Notify list joins"),KviIconManager::NotifyOnLine,KVI_MSGTYPE_LEVEL_3),
 	MSGTYPE_OPTION("NotifyOffLine",__tr_no_lookup("Notify list leaves"),KviIconManager::NotifyOffLine,KVI_MSGTYPE_LEVEL_3),
@@ -874,7 +874,7 @@ KviMessageTypeSettingsOption g_msgtypeOptionsTable[KVI_NUM_MSGTYPE_OPTIONS]=
 	MSGTYPE_OPTION("MeChanUnOwner",__tr_no_lookup("Own chan owner status unset"),KviIconManager::MeChanUnOwner,KVI_MSGTYPE_LEVEL_5),
 	MSGTYPE_OPTION_SPEC("ServerError",__tr_no_lookup("Server error"),KviIconManager::ServerError,KviControlCodes::Red,KviControlCodes::Transparent,KVI_MSGTYPE_LEVEL_5),
 	MSGTYPE_OPTION_SPEC("Help",__tr_no_lookup("Help"),KviIconManager::Help,KviControlCodes::DarkGreen,KviControlCodes::Transparent,KVI_MSGTYPE_LEVEL_1),
-	MSGTYPE_OPTION("TextEncoding",__tr_no_lookup("Text Encoding Server message"),KviIconManager::TextEncoding,KVI_MSGTYPE_LEVEL_1),
+	MSGTYPE_OPTION("TextEncoding",__tr_no_lookup("Text encoding server message"),KviIconManager::TextEncoding,KVI_MSGTYPE_LEVEL_1),
 	// TODO: add icon and check what level means
 	// Pragma: the message level is a warning level that is rendered in the WindowList
 	//         messages with higher level are rendered with more visible color (i.e. red)
@@ -1280,7 +1280,7 @@ void KviApplication::listAvailableOptions(KviWindow *wnd)
 	LIST_OPTIONS(__tr("String options (string value)"),KVI_NUM_STRING_OPTIONS,g_stringOptionsTable)
 	LIST_OPTIONS(__tr("Color options (#RRGGBB)"),KVI_NUM_COLOR_OPTIONS,g_colorOptionsTable)
 	LIST_OPTIONS(__tr("Mirccolor options (#RRGGBB)"),KVI_NUM_MIRCCOLOR_OPTIONS,g_mirccolorOptionsTable)
-	LIST_OPTIONS(__tr("Irc context color options (#RRGGBB)"),KVI_NUM_ICCOLOR_OPTIONS,g_iccolorOptionsTable)
+	LIST_OPTIONS(__tr("IRC context color options (#RRGGBB)"),KVI_NUM_ICCOLOR_OPTIONS,g_iccolorOptionsTable)
 	LIST_OPTIONS(__tr("Pixmap options (image path)"),KVI_NUM_PIXMAP_OPTIONS,g_pixmapOptionsTable)
 	LIST_OPTIONS(__tr("Unsigned integer options (unsigned integer constant)"),KVI_NUM_UINT_OPTIONS,g_uintOptionsTable)
 	LIST_OPTIONS(__tr("Font options (family,pointsize,style,charset,weight,flags (biusf))"),KVI_NUM_FONT_OPTIONS,g_fontOptionsTable)

--- a/src/kvirc/kvs/parser/KviKvsParser_lside.cpp
+++ b/src/kvirc/kvs/parser/KviKvsParser_lside.cpp
@@ -50,7 +50,7 @@
 		where <left_operand> and [right_operand] depend on the <operator>.[br]
 		Some operators have no [right_operand] and these are called [b]unary operators[/b]:
 		they operate directly on <left_operand>.[br]
-		Some operators, like arithmetic ones, are tipically used inside the special function
+		Some operators, like arithmetic ones, are typically used inside the special function
 		[b]$(<expression>)[/b], called the "[doc:expressioneval]Expression evaluation identifier[/doc]";
 		This special function returns the result of the evaluation of the <expression>.
 		In previous versions of KVIrc this function was called $calc().[br]
@@ -165,7 +165,7 @@ end_of_the_param:
 		[br][br]
 		<target> must be a variable, <source> can be any parameter.[br]
 		If the <target> variable doesn't exist, it is created.
-		If it already exists, it is eventually converted to the type of <souce> (scalar, hash or array).[br]
+		If it already exists, it is eventually converted to the type of <source> (scalar, hash or array).[br]
 		If <source> evaluates to an empty value then the <target> variable is unset.
 	@examples:
 		[example]
@@ -194,7 +194,7 @@ end_of_the_param:
 		[cmd]echo[/cmd] %y
 		[comment]# This is equivalent to the above[/comment]
 		%y = ""
-		[comment]# This is equivalent too, if $function evalutates to an empty string[/comment]
+		[comment]# This is equivalent too, if $function evaluates to an empty string[/comment]
 		%y = $function()
 		[comment]# Assigning a variable string to a hash entry[/comment]
 		%Dict{key} = [fnc]$system.osname[/fnc]\ian
@@ -444,7 +444,7 @@ end_of_the_param:
 	@body:
 		This operator is a really ugly, poor and clueless attempt to reach at least 1% of the
 		power of the perl =~ operator :D[br]
-		It allows some complex string operations to be performed efficently by operating directly
+		It allows some complex string operations to be performed efficiently by operating directly
 		on the left operand (in fact this is a lot faster in KVIrc since at least one step of parsing is skipped).[br]
 		Its basic syntax is:[br]
 		[br][b]<left_operand> =~ <operation>[parameters][/b][br][br]
@@ -467,7 +467,7 @@ end_of_the_param:
 		The complete syntax with parameters is:[br]
 		[br][b]<left_operand> =~ s/<search pattern>/<replacement pattern>/[flags][/b][br][br]
 		where <search pattern> is an extended regular expression to be matched in the <left_operand>
-		and <replacement string> is a special pattern that will replace any occurence found.[br]
+		and <replacement string> is a special pattern that will replace any occurrence found.[br]
 		<search pattern> may contain parentheses to capture parts of the matched text.
 		<replacement string> can contain the escape sequences \\N where N is a number between 1 and 9
 		to be replaced by the captured text.[br]
@@ -476,7 +476,7 @@ end_of_the_param:
 		That's also why we use \\N and not \N.[br]
 		\\0 is a special escape that will be replaced by the entire match (is always valid!).[br]
 		[flags] may be a combination of the letters 'g','i' and 'w'.[br]
-		'g' causes the search to be global and not stop after the first occurence of <search pattern>.[br]
+		'g' causes the search to be global and not stop after the first occurrence of <search pattern>.[br]
 		'i' causes the search to be case insensitive.[br]
 		'm' causes the search to be case minimal (non-greedy).[br]
 		'w' causes the search pattern to be interpreted as a simple wildcard regular expression.
@@ -497,7 +497,7 @@ end_of_the_param:
 			[cmd]echo[/cmd] %a
 			%a << rox
 			[cmd]echo[/cmd] %a
-			%a <, but linux is better!
+			%a <, but Linux is better!
 			[cmd]echo[/cmd] %a
 		[/example]
 	@seealso:

--- a/src/modules/ident/libkviident.cpp
+++ b/src/modules/ident/libkviident.cpp
@@ -116,12 +116,12 @@ bool KviIdentSentinel::event(QEvent *e)
 		} else if(((KviThreadEvent *)e)->id() == KVI_IDENT_THREAD_EVENT_EXITING)
 		{
 			if(_OUTPUT_VERBOSE)
-				if(pTarget)pTarget->outputNoFmt(KVI_OUT_IDENT,__tr("Shutting down identd service (spontaneous action)"));
+				if(pTarget)pTarget->outputNoFmt(KVI_OUT_IDENT,__tr("Shutting down Ident service (spontaneous action)"));
 			stopIdentService();
 		} else if(((KviThreadEvent *)e)->id() == KVI_IDENT_THREAD_EVENT_EXITING_ON_REQUEST)
 		{
 			if(_OUTPUT_VERBOSE)
-				if(pTarget)pTarget->outputNoFmt(KVI_OUT_IDENT,__tr("Shutting down identd service (requested action)"));
+				if(pTarget)pTarget->outputNoFmt(KVI_OUT_IDENT,__tr("Shutting down Ident service (requested action)"));
 		}
 
 		return true;
@@ -221,31 +221,31 @@ void KviIdentDaemon::run()
 
 	if(m_sock == KVI_INVALID_SOCKET)
 	{
-		postMessage(__tr("Can't start the ident service : socket() failed"),0);
+		postMessage(__tr("Can't start the Ident service : socket() failed"),0);
 		goto exit_thread;
 	}
 
 	if(!kvi_socket_setNonBlocking(m_sock))
 	{
-		postMessage(__tr("Can't start the ident service : async setting failed"),0);
+		postMessage(__tr("Can't start the Ident service : async setting failed"),0);
 		goto exit_thread;
 	}
 
 	if(!sa.socketAddress())
 	{
-		postMessage(__tr("Can't enable the ident service : can't setup the listen address"),0);
+		postMessage(__tr("Can't enable the Ident service : can't setup the listen address"),0);
 		goto exit_thread;
 	}
 
 	if(!kvi_socket_bind(m_sock,sa.socketAddress(),((int)(sa.addressLength()))))
 	{
-		postMessage(__tr("Can't start the ident service : bind() failed"),0);
+		postMessage(__tr("Can't start the Ident service : bind() failed"),0);
 		goto exit_thread;
 	}
 
 	if(!kvi_socket_listen(m_sock,128))
 	{
-		postMessage(__tr("Can't start the ident service : listen() failed"),0);
+		postMessage(__tr("Can't start the Ident service : listen() failed"),0);
 		goto exit_thread;
 	}
 
@@ -259,13 +259,13 @@ void KviIdentDaemon::run()
 
 		if(m_sock6 == KVI_INVALID_SOCKET)
 		{
-			postMessage(__tr("Can't start the ident service on IPv6 : socket() failed"),0);
+			postMessage(__tr("Can't start the Ident service on IPv6 : socket() failed"),0);
 			goto ipv6_failure;
 		}
 
 		if(!kvi_socket_setNonBlocking(m_sock6))
 		{
-			postMessage(__tr("Can't start the ident service on IPv6 : async setting failed"),0);
+			postMessage(__tr("Can't start the Ident service on IPv6 : async setting failed"),0);
 			kvi_socket_close(m_sock6);
 			m_sock6 = KVI_INVALID_SOCKET;
 			goto ipv6_failure;
@@ -281,12 +281,12 @@ void KviIdentDaemon::run()
 		if(!kvi_socket_setsockopt(m_sock6,KVI_IPPROTO_IPV6,KVI_IPV6_PROTECTION_LEVEL,(const void*)&iPlu, sizeof(iPlu)))
 		{
 			//this is not a fatal error
-			postMessage(__tr("Can't set the IPv6 ident service protection level to unrestricted: the ident service won't be exposed to the internet"),0);
+			postMessage(__tr("Can't set the IPv6 Ident service protection level to unrestricted: the Ident service won't be exposed to the internet"),0);
 		}
 		#endif
 		if(!sa6.socketAddress())
 		{
-			postMessage(__tr("Can't enable the ident service on IPv6 : can't setup the listen address"),0);
+			postMessage(__tr("Can't enable the Ident service on IPv6 : can't setup the listen address"),0);
 			kvi_socket_close(m_sock6);
 			m_sock6 = KVI_INVALID_SOCKET;
 			goto ipv6_failure;
@@ -294,7 +294,7 @@ void KviIdentDaemon::run()
 
 		if(!kvi_socket_bind(m_sock6,sa6.socketAddress(),((int)(sa6.addressLength()))))
 		{
-			postMessage(__tr("Can't start the ident service on IPv6 : bind() failed"),0);
+			postMessage(__tr("Can't start the Ident service on IPv6 : bind() failed"),0);
 			kvi_socket_close(m_sock6);
 			m_sock6 = KVI_INVALID_SOCKET;
 			goto ipv6_failure;
@@ -303,7 +303,7 @@ void KviIdentDaemon::run()
 
 		if(!kvi_socket_listen(m_sock6,128))
 		{
-			postMessage(__tr("Can't start the ident service on IPv6 : listen() failed"),0);
+			postMessage(__tr("Can't start the Ident service on IPv6 : listen() failed"),0);
 			kvi_socket_close(m_sock6);
 			m_sock6 = KVI_INVALID_SOCKET;
 			goto ipv6_failure;
@@ -319,15 +319,15 @@ ipv6_failure:
 	{
 		if(m_sock6 != KVI_INVALID_SOCKET) {
 			if(_OUTPUT_PARANOIC)
-				postMessage(__tr("Starting identd service (IPv4/v6 on separate namespaces)"),0);
+				postMessage(__tr("Starting Ident service (IPv4/v6 on separate namespaces)"),0);
 		} else {
 			if(_OUTPUT_PARANOIC)
-				postMessage(__tr("Starting identd service (IPv4/v6 in IPv6 namespace)"),0);
+				postMessage(__tr("Starting Ident service (IPv4/v6 in IPv6 namespace)"),0);
 		}
 
 	} else {
 		if(_OUTPUT_PARANOIC)
-			postMessage(__tr("Starting identd service (IPv4)"),0);
+			postMessage(__tr("Starting Ident service (IPv4)"),0);
 	}
 #else //!COMPILE_IPV6_SUPPORT
 	if(_OUTPUT_PARANOIC)
@@ -400,7 +400,7 @@ ipv6_failure:
 						if(!satmp.getStringAddress(szHost))szHost = "unknown";
 						KviIdentRequest * r = new KviIdentRequest(t,szHost.toUtf8().data(),satmp.port());
 						m_pRequestList->append(r);
-						postMessage(__tr("Identd accepting connection"),r);
+						postMessage(__tr("Ident service accepting connection"),r);
 					}
 				}
 			}
@@ -420,7 +420,7 @@ ipv6_failure:
 						if(!satmp.getStringAddress(szHost))szHost = "unknown";
 						KviIdentRequest * r = new KviIdentRequest(t,szHost.toUtf8().data(),satmp.port());
 						m_pRequestList->append(r);
-						postMessage(__tr("Identd accepting connection"),r);
+						postMessage(__tr("Ident service accepting connection"),r);
 					}
 				}
 			}
@@ -443,12 +443,12 @@ ipv6_failure:
 							int err = kvi_socket_error();
 							if(!kvi_socket_recoverableConnectError(err))
 							{
-								postMessage(__tr("Identd socket error : dropping connection"),r);
+								postMessage(__tr("Ident service socket error : dropping connection"),r);
 								dying.append(r);
 							}
 						} else {
 							// connection closed
-							postMessage(__tr("Identd connection closed by remote host"),r);
+							postMessage(__tr("Ident service connection closed by remote host"),r);
 							dying.append(r);
 						}
 					}
@@ -469,7 +469,7 @@ ipv6_failure:
 
 					if(szReq.hasData())
 					{
-						postMessage(__tr("Identd processing request"),r,szReq.ptr());
+						postMessage(__tr("Ident service processing request"),r,szReq.ptr());
 
 						if(kvi_strEqualCI("VERSION",szReq.ptr()))
 						{
@@ -547,14 +547,14 @@ exit_thread:
 	@title:
 		ident.start
 	@short:
-		Starts the builtin ident service
+		Starts the builtin Ident service
 	@syntax:
 		ident.start
 	@description:
-		Starts the builtin ident service.[br]
-		WARNING: the kvirc ident service is just a partial implementation
+		Starts the builtin Ident service.[br]
+		WARNING: the KVIrc Ident service is just a partial implementation
 		of the RFC specifications. You should use is ONLY if you can't get
-		any other ident daemon running on your machine.[br]
+		any other Ident daemon running on your machine.[br]
 */
 
 static bool ident_kvs_cmd_start(KviKvsModuleCommandCall *)
@@ -572,11 +572,11 @@ static bool ident_kvs_cmd_start(KviKvsModuleCommandCall *)
 	@title:
 		ident.stop
 	@short:
-		Stops the ident service
+		Stops the Ident service
 	@syntax:
 		ident.stop
 	@description:
-		Stops the ident service
+		Stops the Ident service
 	@seealso:
 		[cmd]ident.start[/cmd]
 */
@@ -611,7 +611,7 @@ static bool ident_module_can_unload(KviModule *)
 }
 
 KVIRC_MODULE(
-	"Ident",                                              // module name
+	"Ident",                                                // module name
 	"4.0.0",                                                // module version
 	"Copyright (C) 2001 Szymon Stefanek (pragma at kvirc dot net)", // author & (C)
 	"Ident service",


### PR DESCRIPTION
This is also split from #1631 but this contains a more controversial subset of #1660 
What I Tried to do here if it isnt obvious, is in addition to some typos and similar fixes to #1660, to capitalize where possible commands/actions or service but some maybe mixed up at this time.
### Notes:

Please on the cases that fit into the categories below **just add with your review** this should be **lower case** and this **can be all capitals** where applicable. I will fix and push the changes as and when reviews come in.

AUTH command vs auth "authorize(d)"
Some of these may be incorrect where **AUTH means just authorized** and not AUTH the command.
#### Excessive... use of... ellipses...

Oops... lines IMO its Oops!

```
oops
o͝ops,o͞ops/
exclamation informal
exclamation: oops

    used to show recognition of a mistake or minor accident, often as part of an apology.
    "“Oops! I'm sorry. I just made you miss your bus.”"
```

Also most sentences dont seem to be very reticent in nature.
I purposefully capitalized the first letter after ellipses, to bring attention to the fact these have to be changed after review to something appropriate and correct.

Rest review as normal with helpful feedback to aid proper correction.
### Please review and provide helpful feedback

Thank you.
