### PR TITLE
fix show Qt in about dialog

### DIFF
--- a/src/kvilib/ext/KviOsInfo.cpp
+++ b/src/kvilib/ext/KviOsInfo.cpp
@@ -718,6 +718,6 @@ namespace KviOsInfo
 
 	QString qtVersion()
 	{
-		return QString(qVersion());
+		return QString(qtVersion());
 	}
 }

--- a/src/modules/about/AboutDialog.cpp
+++ b/src/modules/about/AboutDialog.cpp
@@ -136,10 +136,6 @@ AboutDialog::AboutDialog()
 	infoString += __tr2qs_ctx("Architecture","about");
 	infoString += ": ";
 	infoString += KviOsInfo::machine();
-	infoString += "<br>";
-	infoString += __tr2qs_ctx("Qt Version","about");
-	infoString += ": ";
-	infoString += KviOsInfo::qtVersion();
 	infoString += "<br><br>";
 	infoString += "<b>";
 	infoString += __tr2qs_ctx("Build Info","about");


### PR DESCRIPTION
One commit fixes a typo in return function. which I think prevents it from working. 

The other commit removes KviOsInfo::qtVersion();

```
infoString += "<br>";
infoString += __tr2qs_ctx("Qt Version","about");
infoString += ": ";
infoString += KviOsInfo::qtVersion();
```

Which seems to blow up KVIrc instantly when you try to open the about dialog.

![capture](https://cloud.githubusercontent.com/assets/3521959/11450612/18337e84-959e-11e5-9a5d-e3a004cf02f7.PNG)

just need to increase the default window height to remove the scrollbar and show all the info
