### PR TITLE
OptionsWidget_server: switch order & assign icons to Clear and Import Server list context menu entries

### DIFF
--- a/src/modules/options/OptionsWidget_servers.cpp
+++ b/src/modules/options/OptionsWidget_servers.cpp
@@ -1369,7 +1369,7 @@ OptionsWidget_servers::OptionsWidget_servers(QWidget * parent)
 	m_pImportButton->setMenu(m_pImportPopup);
 	m_pImportButton->setPopupMode(QToolButton::InstantPopup);
 
-	KviTalToolTip::add(m_pImportButton,__tr2qs_ctx("Import List","options"));
+	KviTalToolTip::add(m_pImportButton,__tr2qs_ctx("Import Server List","options"));
 
 	QFrame * lll = new QFrame(vbox);
 	vbox->setStretchFactor(lll,100);
@@ -1860,9 +1860,9 @@ void OptionsWidget_servers::customContextMenuRequested(const QPoint &pnt)
 	m_pContextPopup->addAction(*(g_pIconManager->getSmallIcon(KviIconManager::Paste)),__tr2qs_ctx("&Paste Server","options"),this,SLOT(pasteServer()))
 	    ->setEnabled(m_pClipboard);
 	m_pContextPopup->addSeparator();
-	m_pContextPopup->addAction(__tr2qs_ctx("Clear List","options"),this,SLOT(clearList()));
+	m_pContextPopup->addAction(*(g_pIconManager->getSmallIcon(KviIconManager::Folder)),__tr2qs_ctx("Import Server List","options"))->setMenu(m_pImportPopup);
 	m_pContextPopup->addSeparator();
-	m_pContextPopup->addAction(__tr2qs_ctx("Import List","options"))->setMenu(m_pImportPopup);
+	m_pContextPopup->addAction(*(g_pIconManager->getSmallIcon(KviIconManager::Remove)),__tr2qs_ctx("Clear Server List","options"),this,SLOT(clearList()));
 	m_pContextPopup->popup(QCursor::pos());
 }
 


### PR DESCRIPTION
… And also add Server to their labels and tooltips

All the clear channel list, clear recent server list and other akin functions, the entry is always at the bottom of the menu, here we do that also for this entry, some consistency must be kept where possible!

---

Also the context menu entry **Clear List** label is somewhat misleading, since pressing removes **ALL Servers** and **ALL Networks** and with it **ALL Settings** you may have.
- Ive renamed that entry to **Clear Server List**, but Im not yet happy with it, as I think this entry is way too destructive to be named so innocently... make no mistake this is a W.D.M. not a Eraser.

![lyj78lyt](https://cloud.githubusercontent.com/assets/3521959/10985804/583479d6-841c-11e5-8896-64611d344bc2.png)

This PR also addresses other label improvements and Import Server List tooltip label.

![capture](https://cloud.githubusercontent.com/assets/3521959/10985923/43194d00-841d-11e5-9444-887221da71ee.PNG)

I want to actually test this locally and see if it builds, before pushing it in.
