### PR TITLE
numeric: Parse 396 and output it as a snotice

### DIFF
--- a/src/kvirc/sparser/KviIrcServerParser.h
+++ b/src/kvirc/sparser/KviIrcServerParser.h
@@ -204,6 +204,7 @@ private:
 	void parseNumericNoSuchChannel(KviIrcMessage *msg);
 	void parseNumericNoSuchServer(KviIrcMessage *msg);
 	void parseNumericTime(KviIrcMessage *msg);
+	void parseNumericHiddenHost(KviIrcMessage *msg);
 	void parseNumericInfoEnd(KviIrcMessage *msg);
 	void parseNumericInfoStart(KviIrcMessage *msg);
 	void parseNumericInfo(KviIrcMessage *msg);

--- a/src/kvirc/sparser/KviIrcServerParser_numericHandlers.cpp
+++ b/src/kvirc/sparser/KviIrcServerParser_numericHandlers.cpp
@@ -2259,6 +2259,22 @@ void KviIrcServerParser::parseNumericTime(KviIrcMessage * msg)
 	}
 }
 
+void KviIrcServerParser::parseNumericHiddenHost(KviIrcMessage * msg)
+{
+	//RPL_HOSTHIDDEN       396
+	//<prefix> 396 target <[user@]host> :<message>
+	QString pref      = msg->connection()->decodeText(msg->safePrefix());
+	QString szHost    = msg->connection()->decodeText(msg->safeParam(1));
+	QString szMsgText = msg->connection()->decodeText(msg->safeTrailing());
+
+	if(!msg->haltOutput())
+	{
+		KviWindow * pOut = KVI_OPTION_BOOL(KviOption_boolServerNoticesToActiveWindow) ?
+			msg->console()->activeWindow() : (KviWindow *)(msg->console());
+		pOut->output(KVI_OUT_SERVERNOTICE,msg->serverTime(),"[\r!s\r%Q\r]: %Q %Q",&pref,&szHost,&szMsgText);
+	}
+}
+
 void KviIrcServerParser::parseNumericNoSuchServer(KviIrcMessage * msg)
 {
 	//ERR_NOSUCHSERVER     402

--- a/src/kvirc/sparser/KviIrcServerParser_tables.cpp
+++ b/src/kvirc/sparser/KviIrcServerParser_tables.cpp
@@ -485,7 +485,7 @@ messageParseProc KviIrcServerParser::m_numericParseProcTable[1000]=
 	0,                                               // 393 RPL_USERS
 	0,                                               // 394 RPL_ENDOFUSERS
 	0,                                               // 395 RPL_NOUSERS
-	0,                                               // 396 RPL_HOSTHIDDEN, RPL_YOURDISPLAYEDHOST
+	PTM(parseNumericHiddenHost),                     // 396 RPL_HOSTHIDDEN, RPL_YOURDISPLAYEDHOST
 	0,                                               // 397
 	0,                                               // 398
 	0,                                               // 399


### PR DESCRIPTION
### before

![](http://i.imgur.com/p2bnPdA.png)
### after

![](http://i.imgur.com/db2AnB1.png)

I originally got the idea from OFTC, but this really does make sense to me. Not only does it look nicer but if my host was changed (cough cough oper abuse :smile:) I'd also want to know right then and there. (assuming boolServerNoticesToActiveWindow was set). But really this is just more of an excuse to add some formatting to some highly active numerics that are function-less. Something I also want to do is add a KVS event for OnMeHostChange. (For things like idlerpg or other bots logging you out on host change)
