### PR TITLE
Fix no output generated notes

### DIFF
--- a/src/kvilib/ext/KviDbusAdaptor.h
+++ b/src/kvilib/ext/KviDbusAdaptor.h
@@ -33,7 +33,6 @@
 
 	class KVILIB_API KviDbusAdaptor: public QDBusAbstractAdaptor
 	{
-		Q_OBJECT
 		Q_CLASSINFO("KVIrc D-Bus Interface", "org.kvirc.KVIrc")
 
 	public:

--- a/src/kvirc/ui/KviWebPackageManagementDialog.h
+++ b/src/kvirc/ui/KviWebPackageManagementDialog.h
@@ -47,8 +47,6 @@ class QUrl;
 ///
 class KVIRC_API KviWebPackageManagementDialog : public QWidget
 {
-	Q_OBJECT
-
 public:
 
 	///

--- a/src/modules/about/libkviabout.h
+++ b/src/modules/about/libkviabout.h
@@ -36,7 +36,6 @@ class KviDlgAbout;
 
 class KviAboutLabel : public QLabel
 {
-	Q_OBJECT
 public:
 	KviAboutLabel(KviDlgAbout * par);
 	~KviAboutLabel();
@@ -52,7 +51,6 @@ public:
 
 class KviDlgAbout : public QDialog
 {
-	Q_OBJECT
 public:
 	KviDlgAbout();
 	~KviDlgAbout();
@@ -73,7 +71,6 @@ public:
 
 class KviDlgBuildInfo : public QDialog
 {
-	Q_OBJECT
 public:
 	KviDlgBuildInfo();
 	~KviDlgBuildInfo();

--- a/src/modules/addon/WebAddonInterfaceDialog.h
+++ b/src/modules/addon/WebAddonInterfaceDialog.h
@@ -39,8 +39,6 @@
 ///
 class WebAddonInterfaceDialog : public KviWebPackageManagementDialog
 {
-	Q_OBJECT
-
 public:
 
 	///

--- a/src/modules/dcc/DccCanvasWindow.h
+++ b/src/modules/dcc/DccCanvasWindow.h
@@ -41,7 +41,6 @@
 
 	class DccCanvasWindow : public DccWindow
 	{
-		Q_OBJECT
 	public:
 		DccCanvasWindow(DccDescriptor * dcc,const char * name);
 		~DccCanvasWindow();

--- a/src/modules/dcc/canvaswidget.h
+++ b/src/modules/dcc/canvaswidget.h
@@ -189,7 +189,6 @@
 
 	class KviCanvasView : public QCanvasView
 	{
-		Q_OBJECT
 	public:
 		KviCanvasView(QCanvas * c,DccCanvasWidget * cw,QWidget * par);
 		~KviCanvasView();
@@ -267,7 +266,6 @@
 
 	class KviCanvasItemPropertiesWidget : public QTable
 	{
-		Q_OBJECT
 	public:
 		KviCanvasItemPropertiesWidget(QWidget * par);
 		~KviCanvasItemPropertiesWidget();
@@ -283,7 +281,6 @@
 	class DccCanvasWidget : public QWidget
 	{
 		friend class KviCanvasView;
-		Q_OBJECT
 	public:
 		DccCanvasWidget(QWidget * par);
 		~DccCanvasWidget();

--- a/src/modules/objects/KvsObject_webView.h
+++ b/src/modules/objects/KvsObject_webView.h
@@ -39,7 +39,6 @@
 class KvsObject_webView;
 class KviKvsWebView :  public QWebView
 {
-	Q_OBJECT
 public:
 	KviKvsWebView(QWidget * par,const char * name,KvsObject_webView *);
 	//void accept();
@@ -60,7 +59,6 @@ protected:
 
 class KvsObject_webView : public KviKvsObject
 {
-	Q_OBJECT
 public:
 	KVSO_DECLARE_OBJECT(KvsObject_webView)
 protected:
@@ -156,7 +154,6 @@ protected slots:
 
 class KviKvsDownloadHandler : public QObject
 {
-	Q_OBJECT
 public:
 	KviKvsDownloadHandler(KvsObject_webView * pParent, QFile * pFile, QNetworkReply * pNetReply, int iId);
 

--- a/src/modules/term/TermWidget.h
+++ b/src/modules/term/TermWidget.h
@@ -38,7 +38,6 @@
 
 	class TermWidget : public QFrame
 	{
-		Q_OBJECT
 		Q_PROPERTY( int KviProperty_ChildFocusOwner READ dummy )
 	public:
 		TermWidget(QWidget * par,bool bIsStandalone = false);

--- a/src/modules/term/TermWindow.h
+++ b/src/modules/term/TermWindow.h
@@ -34,7 +34,6 @@
 
 	class TermWindow : public KviWindow
 	{
-		Q_OBJECT
 	public:
 		TermWindow(const char * name);
 		~TermWindow();

--- a/src/modules/theme/WebThemeInterfaceDialog.h
+++ b/src/modules/theme/WebThemeInterfaceDialog.h
@@ -34,7 +34,6 @@
 
 class WebThemeInterfaceDialog : public KviWebPackageManagementDialog
 {
-	Q_OBJECT
 public:
 	WebThemeInterfaceDialog(QWidget *par=0);
 	~WebThemeInterfaceDialog();

--- a/src/modules/torrent/KTorrentDbusInterface.h
+++ b/src/modules/torrent/KTorrentDbusInterface.h
@@ -36,8 +36,6 @@
 
 	class KTorrentDbusInterface : public TorrentInterface
 	{
-		Q_OBJECT
-
 	public:
 		KTorrentDbusInterface();
 		virtual ~KTorrentDbusInterface();


### PR DESCRIPTION
e.g. `KVIrc/src/modules/term/TermWindow.h:0: Note: No relevant classes found. No output generated.`
