### PR TITLE
kvs: Add event for OnMeHostChange

### DIFF
--- a/src/kvirc/kvs/event/KviKvsEventTable.cpp
+++ b/src/kvirc/kvs/event/KviKvsEventTable.cpp
@@ -3986,6 +3986,26 @@ KviKvsEvent KviKvsEventManager::m_appEventTable[KVI_KVS_NUM_APP_EVENTS]=
 		"$0 = source nick\n"
 		"$1 = source username\n" \
 		"$2 = source hostname\n" \
-		"$3 = ban mask")
+		"$3 = ban mask"),
 
+	/*
+		@doc: onmehostchange
+		@type:
+			event
+		@title:
+			OnMeHostChange
+		@short:
+			Local user's visible host is changed
+		@parameters:
+			$0 = source server
+			$1 = new host
+		@window:
+			Console
+		@description:
+			Triggered when your visible hostname has been changed. The source could either be services or the IRCd.[br]
+			Note that not all IRC Network support this event, however, major IRC networks including Freenode do.
+	*/
+	EVENT("OnMeHostChange", \
+		"$0 = source server\n" \
+		"$1 = new host\n")
 };

--- a/src/kvirc/kvs/event/KviKvsEventTable.cpp
+++ b/src/kvirc/kvs/event/KviKvsEventTable.cpp
@@ -4002,8 +4002,7 @@ KviKvsEvent KviKvsEventManager::m_appEventTable[KVI_KVS_NUM_APP_EVENTS]=
 		@window:
 			Console
 		@description:
-			Triggered when your visible hostname has been changed. The source could either be services or the IRCd.[br]
-			Note that not all IRC Network support this event, however, major IRC networks including Freenode do.
+			Triggered when your visible hostname has been changed. The source could either be services or the IRCd.
 	*/
 	EVENT("OnMeHostChange", \
 		"$0 = source server\n" \

--- a/src/kvirc/kvs/event/KviKvsEventTable.h
+++ b/src/kvirc/kvs/event/KviKvsEventTable.h
@@ -104,6 +104,7 @@
 #define KviEvent_OnHTTPGetTerminated         28
 #define KviEvent_OnUnhandledLiteral          29
 #define KviEvent_OnOutboundTraffic           30
+#define KviEvent_OnMeHostChange              153
 
 // Popups
 /**
@@ -377,6 +378,6 @@
 #define KviEvent_OnQueryNickDefaultActionRequest   144
 
 /** \def KVI_KVS_NUM_APP_EVENTS Defines the number of events */
-#define KVI_KVS_NUM_APP_EVENTS 153
+#define KVI_KVS_NUM_APP_EVENTS 154
 
 #endif //_KVI_KVS_EVENTTABLE_H_

--- a/src/kvirc/sparser/KviIrcServerParser_literalHandlers.cpp
+++ b/src/kvirc/sparser/KviIrcServerParser_literalHandlers.cpp
@@ -1426,6 +1426,21 @@ output_to_query_window:
 			//SERVER NOTICE DIRECTED TO A CHANNEL (EG. &servers, &kills on ircd)
 			// FIXME: "Dedicated window for server notices ?"
 
+			KviIrcConnectionServerInfo * pServerInfo = msg->connection()->serverInfo();
+			QString version = pServerInfo->software();
+
+			// OFTC replaced RPL_HOSTHIDDEN with a server notice
+			if(version == "Hybrid+Oftc")
+			{
+				QStringList parts = szMsgText.split(" ", QString::SkipEmptyParts);
+				if(parts.count() == 3)
+				{
+					if(parts[0] == "Activating" && parts[1] == "Cloak:")
+						if(KVS_TRIGGER_EVENT_2_HALTED(KviEvent_OnMeHostChange,msg->console(),szNick,parts[2]))
+							msg->setHaltOutput();
+				}
+			}
+
 			if(KVS_TRIGGER_EVENT_2_HALTED(KviEvent_OnServerNotice,console,szNick,szMsgText))
 				msg->setHaltOutput();
 

--- a/src/kvirc/sparser/KviIrcServerParser_numericHandlers.cpp
+++ b/src/kvirc/sparser/KviIrcServerParser_numericHandlers.cpp
@@ -2406,6 +2406,9 @@ void KviIrcServerParser::parseNumericHiddenHost(KviIrcMessage * msg)
 	QString szHost    = msg->connection()->decodeText(msg->safeParam(1));
 	QString szMsgText = msg->connection()->decodeText(msg->safeTrailing());
 
+	if(KVS_TRIGGER_EVENT_2_HALTED(KviEvent_OnMeHostChange,msg->console(),pref,szHost))
+		msg->setHaltOutput();
+
 	if(!msg->haltOutput())
 	{
 		KviWindow * pOut = KVI_OPTION_BOOL(KviOption_boolServerNoticesToActiveWindow) ?


### PR DESCRIPTION
So basically, the idea here is to make it so you can manually script your client to join channels _after_ you have had your host changed which can aid in both privacy and channel flood (i.e. User has joined, services set mode +whatever on User, User has quit irc changing host, user has rejoined, server reset chan modes the user had). I'm honestly quiet terrible with scripting but I can imagine that others may find more reasons to use this. The only network I've found that doesn't support this event is OFTC due to their re-implementation of host changes within their IRCd's fork (it gets sent as a literal server notice).

Thoughts?
