### PR TITLE
client: Revamp user mode support

### DIFF
--- a/src/kvirc/kernel/KviIrcConnectionServerInfo.cpp
+++ b/src/kvirc/kernel/KviIrcConnectionServerInfo.cpp
@@ -63,7 +63,6 @@ bool KviIrcConnectionServerInfo::isSupportedChannelType(QChar c)
 	return m_szSupportedChannelTypes.contains(c);
 }
 
-
 void KviIrcConnectionServerInfo::addSupportedCaps(const QString &szCapList)
 {
 	m_bSupportsCap = true;
@@ -264,7 +263,6 @@ void KviIrcConnectionServerInfo::setServerVersion(const QString & version)
 		m_pServInfo = new KviBasicIrcServerInfo(this, version);
 }
 
-
 KviBasicIrcServerInfo::KviBasicIrcServerInfo(KviIrcConnectionServerInfo * pParent, const QString & version)
 {
 	m_szServerVersion = version;
@@ -274,6 +272,566 @@ KviBasicIrcServerInfo::KviBasicIrcServerInfo(KviIrcConnectionServerInfo * pParen
 KviBasicIrcServerInfo::~KviBasicIrcServerInfo()
 {
 }
+
+////////////////
+// User modes
+////////////////
+
+const QString & KviBasicIrcServerInfo::getUserModeDescription(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'O': return __tr2qs("O: Local IRC Operator (locop)"); break;
+		case 'a': return __tr2qs("a: Server administrator"); break;
+		case 'c': return __tr2qs("c: Recipient for cconn messages"); break;
+		case 'd': return __tr2qs("d: Recipient for server debug notices"); break;
+		case 'f': return __tr2qs("f: Recipient for full server notices"); break;
+		case 'i': return __tr2qs("i: Invisible"); break;
+		case 'k': return __tr2qs("k: Recipient for server KILL messages"); break;
+		case 'n': return __tr2qs("n: Recipient for nick changes"); break;
+		case 'o': return __tr2qs("o: IRC Operator (oper)"); break;
+		case 'r': return __tr2qs("r: User with restricted connection (or recipient for messages about rejected bots)"); break;
+		case 's': return __tr2qs("s: Recipient for server notices"); break;
+		case 'w': return __tr2qs("w: Recipient for WALLOPS messages"); break;
+		case 'y': return __tr2qs("y: Recipient for spy notices"); break;
+		case 'z': return __tr2qs("z: Recipient for oper WALLOP messages"); break;
+	}
+	return KviQString::Empty;
+}
+
+const QString & KviIrcuIrcServerInfo::getUserModeDescription(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'I': return __tr2qs("I: Idle time hidden"); break;
+		case 'd': return __tr2qs("d: Deaf"); break;
+		case 'g': return __tr2qs("g: Recipient for server debug notices"); break;
+		case 'k': return __tr2qs("k: Network service"); break;
+		case 'n': return __tr2qs("n: Channels hidden from WHOIS"); break;
+		case 'r': return __tr2qs("r: Registered)"); break;
+		case 'x': return __tr2qs("x: Host hidden"); break;
+	}
+	return KviBasicIrcServerInfo::getUserModeDescription(mode);
+}
+
+const QString & KviSnircdIrcServerInfo::getUserModeDescription(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'P': return __tr2qs("P: Recipient for notices on WHOIS"); break;
+		case 'R': return __tr2qs("R: Only receive private messages from registered nicks"); break;
+		case 'X': return __tr2qs("X: Special powers"); break;
+		case 'h': return __tr2qs("h: Host changed"); break;
+	}
+	return KviIrcuIrcServerInfo::getUserModeDescription(mode);
+}
+
+const QString & KviDarenetIrcServerInfo::getUserModeDescription(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'F': return __tr2qs("F: Disable fake lag"); break;
+		case 'H': return __tr2qs("H: Hide oper status"); break;
+		case 'N': return __tr2qs("N: Network administrator"); break;
+		case 'P': return __tr2qs("P: Recipient for notices on WHOIS"); break;
+		case 'R': return __tr2qs("R: Only receive private messages from registered nicks"); break;
+		case 'X': return __tr2qs("X: Special powers"); break;
+		case 'a': return __tr2qs("a: Server administrator"); break;
+	}
+	return KviIrcuIrcServerInfo::getUserModeDescription(mode);
+}
+
+const QString & KviHybridServerInfo::getUserModeDescription(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'D': return __tr2qs("D: Deaf"); break;
+		case 'F': return __tr2qs("F: Recipient for far connect/quit notices"); break;
+		case 'G': return __tr2qs("G: Only accept private messages from users in common channels"); break;
+		case 'H': return __tr2qs("H: Hide oper status"); break;
+		case 'R': return __tr2qs("R: Only receive private messages from registered nicks"); break;
+		case 'S': return __tr2qs("S: Connected over SSL"); break;
+		case 'W': return __tr2qs("W: Connected over WEBIRC"); break;
+		case 'a': return __tr2qs("a: Server administrator"); break;
+		case 'b': return __tr2qs("b: Recipient for bot/join flood warnings"); break;
+		case 'e': return __tr2qs("e: Recipient for server introduction and split notices"); break;
+		case 'f': return __tr2qs("f: Recipient for full I-Line notices"); break;
+		case 'g': return __tr2qs("g: Only allow accepted clients to message you"); break;
+		case 'j': return __tr2qs("j: Recipient for rejected client notices"); break;
+		case 'l': return __tr2qs("l: Recipient for LOCOPS"); break;
+		case 'p': return __tr2qs("p: Channels hidden from WHOIS"); break;
+		case 'q': return __tr2qs("q: Idle time hidden from WHOIS"); break;
+		case 'r': return __tr2qs("r: Registered"); break;
+		case 'u': return __tr2qs("u: Recipient for unauthorized client notices"); break;
+		case 'x': return __tr2qs("x: Host hidden"); break;
+		case 'y': return __tr2qs("y: Can see stats/links/admin requests"); break;
+	}
+	return KviBasicIrcServerInfo::getUserModeDescription(mode);
+}
+
+const QString & KviIrcdSevenIrcServerInfo::getUserModeDescription(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'O': return __tr2qs("O: IRC Help Operator"); break;
+		case 'Q': return __tr2qs("Q: Prevents you from being affected by channel forwarding"); break;
+		case 'S': return __tr2qs("S: Network service"); break;
+		case 'Z': return __tr2qs("Z: Connected over SSL"); break;
+		case 'h': return __tr2qs("h: Marks you as a helper in /stats p"); break;
+		case 'p': return __tr2qs("p: Enable oper overrides"); break;
+	}
+	return KviHybridServerInfo::getUserModeDescription(mode);
+}
+
+const QString & KviPlexusIrcServerInfo::getUserModeDescription(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'C': return __tr2qs("C: Prevent CTCPs"); break;
+		case 'N': return __tr2qs("N: Network administrator"); break;
+		case 'U': return __tr2qs("U: Network service"); break;
+		case 'X': return __tr2qs("X: Recipient for new server introduction and split messages"); break;
+		case 'w': return __tr2qs("w: Recipient for server WALLOPS"); break;
+		case 'z': return __tr2qs("z: Recipient for oper WALLOPS"); break;
+		case 'y': return __tr2qs("y: Recipient for notices on WHOIS"); break;
+		case 'a': return __tr2qs("a: Server administrator"); break;
+		case 'q': return __tr2qs("q: Services administrator, can use SQUIT"); break;
+	}
+	return KviHybridServerInfo::getUserModeDescription(mode);
+}
+
+const QString & KviOftcIrcServerInfo::getUserModeDescription(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'C': return __tr2qs("C: Recipient for far connect/quit notices"); break;
+		case 'P': return __tr2qs("P: Network service"); break;
+		case 'w': return __tr2qs("w: Recipient for server WALLOPS"); break;
+		case 'z': return __tr2qs("z: Recipient for oper WALLOPS"); break;
+	}
+	return KviHybridServerInfo::getUserModeDescription(mode);
+}
+
+const QString & KviBahamutIrcServerInfo::getUserModeDescription(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'A': return __tr2qs("A: Server administrator"); break;
+		case 'C': return __tr2qs("C: Only accept private messages from users in common channels"); break;
+		case 'F': return __tr2qs("F: Can bypass the IRCd's recvq throttling"); break;
+		case 'I': return __tr2qs("I: Hide oper status"); break;
+		case 'K': return __tr2qs("K: Can see U:lined kill messages"); break;
+		case 'R': return __tr2qs("R: Only receive private messages from registered nicks"); break;
+		case 'S': return __tr2qs("S: Connected over SSL"); break;
+		case 'X': return __tr2qs("X: Squelch without notice"); break;
+		case 'a': return __tr2qs("a: Services administrator"); break;
+		case 'b': return __tr2qs("b: Can see CHATOPS notices"); break;
+		case 'e': return __tr2qs("e: Recipient for blocked DCC notices"); break;
+		case 'f': return __tr2qs("f: Recipient for flood warnings"); break;
+		case 'g': return __tr2qs("g: Recipient for GLOBOPS notices"); break;
+		case 'h': return __tr2qs("h: Available for help (helpop)"); break;
+		case 'j': return __tr2qs("j: Recipient for rejected client notices"); break;
+		case 'm': return __tr2qs("m: Recipient for spambot notices"); break;
+		case 'n': return __tr2qs("n: Recipient for routing notices"); break;
+		case 'r': return __tr2qs("r: Registered"); break;
+		case 's': return __tr2qs("s: Recipient for server KILL messages"); break;
+		case 'x': return __tr2qs("x: Squelch with notice"); break;
+		case 'y': return __tr2qs("y: Can see certain information requests (e.g. /stats)"); break;
+	}
+	return KviBasicIrcServerInfo::getUserModeDescription(mode);
+}
+
+const QString & KviUnreal32IrcServerInfo::getUserModeDescription(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'A': return __tr2qs("A: Server administrator"); break;
+		case 'B': return __tr2qs("B: Marks as being a bot"); break;
+		case 'C': return __tr2qs("C: Co-Admin"); break;
+		case 'F': return __tr2qs("F: Override filter settings"); break;
+		case 'G': return __tr2qs("G: Filter out bad words"); break;
+		case 'H': return __tr2qs("H: Hide oper status"); break;
+		case 'I': return __tr2qs("I: Idle time hidden from WHOIS"); break;
+		case 'N': return __tr2qs("N: Network administrator"); break;
+		case 'R': return __tr2qs("R: Only receive private messages from registered nicks"); break;
+		case 'S': return __tr2qs("S: Network service"); break;
+		case 'T': return __tr2qs("T: Prevent CTCPs"); break;
+		case 'V': return __tr2qs("V: Connected over WebTV"); break;
+		case 'W': return __tr2qs("W: Recipient for notices on WHOIS"); break;
+		case 'a': return __tr2qs("a: Services administrator"); break;
+		case 'd': return __tr2qs("d: Deaf"); break;
+		case 'g': return __tr2qs("g: Can send & read LOCOPS and GLOBOPS"); break;
+		case 'h': return __tr2qs("h: Available for help (helpop)"); break;
+		case 'p': return __tr2qs("p: Channels hidden from WHOIS"); break;
+		case 'q': return __tr2qs("q: Immune to kicks (except U-Line)"); break;
+		case 'r': return __tr2qs("r: Registered"); break;
+		case 't': return __tr2qs("t: Using a vhost"); break;
+		case 'v': return __tr2qs("v: Recipient for infected DCC SEND rejection notices"); break;
+		case 'x': return __tr2qs("x: Host hidden"); break;
+		case 'z': return __tr2qs("z: Connected over SSL"); break;
+	}
+	return KviBasicIrcServerInfo::getUserModeDescription(mode);
+}
+
+const QString & KviInspIRCdIrcServerInfo::getUserModeDescription(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'c': return __tr2qs("c: Prevent CTCPs"); break;
+		case 'd': return __tr2qs("d: Deaf"); break;
+		case 'g': return __tr2qs("g: Server side ignore"); break;
+		case 'h': return __tr2qs("h: Available for help (helpop)"); break;
+		case 'k': return __tr2qs("k: Network service"); break;
+		case 'r': return __tr2qs("r: Registered"); break;
+		case 'x': return __tr2qs("x: Host hidden"); break;
+		case 'B': return __tr2qs("B: Marks as being a bot"); break;
+		case 'G': return __tr2qs("G: Censor bad words"); break;
+		case 'H': return __tr2qs("H: Hide oper status"); break;
+		case 'I': return __tr2qs("I: Channels hidden from WHOIS"); break;
+		case 'Q': return __tr2qs("Q: Marks an IRC operator as invisible from user lists"); break;
+		case 'R': return __tr2qs("R: Only receive private messages from registered nicks"); break;
+		case 'S': return __tr2qs("S: Strip colors out of private messages"); break;
+		case 'W': return __tr2qs("W: Recipient for notices on WHOIS"); break;
+	}
+	return KviBasicIrcServerInfo::getUserModeDescription(mode);
+}
+
+const QString & KviCritenIrcServerInfo::getUserModeDescription(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'C': return __tr2qs("C: Can see CHATOPS notices"); break;
+		case 'D': return __tr2qs("D: Has seen DCCALLOW warning message"); break;
+		case 'F': return __tr2qs("F: Recipient for far connect/quit notices"); break;
+		case 'P': return __tr2qs("P: Services administrator"); break;
+		case 'S': return __tr2qs("S: Network service"); break;
+		case 'W': return __tr2qs("W: Recipient for notices on WHOIS"); break;
+		case 'Z': return __tr2qs("Z: Services root administrator"); break;
+		case 'a': return __tr2qs("a: Services operator"); break;
+		case 'e': return __tr2qs("e: Recipient for blocked DCC notices"); break;
+		case 'f': return __tr2qs("f: Recipient for exess flood notices"); break;
+		case 'g': return __tr2qs("g: Recipient for GLOBOPS notices"); break;
+		case 'h': return __tr2qs("h: Available for help (helpop)"); break;
+		case 'm': return __tr2qs("m: Recipient for spam warning notices"); break;
+		case 'n': return __tr2qs("n: Recipient for NETINFO and routing notices"); break;
+		case 'p': return __tr2qs("p: Protected IRC operator"); break;
+		case 'r': return __tr2qs("r: Registered"); break;
+		case 'x': return __tr2qs("x: Host hidden"); break;
+	}
+	return KviBasicIrcServerInfo::getUserModeDescription(mode);
+}
+
+const QString & KviIrcdRatboxIrcServerInfo::getUserModeDescription(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'C': return __tr2qs("C: Prevent CTCPs"); break;
+		case 'D': return __tr2qs("D: Deaf"); break;
+		case 'Z': return __tr2qs("Z: Recipient for oper spy notices"); break;
+		case 'a': return __tr2qs("a: Server administrator"); break;
+		case 'b': return __tr2qs("b: Recipient for bot/join flood warnings"); break;
+		case 'f': return __tr2qs("f: Recipient for full I-Line notices"); break;
+		case 'g': return __tr2qs("g: Only allow accepted clients to message you"); break;
+		case 'l': return __tr2qs("l: Recipient for LOCOPS"); break;
+		case 'r': return __tr2qs("r: Recipient for rejected client notices"); break;
+		case 'u': return __tr2qs("u: Recipient for unauthorised client notices"); break;
+		case 'x': return __tr2qs("x: Recipient for remote server connection and split notices"); break;
+		case 'z': return __tr2qs("z: Recipient for OPERWALL messages"); break;
+	}
+	return KviBasicIrcServerInfo::getUserModeDescription(mode);
+}
+
+const QString & KviHyperionIrcServerInfo::getUserModeDescription(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'A': return __tr2qs("A: Can see all servers and IP addresses"); break;
+		case 'B': return __tr2qs("B: Allows the use of SETHOST, SETNAME, and SETIDENT commands on other people"); break;
+		case 'C': return __tr2qs("C: Prevent CTCPs"); break;
+		case 'D': return __tr2qs("D: Allows the use of DIE and RESTART"); break;
+		case 'E': return __tr2qs("E: Only receive private messages from registered nicks"); break;
+		case 'F': return __tr2qs("F: Immune to flood protection"); break;
+		case 'G': return __tr2qs("G: Allows the use of KILL for users on remote servers"); break;
+		case 'H': return __tr2qs("H: Allows the use of REHASH"); break;
+		case 'I': return __tr2qs("I: Prevents you from receiving INVITEs"); break;
+		case 'K': return __tr2qs("K: Allows the use of KLINE"); break;
+		case 'L': return __tr2qs("L: Allows the use of 4-argument LUSERS to force a recount"); break;
+		case 'M': return __tr2qs("M: Allows the use of NOTICE based on mask"); break;
+		case 'N': return __tr2qs("N: Can override Q-Lines"); break;
+		case 'P': return __tr2qs("P: Allows the use of SETHOST, SETIDENT and SETNAME"); break;
+		case 'Q': return __tr2qs("Q: Prevents you from being affected by channel forwarding"); break;
+		case 'R': return __tr2qs("R: Allows the use of CONNECT, SQUIT, and HTM"); break;
+		case 'S': return __tr2qs("S: Allows the use of remotely running server commands"); break;
+		case 'T': return __tr2qs("T: Allows you to appear in /stats p"); break;
+		case 'U': return __tr2qs("U: Allows the use of UNKLINE"); break;
+		case 'V': return __tr2qs("V: Allows the use of MAP, LINKS, as well as receiving connection information");
+		case 'W': return __tr2qs("W: Allows the ability to send WALLOPS"); break;
+		case 'X': return __tr2qs("X: Grants access to experimental features"); break;
+		case 'Y': return __tr2qs("Y: Displays extra information during netjoins"); break;
+		case 'Z': return __tr2qs("Z: Allows the ability to send OPERWALL messages"); break;
+		case 'a': return __tr2qs("a: Can see all users and channels"); break;
+		case 'b': return __tr2qs("b: Recipient for spam warning notices"); break;
+		case 'c': return __tr2qs("c: Recipient for connect and netjoin notices"); break;
+		case 'e': return __tr2qs("e: Registered"); break;
+		case 'f': return __tr2qs("f: Recipient for full I-Line notices"); break;
+		case 'h': return __tr2qs("h: Sets user in high priority mode"); break;
+		case 'j': return __tr2qs("j: Allows the use of auto D-Lines"); break;
+		case 'l': return __tr2qs("l: Recipient for new channel creation notices"); break;
+		case 'm': return __tr2qs("m: Can't be KICKed, DEOPed, or D-Lined"); break;
+		case 'p': return __tr2qs("p: Allows implicit access in all channels, regardless of status"); break;
+		case 'r': return __tr2qs("r: Recipient for notices on users attempting to use invalid nicks, Q-Lined or X-Lined nicks"); break;
+		case 't': return __tr2qs("t: Allows the use of channel logging"); break;
+		case 'u': return __tr2qs("u: Allows the ability to join more channels than the default IRCd limit"); break;
+		case 'v': return __tr2qs("v: Allows the ability to view oper privileges via WHOIS"); break;
+		case 'x': return __tr2qs("x: Allows the ability to see netjoins"); break;
+		case 'z': return __tr2qs("z: Recipient for OPERWALL messages"); break;
+		case '0': return __tr2qs("0: Allows the ability to view oper information"); break;
+		case '1': return __tr2qs("1: Allows the ability to view I-Lines and Y-Lines"); break;
+		case '2': return __tr2qs("2: Allows the ability to view D-Lines and K-Lines"); break;
+		case '3': return __tr2qs("3: Allows the ability to view Q-Lines and X-Lines"); break;
+		case '4': return __tr2qs("4: Allows the ability to use STATS T"); break;
+		case '5': return __tr2qs("5: Allows the ability to use STATS ?"); break;
+		case '9': return __tr2qs("9: Allows the use of TESTLINE"); break;
+		case '*': return __tr2qs("*: Allows the user to grant umodes they have access to to other people"); break;
+		case '@': return __tr2qs("@: allows the user to change their host to anything with the SETHOST command"); break;
+	}
+	return KviBasicIrcServerInfo::getUserModeDescription(mode);
+}
+
+////////////////
+// UMODE Requirements
+////////////////
+
+QChar KviBasicIrcServerInfo::getUserModeRequirement(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'O': return 'O'; case 'a': return 'a';
+
+		case 'c': case 'd': case 'f': case 'k':
+		case 'n': case 'o': case 's': case 'y':
+		case 'z': return 'o';
+	}
+	return 0;
+}
+
+QChar KviUnreal32IrcServerInfo::getUserModeRequirement(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'A': return 'A'; case 'C': return 'C';
+		case 'N': return 'N'; case 'O': return 'O';
+		case 'a': return 'a'; case 'r': return 'r';
+		case 't': return 't';
+
+		case 'S': case 'V': case 'x': case 'z':
+		return 1;
+
+		case 'F': case 'H': case 'W': case 'f':
+		case 'g': case 'h': case 'o': case 's':
+		case 'v': case 'w': return 'o';
+
+		case 'q': return 'a';
+	}
+	return 0;
+}
+
+QChar KviHybridServerInfo::getUserModeRequirement(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'a': return 'a';
+
+		case 'S': case 'W': case 'r': case 'x':
+		return 1;
+
+		case 'F': case 'H': case 'c': case 'd':
+		case 'e': case 'f': case 'j': case 'k':
+		case 'l': case 'n': case 'o': case 's':
+		case 'u': case 'y': return 'o';
+	}
+	return 0;
+}
+
+QChar KviCritenIrcServerInfo::getUserModeRequirement(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'O': return 'O';
+
+		case 'P': case 'S': case 'Z': case 'a':
+		case 'r': case 'x': return 1;
+
+		case 'c': case 'C': case 'd': case 'e':
+		case 'f': case 'F': case 'g': case 'm':
+		case 'n': case 'p': case 'W': case 'y':
+		case 'h': case 'o': return 'o';
+	}
+	return 0;
+}
+
+QChar KviBahamutIrcServerInfo::getUserModeRequirement(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'A': return 'A'; case 'O': return 'O';
+
+		case 'S': case 'W': case 'X': case 'a':
+		case 'r': case 'w': case 'x': return 1;
+
+		case 'F': case 'I': case 'K': case 'b':
+		case 'c': case 'd': case 'e': case 'f':
+		case 'g': case 'h': case 'j': case 'k':
+		case 'm': case 'n': case 'o': case 'y':
+		return 'o';
+	}
+	return 0;
+}
+
+QChar KviHyperionIrcServerInfo::getUserModeRequirement(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'e': return 1;
+
+		case 'A': case 'B': case 'D': case 'F':
+		case 'G': case 'K': case 'L': case 'M':
+		case 'N': case 'P': case 'R': case 'S':
+		case 'T': case 'U': case 'V': case 'W':
+		case 'X': case 'Y': case 'Z': case 'a':
+		case 'b': case 'c': case 'd': case 'f':
+		case 'h': case 'H': case 'j': case 'k':
+		case 'l': case 'm': case 'n': case 'o':
+		case 'p': case 'r': case 'u': case 'v':
+		case 'x': case 'y': case 'z': case '0':
+		case '1': case '2': case '3': case '4':
+		case '5': case '9': case '*': case '@':
+		return 'o';
+	}
+	return 0;
+}
+
+QChar KviIrcdSevenIrcServerInfo::getUserModeRequirement(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'O': return 'O'; case 'a': return 'a';
+
+		case 'S': case 'Z': return 1;
+
+		case 'h': case 'l': case 'o': case 'p':
+		case 'z': return 'o';
+	}
+	return 0;
+}
+
+QChar KviIrcdRatboxIrcServerInfo::getUserModeRequirement(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'a': return 'a';
+
+		case 'Z': case 'b': case 'c': case 'd':
+		case 'f': case 'k': case 'l': case 'n':
+		case 'o': case 'r': case 'u': case 'x':
+		case 'y': case 'z': return 'o';
+	}
+	return 0;
+}
+
+QChar KviInspIRCdIrcServerInfo::getUserModeRequirement(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'k': case 'r': case 'x': return 1;
+
+		case 'H': case 'Q': case 'W': case 'h':
+		case 'o': return 'o';
+	}
+	return 0;
+}
+
+QChar KviIrcuIrcServerInfo::getUserModeRequirement(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'O': return 'O';
+
+		case 'k': case 'r': case 'x': return 1;
+
+		case 'I': case 'g': case 'n': case 'o':
+		return 'o';
+	}
+	return 0;
+}
+
+QChar KviSnircdIrcServerInfo::getUserModeRequirement(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'O': return 'O';
+
+		case 'k': case 'r': case 'x': return 1;
+
+		case 'I': case 'P': case 'X': case 'g':
+		case 'n': case 'o': return 'o';
+	}
+	return 0;
+}
+
+QChar KviPlexusIrcServerInfo::getUserModeRequirement(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'N': return 'N'; case 'a': return 'a';
+		case 'q': return 'q';
+
+		case 'S': case 'U': case 'W': case 'r':
+		return 1;
+
+		case 'F': case 'X': case 'b': case 'c':
+		case 'd': case 'f': case 'j': case 'k':
+		case 'l': case 'n': case 'o': case 'u':
+		case 'y': case 'z': return 'o';
+	}
+	return 0;
+}
+
+QChar KviOftcIrcServerInfo::getUserModeRequirement(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'a': return 'a';
+
+		case 'P': case 'S': return 1;
+
+		case 'C': case 'b': case 'c': case 'd':
+		case 'f': case 'k': case 'l': case 'n':
+		case 'o': case 'r': case 'u': case 'y':
+		case 'x': case 'z': return 'o';
+	}
+	return 0;
+}
+
+QChar KviDarenetIrcServerInfo::getUserModeRequirement(QChar mode)
+{
+	switch(mode.unicode())
+	{
+		case 'N': return 'N'; case 'O': return 'O';
+		case 'a': return 'a';
+
+		case 'k': case 'x': return 1;
+
+		case 'F': case 'H': case 'I': case 'P':
+		case 'X': case 'g': case 'n': case 'o':
+		case 'z': return 'o';
+	}
+	return 0;
+}
+
+////////////////
+// Channel modes
+////////////////
 
 const QString & KviBasicIrcServerInfo::getChannelModeDescription(char mode)
 {
@@ -300,27 +858,6 @@ const QString & KviBasicIrcServerInfo::getChannelModeDescription(char mode)
 	return KviQString::Empty;
 }
 
-const QString & KviBasicIrcServerInfo::getUserModeDescription(QChar mode)
-{
-	switch(mode.unicode())
-	{
-		case 'o': return __tr2qs("o: IRC operator (OPER)"); break;
-		case 'O': return __tr2qs("O: Local IRC operator (LOCOP)"); break;
-		case 'i': return __tr2qs("i: Invisible"); break;
-		case 'w': return __tr2qs("w: Recipient for WALLOPS messages"); break;
-		case 'r': return __tr2qs("r: User with restricted connection (or recipient for messages about rejected bots)"); break;
-		case 's': return __tr2qs("s: Recipient for server notices"); break;
-		case 'z': return __tr2qs("z: Recipient for oper wallop messages"); break;
-		case 'c': return __tr2qs("c: Recipient for cconn messages"); break;
-		case 'k': return __tr2qs("k: Recipient for server kill messages"); break;
-		case 'f': return __tr2qs("f: Recipient for full server notices"); break;
-		case 'y': return __tr2qs("y: Spy :)"); break;
-		case 'd': return __tr2qs("d: Obscure 'DEBUG' flag"); break;
-		case 'n': return __tr2qs("n: Recipient for nick changes"); break;
-	}
-	return KviQString::Empty;
-}
-
 const QString & KviUnrealIrcServerInfo::getChannelModeDescription(char mode)
 {
 	switch(mode)
@@ -335,7 +872,7 @@ const QString & KviUnrealIrcServerInfo::getChannelModeDescription(char mode)
 		case 'O': return __tr2qs("IRC-Op only channel"); break;
 		case 'Q': return __tr2qs("Disallow KICK (unless U-Line)"); break;
 		case 'R': return __tr2qs("Only registered nicks can join"); break;
-		case 'a': return __tr2qs("Protected/admin nicks"); break;
+		case 'a': return __tr2qs("Protected/administrator nicks"); break;
 		case 'c': return __tr2qs("No control codes (colors, bold, ..)"); break;
 		case 'f': return __tr2qs("Flood protection (<num><type>:<secs>)"); break;
 		case 'h': return __tr2qs("Half-operators"); break;
@@ -397,7 +934,6 @@ const QString & KviIrcdSevenIrcServerInfo::getChannelModeDescription(char mode)
 {
 	switch(mode)
 	{
-		case 'C': return __tr2qs("Forbid channel CTCPs"); break;
 		case 'F': return __tr2qs("Enable forwarding"); break;
 		case 'L': return __tr2qs("Large ban/exempt/invex lists (staff only)"); break;
 		case 'M': return __tr2qs("Disallow kicking opers (staff only)"); break;
@@ -406,7 +942,6 @@ const QString & KviIrcdSevenIrcServerInfo::getChannelModeDescription(char mode)
 		case 'R': return __tr2qs("Only registered nicks can join"); break;
 		case 'S': return __tr2qs("Strip colors"); break;
 		case 'T': return __tr2qs("Forbid channel NOTICEs"); break;
-		case 'c': return __tr2qs("No control codes (colors, bold, ..)"); break;
 		case 'f': return __tr2qs("Forward to another channel on uninvited"); break;
 		case 'g': return __tr2qs("Allow anybody to invite"); break;
 		case 'j': return __tr2qs("Join throttling (<num>:<secs>)"); break;
@@ -415,7 +950,7 @@ const QString & KviIrcdSevenIrcServerInfo::getChannelModeDescription(char mode)
 		case 'r': return __tr2qs("Need auth to join channel"); break;
 		case 'z': return __tr2qs("Reduced moderation for ops"); break;
 	}
-	return KviBasicIrcServerInfo::getChannelModeDescription(mode);
+	return KviIrcdSevenIrcServerInfo::getChannelModeDescription(mode);
 }
 
 const QString & KviBahamutIrcServerInfo::getChannelModeDescription(char mode)
@@ -472,7 +1007,7 @@ const QString & KviInspIRCdIrcServerInfo::getChannelModeDescription(char mode)
 		case 'R': return __tr2qs("Only registered nicks can join"); break;
 		case 'S': return __tr2qs("Strip colors"); break;
 		case 'T': return __tr2qs("Forbid channel NOTICEs"); break;
-		case 'a': return __tr2qs("Protected/admin nicks"); break;
+		case 'a': return __tr2qs("Protected/administrator nicks"); break;
 		case 'c': return __tr2qs("No control codes (colors, bold, ..)"); break;
 		case 'f': return __tr2qs("Kick/[*]ban on message flood ([*]<num>:<secs>)"); break;
 		case 'g': return __tr2qs("Block message matching"); break;
@@ -531,7 +1066,7 @@ const QString & KviPlexusIrcServerInfo::getChannelModeDescription(char mode)
 	{
 		case 'B': return __tr2qs("Bandwidth Saver"); break;
 		case 'N': return __tr2qs("Forbid channel NOTICEs"); break;
-		case 'a': return __tr2qs("Protected/admin nicks"); break;
+		case 'a': return __tr2qs("Protected/administrator nicks"); break;
 		case 'p': return __tr2qs("Paranoia"); break;
 		case 'q': return __tr2qs("Channel owners"); break;
 		case 'z': return __tr2qs("Persistent (staff only)"); break;

--- a/src/kvirc/kernel/KviIrcConnectionServerInfo.h
+++ b/src/kvirc/kernel/KviIrcConnectionServerInfo.h
@@ -315,6 +315,8 @@ public:
 	const QString & getChannelModeDescription(char mode) { return m_pServInfo->getChannelModeDescription(mode); };
 	const QString & getUserModeDescription(QChar mode) { return m_pServInfo->getUserModeDescription(mode); };
 
+	// Returning 1 means the mode can never be set by the user. Returning 0 means the mode is free to set.
+	// Returning a QChar means the mode has another mode dependency (the char we're returning)
 	QChar getUserModeRequirement(QChar mode) { return m_pServInfo ? m_pServInfo->getUserModeRequirement(mode) : 0; };
 
 	bool isSupportedChannelType(QChar c);

--- a/src/kvirc/kernel/KviIrcConnectionServerInfo.h
+++ b/src/kvirc/kernel/KviIrcConnectionServerInfo.h
@@ -34,7 +34,7 @@ class KviIrcConnectionServerInfo;
 
 class KVIRC_API KviBasicIrcServerInfo
 {
-	//ircnet
+	// ircnet
 protected:
 	QString m_szServerVersion;
 	KviIrcConnectionServerInfo * m_pParent;
@@ -44,9 +44,11 @@ public:
 public:
 	virtual const QString & getChannelModeDescription(char mode);
 	virtual const QString & getUserModeDescription(QChar mode);
+	virtual QChar getUserModeRequirement(QChar mode);
 	virtual char getRegisterModeChar() { return 0; };
 	virtual const char * getSoftware() { return "Ircd"; };
 	virtual bool getNeedsOpToListModeseI() { return false; };
+	virtual bool getNeedsOperToSetS() { return false; };
 };
 
 class KVIRC_API KviUnrealIrcServerInfo : public KviBasicIrcServerInfo
@@ -54,10 +56,11 @@ class KVIRC_API KviUnrealIrcServerInfo : public KviBasicIrcServerInfo
 public:
 	KviUnrealIrcServerInfo(KviIrcConnectionServerInfo * pParent = 0, const QString & version = KviQString::Empty)
 		:KviBasicIrcServerInfo(pParent, version) {;};
+	virtual const QString & getChannelModeDescription(char mode);
 	virtual char getRegisterModeChar() { return 'r'; };
 	virtual const char * getSoftware() { return "Unreal"; };
 	virtual bool getNeedsOpToListModeseI() { return false; };
-	virtual const QString & getChannelModeDescription(char mode);
+	virtual bool getNeedsOperToSetS() { return true; };
 };
 
 class KVIRC_API KviUnreal32IrcServerInfo : public KviUnrealIrcServerInfo
@@ -67,8 +70,10 @@ class KVIRC_API KviUnreal32IrcServerInfo : public KviUnrealIrcServerInfo
 public:
 	KviUnreal32IrcServerInfo(KviIrcConnectionServerInfo * pParent = 0, const QString & version = KviQString::Empty)
 		:KviUnrealIrcServerInfo(pParent, version) {;};
-	virtual const char * getSoftware() { return "Unreal32"; };
 	virtual const QString & getChannelModeDescription(char mode);
+	virtual const QString & getUserModeDescription(QChar mode);
+	virtual QChar getUserModeRequirement(QChar mode);
+	virtual const char * getSoftware() { return "Unreal32"; };
 };
 
 class KVIRC_API KviHybridServerInfo : public KviBasicIrcServerInfo
@@ -77,27 +82,31 @@ class KVIRC_API KviHybridServerInfo : public KviBasicIrcServerInfo
 public:
 	KviHybridServerInfo(KviIrcConnectionServerInfo * pParent = 0, const QString & version = KviQString::Empty)
 		:KviBasicIrcServerInfo(pParent, version) {;};
+	virtual const QString & getChannelModeDescription(char mode);
+	virtual const QString & getUserModeDescription(QChar mode);
+	virtual QChar getUserModeRequirement(QChar mode);
 	virtual char getRegisterModeChar() { return 'r'; };
 	virtual const char * getSoftware() { return "Hybrid"; };
 	virtual bool getNeedsOpToListModeseI() { return false; };
-	virtual const QString & getChannelModeDescription(char mode);
 };
 
 class KVIRC_API KviCritenIrcServerInfo : public KviBasicIrcServerInfo
 {
-	//abjects
+	// abjects
 public:
 	KviCritenIrcServerInfo(KviIrcConnectionServerInfo * pParent = 0, const QString & version = KviQString::Empty)
 		:KviBasicIrcServerInfo(pParent, version) {;};
+	virtual const QString & getChannelModeDescription(char mode);
+	virtual const QString & getUserModeDescription(QChar mode);
+	virtual QChar getUserModeRequirement(QChar mode);
 	virtual char getRegisterModeChar() { return 'r'; };
 	virtual const char * getSoftware() { return "Criten"; };
 	virtual bool getNeedsOpToListModeseI() { return true; };
-	virtual const QString & getChannelModeDescription(char mode);
 };
 
 class KVIRC_API KviNemesisIrcServerInfo : public KviCritenIrcServerInfo
 {
-	//criten
+	// criten
 public:
 	KviNemesisIrcServerInfo(KviIrcConnectionServerInfo * pParent = 0, const QString & version = KviQString::Empty)
 		:KviCritenIrcServerInfo(pParent, version) {;};
@@ -106,14 +115,16 @@ public:
 
 class KVIRC_API KviBahamutIrcServerInfo : public KviBasicIrcServerInfo
 {
-	//dalnet, azzurranet
+	// dalnet, azzurranet
 public:
 	KviBahamutIrcServerInfo(KviIrcConnectionServerInfo * pParent = 0, const QString & version = KviQString::Empty)
 		:KviBasicIrcServerInfo(pParent, version) {;};
+	virtual const QString & getChannelModeDescription(char mode);
+	virtual const QString & getUserModeDescription(QChar mode);
+	virtual QChar getUserModeRequirement(QChar mode);
 	virtual char getRegisterModeChar() { return 'r'; };
 	virtual const char * getSoftware() { return "Bahamut"; };
 	virtual bool getNeedsOpToListModeseI() { return false; };
-	virtual const QString & getChannelModeDescription(char mode);
 };
 
 class KVIRC_API KviHyperionIrcServerInfo : public KviBasicIrcServerInfo
@@ -122,102 +133,124 @@ class KVIRC_API KviHyperionIrcServerInfo : public KviBasicIrcServerInfo
 public:
 	KviHyperionIrcServerInfo(KviIrcConnectionServerInfo * pParent = 0, const QString & version = KviQString::Empty)
 		:KviBasicIrcServerInfo(pParent, version) {;};
+	virtual const QString & getUserModeDescription(QChar mode);
+	virtual QChar getUserModeRequirement(QChar mode);
 	virtual char getRegisterModeChar() { return 'e'; };
 	virtual const char * getSoftware() { return "Hyperion"; };
 	virtual bool getNeedsOpToListModeseI() { return true; };
 };
 
-class KVIRC_API KviIrcdSevenIrcServerInfo : public KviBasicIrcServerInfo
+class KVIRC_API KviIrcdSevenIrcServerInfo : public KviHybridServerInfo
 {
-	//freenode
+	// freenode
 public:
 	KviIrcdSevenIrcServerInfo(KviIrcConnectionServerInfo * pParent = 0, const QString & version = KviQString::Empty)
-		:KviBasicIrcServerInfo(pParent, version) {;};
+		:KviHybridServerInfo(pParent, version) {;};
+	virtual const QString & getChannelModeDescription(char mode);
+	virtual const QString & getUserModeDescription(QChar mode);
+	virtual QChar getUserModeRequirement(QChar mode);
 	virtual char getRegisterModeChar() { return 0; };
 	virtual const char * getSoftware() { return "Ircd-seven"; };
 	virtual bool getNeedsOpToListModeseI() { return true; };
-	virtual const QString & getChannelModeDescription(char mode);
+	virtual bool getNeedsOperToSetS() { return true; };
 };
 
 class KVIRC_API KviIrcdRatboxIrcServerInfo : public KviBasicIrcServerInfo
 {
-	//efnet
+	// efnet
 public:
 	KviIrcdRatboxIrcServerInfo(KviIrcConnectionServerInfo * pParent = 0, const QString & version = KviQString::Empty)
 		:KviBasicIrcServerInfo(pParent, version) {;};
+	virtual const QString & getChannelModeDescription(char mode);
+	virtual const QString & getUserModeDescription(QChar mode);
+	virtual QChar getUserModeRequirement(QChar mode);
 	virtual char getRegisterModeChar() { return 0; };
 	virtual const char * getSoftware() { return "Ircd-ratbox"; };
 	virtual bool getNeedsOpToListModeseI() { return true; };
-	virtual const QString & getChannelModeDescription(char mode);
 };
 
 class KVIRC_API KviInspIRCdIrcServerInfo : public KviBasicIrcServerInfo
 {
-	//chatspike
+	// chatspike
 public:
 	KviInspIRCdIrcServerInfo(KviIrcConnectionServerInfo * pParent = 0, const QString & version = KviQString::Empty)
 		:KviBasicIrcServerInfo(pParent, version) {;};
+	virtual const QString & getChannelModeDescription(char mode);
+	virtual const QString & getUserModeDescription(QChar mode);
+	virtual QChar getUserModeRequirement(QChar mode);
 	virtual char getRegisterModeChar() { return 'r'; };
 	virtual const char * getSoftware() { return "InspIRCd"; };
 	virtual bool getNeedsOpToListModeseI() { return true; };
-	virtual const QString & getChannelModeDescription(char mode);
+	virtual bool getNeedsOperToSetS() { return true; };
 };
 
 class KVIRC_API KviIrcuIrcServerInfo : public KviBasicIrcServerInfo
 {
-	//undernet
+	// undernet
 public:
 	KviIrcuIrcServerInfo(KviIrcConnectionServerInfo * pParent = 0, const QString & version = KviQString::Empty)
 		:KviBasicIrcServerInfo(pParent, version) {;};
+	virtual const QString & getChannelModeDescription(char mode);
+	virtual const QString & getUserModeDescription(QChar mode);
+	virtual QChar getUserModeRequirement(QChar mode);
 	virtual char getRegisterModeChar() { return 0; };
 	virtual const char * getSoftware() { return "Ircu"; };
 	virtual bool getNeedsOpToListModeseI() { return true; };
-	virtual const QString & getChannelModeDescription(char mode);
+	virtual bool getNeedsOperToSetS() { return true; };
 };
 
 class KVIRC_API KviSnircdIrcServerInfo : public KviIrcuIrcServerInfo
 {
-	//quakenet; note: snird is an extension to ircu
+	// quakenet; note: snird is an extension to ircu
 public:
 	KviSnircdIrcServerInfo(KviIrcConnectionServerInfo * pParent = 0, const QString & version = KviQString::Empty)
 		:KviIrcuIrcServerInfo(pParent, version) {;};
-	virtual const char * getSoftware() { return "Snircd"; };
 	virtual const QString & getChannelModeDescription(char mode);
+	virtual const QString & getUserModeDescription(QChar mode);
+	virtual QChar getUserModeRequirement(QChar mode);
+	virtual const char * getSoftware() { return "Snircd"; };
+	virtual bool getNeedsOperToSetS() { return true; };
 };
 
 class KVIRC_API KviPlexusIrcServerInfo : public KviHybridServerInfo
 {
-	//rizon; note: plexus is an extension to hybrid
+	// rizon; note: plexus is an extension to hybrid
 public:
 	KviPlexusIrcServerInfo(KviIrcConnectionServerInfo * pParent = 0, const QString & version = KviQString::Empty)
 		:KviHybridServerInfo(pParent, version) {;};
+	virtual const QString & getChannelModeDescription(char mode);
+	virtual const QString & getUserModeDescription(QChar mode);
+	virtual QChar getUserModeRequirement(QChar mode);
 	virtual const char * getSoftware() { return "Plexus"; };
 	virtual bool getNeedsOpToListModeseI() { return true; };
-	virtual const QString & getChannelModeDescription(char mode);
 };
 
 class KVIRC_API KviOftcIrcServerInfo : public KviHybridServerInfo
 {
-	//oftc; note: hybrid+oftc is an extension to hybrid
+	// oftc; note: hybrid+oftc is an extension to hybrid
 public:
 	KviOftcIrcServerInfo(KviIrcConnectionServerInfo * pParent = 0, const QString & version = KviQString::Empty)
 		:KviHybridServerInfo(pParent, version) {;};
+	virtual const QString & getChannelModeDescription(char mode);
+	virtual const QString & getUserModeDescription(QChar mode);
+	virtual QChar getUserModeRequirement(QChar mode);
 	virtual char getRegisterModeChar() { return 'R'; };
 	virtual const char * getSoftware() { return "Hybrid+Oftc"; };
 	virtual bool getNeedsOpToListModeseI() { return true; };
-	virtual const QString & getChannelModeDescription(char mode);
 };
 
 class KVIRC_API KviDarenetIrcServerInfo : public KviIrcuIrcServerInfo
 {
-	//darenet; note: u2+ircd-darenet is an extension to ircu
+	// darenet; note: u2+ircd-darenet is an extension to ircu
 public:
 	KviDarenetIrcServerInfo(KviIrcConnectionServerInfo * pParent = 0, const QString & version = KviQString::Empty)
 		:KviIrcuIrcServerInfo(pParent, version) {;};
+	virtual const QString & getChannelModeDescription(char mode);
+	virtual const QString & getUserModeDescription(QChar mode);
+	virtual QChar getUserModeRequirement(QChar mode);
 	virtual char getRegisterModeChar() { return 'r'; };
 	virtual const char * getSoftware() { return "Ircu+Darenet"; };
 	virtual bool getNeedsOpToListModeseI() { return false; };
-	virtual const QString & getChannelModeDescription(char mode);
 };
 
 class KVIRC_API KviIrcConnectionServerInfo
@@ -257,6 +290,7 @@ public:
 	char  registerModeChar() { return m_pServInfo ?  m_pServInfo->getRegisterModeChar() : 0; };
 	const char * software() { return m_pServInfo ? m_pServInfo->getSoftware() : 0; };
 	bool getNeedsOpToListModeseI() { return m_pServInfo ? m_pServInfo->getNeedsOpToListModeseI() : false; };
+	bool getNeedsOperToSetS() { return m_pServInfo ? m_pServInfo->getNeedsOperToSetS() : false; };
 	const QString & name() { return m_szName; };
 	const QString & networkName() { return m_szNetworkName; };
 	const QString & supportedUserModes() { return m_szSupportedUserModes; };
@@ -280,6 +314,8 @@ public:
 
 	const QString & getChannelModeDescription(char mode) { return m_pServInfo->getChannelModeDescription(mode); };
 	const QString & getUserModeDescription(QChar mode) { return m_pServInfo->getUserModeDescription(mode); };
+
+	QChar getUserModeRequirement(QChar mode) { return m_pServInfo ? m_pServInfo->getUserModeRequirement(mode) : 0; };
 
 	bool isSupportedChannelType(QChar c);
 	bool isSupportedModePrefix(QChar c);


### PR DESCRIPTION
serverinfo: Add all user modes with descriptions to each IRCd's applicable
class. Create tables for user mode requirements to determine whether or not
the user mode can be applied to the user.
coreactions: Display information on each user mode in the drop down menu
for user mode selection. Check if the user mode can be set with the users
current permissions, if it cannot then gray it out.

---

Alright so I'll start this off with a pure before & after:
## Before (From a Plexus 3 server on Rizon)

![](http://i.imgur.com/UwCUmWv.png)
## After

![](http://i.imgur.com/o0nSoeh.png)
## Now for some technical explanations
### +s check

You will notice that I have a check within core actions to make sure user mode +s is supported by the IRCd. Some IRCds do not support +s for whatever reason, so for that we want to make sure it exists. The same could be done for +i and +w, however, I have yet to find a server that _doesn't_ support those modes.
### User mode enabled

Most user modes will be grayed out. This is due to that fact that user modes in general are more geared towards IRC Operators for server information. I have created some functions that determine whether or not the mode can be set based on the IRCd's programming. This is also to avoid having to rewrite "(staff only)" or "(server only)" within each string. Cut and dry, if it's grayed out then you can't use it. A further explanation can be determined with the mode's description.
### Rewriting "indexOf('+');"

This broke support for the 3 core modes that KVIrc appears to favor (+s, +i, and +w). I have gone ahead and standardized the strings to follow the same format as the channel mode window ("modechar: Description here"). This makes it simpler for the user to determine what each mode does, as the + might confuse users whether or not it is set. Why we have the sanity check there in the first place is beyond me as this is hard coded data calling hard coded data.
### getUserModeDescription()

This has been added to all existing IRCds that KVIrc currently supports. I have gone though each IRCd's help files and source code to verify accuracy.
### Add getUserModeRequirement()

This has been added to determine whether or not the user mode can be set. The user mode gets passed to the function and returns the user mode (if any) required to set. If it returns 1, then it cannot be changed (server managed only). If it returns 0 then it can be set. If it returns a QChar then it checks to see if the user has it set. If they do then the option is enabled. If not then it is grayed out.
### Add getNeedsOperToSetS()

Some IRCds require Oper to set user mode +s. I have added this bool function to determine whether or not the IRCd requires +s or not. If the function returns true then core actions checks for user mode +o. If the user does not have +o then the mode is grayed out.
