### PR TITLE
kvisnd: Deprecate Phonon support in Qt5

### DIFF
--- a/src/modules/snd/libkvisnd.cpp
+++ b/src/modules/snd/libkvisnd.cpp
@@ -95,7 +95,7 @@ KviSoundPlayer::KviSoundPlayer()
 	m_pSoundSystemDict = new KviPointerHashTable<QString,KviSoundPlayerEntry>(17,false);
 	m_pSoundSystemDict->setAutoDelete(true);
 
-#ifdef COMPILE_PHONON_SUPPORT
+#if defined(COMPILE_PHONON_SUPPORT) && (QT_VERSION < 0x050000)
 	m_pSoundSystemDict->insert("phonon",new KviSoundPlayerEntry(KVI_PTR2MEMBER(KviSoundPlayer::playPhonon),KVI_PTR2MEMBER(KviSoundPlayer::cleanupPhonon)));
 #endif //!COMPILE_PHONON_SUPPORT
 
@@ -254,7 +254,7 @@ void KviSoundPlayer::detectSoundSystem()
 #endif
 }
 
-#ifdef COMPILE_PHONON_SUPPORT
+#if defined(COMPILE_PHONON_SUPPORT) && (QT_VERSION < 0x050000)
 bool KviSoundPlayer::playPhonon(const QString &szFileName)
 {
 	if(isMuted())

--- a/src/modules/snd/libkvisnd.h
+++ b/src/modules/snd/libkvisnd.h
@@ -166,7 +166,7 @@ protected:
 protected:
 	void stopAllSoundThreads();
 	void cleanupAfterLastPlayerEntry();
-#ifdef COMPILE_PHONON_SUPPORT
+#if defined(COMPILE_PHONON_SUPPORT) && (QT_VERSION < 0x050000)
 	bool playPhonon(const QString &szFileName);
 	void cleanupPhonon();
 #endif //!COMPILE_PHONON_SUPPORT


### PR DESCRIPTION
Phonon is no longer supported within Qt5 and has already
been supersceded by the Qt Multimedia module

---

This silences

```
KVIrc/src/modules/snd/libkvisnd.cpp: In member function ‘bool KviSoundPlayer::playPhonon(const QString&)’:
KVIrc/src/modules/snd/libkvisnd.cpp:263:38: warning: ‘Phonon::MediaSource::MediaSource(const QString&)’ is deprecated (declared at /usr/include/phonon4qt5/phonon/mediasource.h:144) [-Wdeprecated-declarations]
  Phonon::MediaSource media(szFileName);
```
