### PR TITLE
Add IRCHighWay - based on https://irchighway.net/

### DIFF
--- a/data/config/serverdb.kvc
+++ b/data/config/serverdb.kvc
@@ -530,6 +530,16 @@ NServers=1
 NServers=1
 Description=The%20Biggest%20Belarus%20Network
 Encoding=CP-1251
+[IRCHighWay]
+0_Hostname=irc.irchighway.net
+0_Description=Random%20Server%20-%20Port%206660
+0_Port=6660
+1_Hostname=irc.irchighway.net
+1_Description=Random%20Server%20-%20SSL%20Port%209999
+1_Port=9999
+1_SSL=true
+NServers=2
+Description=Your%20IRC%20Superhighway
 [IRC-Hispano]
 0_Hostname=irc.irc-hispano.org
 0_Description=IRC-Hispano:%20Random%20server


### PR DESCRIPTION
Ive no idea about this https://irchighway.net/, since its a main router hub with several ports

Didnt fancy adding Only SSL port like the mess on https://github.com/kvirc/KVIrc/pull/1666

Edit__
Im inclined to including only 1 regular and 1 SSL
--Done with [ci skip] no need to waste resources on silly things.

suggestions welcome.
