### PR TITLE
build: Fix compiler warnings

### DIFF
--- a/src/modules/options/OptionsWidget_connection.cpp
+++ b/src/modules/options/OptionsWidget_connection.cpp
@@ -150,7 +150,7 @@ OptionsWidget_connectionSocket::OptionsWidget_connectionSocket(QWidget * parent)
 	createLayout();
 	KviUIntSelector * u;
 
-	KviTalGroupBox * g = addGroupBox(0,0,0,0,Qt::Horizontal,__tr2qs_ctx("Timeout Values","options"),this);
+	KviTalGroupBox * g = addGroupBox(0,0,0,0,Qt::Horizontal,__tr2qs_ctx("Timeout Values","options"));
 	u = addUIntSelector(g,__tr2qs_ctx("Connect timeout:","options"),KviOption_uintIrcSocketTimeout,5,6000,60);
 	u->setSuffix(__tr2qs_ctx(" sec","options"));
 	u = addUIntSelector(g,__tr2qs_ctx("Outgoing data queue flush timeout:","options"),KviOption_uintSocketQueueFlushTimeout,100,2000,500);

--- a/src/modules/options/OptionsWidget_proxy.cpp
+++ b/src/modules/options/OptionsWidget_proxy.cpp
@@ -104,7 +104,7 @@ OptionsWidget_proxy::OptionsWidget_proxy(QWidget * parent)
 	vbox->setStretchFactor(lll,100);
 
 
-	KviTalGroupBox * gbox = addGroupBox(0,2,1,2,Qt::Horizontal,__tr2qs_ctx("Configuration","options"),this);
+	KviTalGroupBox * gbox = addGroupBox(0,2,1,2,Qt::Horizontal,__tr2qs_ctx("Configuration","options"));
 	//QGridLayout * gl = new QGridLayout(gbox->layout());
 	//gl->setMargin(2);
 	//gl->setSpacing(4);


### PR DESCRIPTION
'this' is always going to be true, so mute a compiler
warning by having it default to true. Fixes #1689

---

This seems right, right? Unless I'm missing something. @pragmaware?
