### PR TITLE
Alignment fixes to masks dialogs + add a more descriptive title to servers dialog entry

### DIFF
--- a/src/kvirc/ui/KviCryptController.cpp
+++ b/src/kvirc/ui/KviCryptController.cpp
@@ -129,8 +129,10 @@
 		pLayout->addWidget(m_pDecryptHexKeyCheck,8,3);
 
 		m_pOkButton = new QPushButton(__tr2qs("OK"),this);
-		pLayout->addWidget(m_pOkButton,9,0,1,4);
+		pLayout->addWidget(m_pOkButton,9,2,1,2);
+		m_pOkButton->setMinimumWidth(80);
 		connect(m_pOkButton,SIGNAL(clicked()),this,SLOT(okClicked()));
+		m_pOkButton->setIcon(*(g_pIconManager->getSmallIcon(KviIconManager::Accept)));
 
 		pLayout->setRowStretch(3,1);
 		pLayout->setColumnStretch(2,1);

--- a/src/kvirc/ui/KviCryptController.cpp
+++ b/src/kvirc/ui/KviCryptController.cpp
@@ -72,11 +72,15 @@
 
 		QGridLayout * pLayout = new QGridLayout(this);
 
+		QHBoxLayout * pTitleLayout = new QHBoxLayout(this);
+
 		QLabel * pLabel = new QLabel(this);
 		pLabel->setPixmap(*(g_pIconManager->getSmallIcon(KviIconManager::Locked)));
-		pLayout->addWidget(pLabel,0,0);
+		pTitleLayout->addWidget(pLabel,0);
 		pLabel = new QLabel(__tr2qs("Cryptography/text transformation"),this);
-		pLayout->addWidget(pLabel,0,1,1,3);
+		pTitleLayout->addWidget(pLabel,1);
+
+		pLayout->addLayout(pTitleLayout,0,0);
 
 		QFrame * pFrame = new QFrame(this);
 		pFrame->setFrameStyle(QFrame::HLine | QFrame::Sunken);

--- a/src/kvirc/ui/KviCryptController.cpp
+++ b/src/kvirc/ui/KviCryptController.cpp
@@ -94,11 +94,11 @@
 		connect(m_pListBox,SIGNAL(currentItemChanged(QListWidgetItem *, QListWidgetItem *)),this,SLOT(engineHighlighted(QListWidgetItem *, QListWidgetItem *)));
 		pLayout->addWidget(m_pListBox,3,0,6,1);
 
-		m_pDescriptionLabel = new QLabel(this);
-		m_pDescriptionLabel->setWordWrap(true);
-		m_pDescriptionLabel->setFrameStyle(QFrame::Sunken | QFrame::StyledPanel);
-		m_pDescriptionLabel->setAlignment(Qt::AlignTop | Qt::AlignLeft);
-		pLayout->addWidget(m_pDescriptionLabel,3,1,1,3);
+		m_pDescriptionText = new QTextEdit(this);
+		m_pDescriptionText->setReadOnly(true);
+		m_pDescriptionText->setFrameStyle(QFrame::Sunken | QFrame::StyledPanel);
+		m_pDescriptionText->setAlignment(Qt::AlignTop | Qt::AlignLeft);
+		pLayout->addWidget(m_pDescriptionText,3,1,1,3);
 
 		m_pAuthorLabel = new QLabel(this);
 		m_pAuthorLabel->setFrameStyle(QFrame::Sunken | QFrame::StyledPanel);
@@ -197,7 +197,7 @@
 			szDesc += pEngine->m_szDescription.toUtf8().data();
 			szDesc += "<br><br>";
 			szDesc += __tr2qs("If you don't want to encrypt a particular text line then just start it with the CTRL+P prefix");
-			m_pDescriptionLabel->setText(szDesc);
+			m_pDescriptionText->setText(szDesc);
 			m_pEnableEncrypt->setEnabled(pEngine->m_iFlags & KviCryptEngine::CanEncrypt);
 			m_pEncryptKeyLabel->setEnabled((pEngine->m_iFlags & KviCryptEngine::CanEncrypt) &&
 				(pEngine->m_iFlags & KviCryptEngine::WantEncryptKey));
@@ -228,7 +228,7 @@
 	{
 		m_pListBox->setEnabled(bEnabled);
 		m_pAuthorLabel->setEnabled(bEnabled && m_pLastItem);
-		m_pDescriptionLabel->setEnabled(bEnabled && m_pLastItem);
+		m_pDescriptionText->setEnabled(bEnabled && m_pLastItem);
 		bool bCanDecrypt = m_pLastItem ? m_pLastItem->m_iFlags & KviCryptEngine::CanDecrypt : false;
 		bool bCanEncrypt = m_pLastItem ? m_pLastItem->m_iFlags & KviCryptEngine::CanEncrypt : false;
 		m_pEnableEncrypt->setEnabled(bEnabled && bCanEncrypt);
@@ -248,8 +248,8 @@
 
 		m_pEnableCheck->setEnabled(false);
 		enableWidgets(false);
-		m_pDescriptionLabel->setText(__tr2qs("Sorry, no encryption engines available"));
-		m_pDescriptionLabel->setEnabled(true); // we want this text to be visible.
+		m_pDescriptionText->setText(__tr2qs("Sorry, no encryption engines available"));
+		m_pDescriptionText->setEnabled(true); // we want this text to be visible.
 		m_pOkButton->setEnabled(false);
 	}
 

--- a/src/kvirc/ui/KviCryptController.h
+++ b/src/kvirc/ui/KviCryptController.h
@@ -40,6 +40,7 @@
 	#include <QLabel>
 	#include <QLineEdit>
 	#include <QCheckBox>
+	#include <QTextEdit>
 
 	class KviWindow;
 
@@ -77,7 +78,7 @@
 		KviTalListWidget     * m_pListBox;
 		QPushButton          * m_pOkButton;
 		QCheckBox            * m_pEnableCheck;
-		QLabel               * m_pDescriptionLabel;
+		QTextEdit            * m_pDescriptionText;
 		QLabel               * m_pAuthorLabel;
 		QCheckBox            * m_pEnableEncrypt;
 		QLabel               * m_pEncryptKeyLabel;

--- a/src/kvirc/ui/KviMaskEditor.cpp
+++ b/src/kvirc/ui/KviMaskEditor.cpp
@@ -163,23 +163,28 @@ KviMaskEditor::KviMaskEditor(QWidget * par,KviChannelWindow * pChannel,KviWindow
 			break;
 	}
 
-	QLabel * l = new QLabel("",this);
-	l->setPixmap(*(g_pIconManager->getSmallIcon(m_eIcon)));
-	g->addWidget(l,0,0);
+	KviTalHBox * pTitleLayout = new KviTalHBox(this);
+	g->addWidget(pTitleLayout,0,0);
 
-	l = new QLabel(szDescription,this);
-	g->addWidget(l,0,1);
+	QLabel * l = new QLabel("",pTitleLayout);
+	l->setPixmap(*(g_pIconManager->getSmallIcon(m_eIcon)));
+
+	l = new QLabel(szDescription,pTitleLayout);
+
+	QFrame * pFrame = new QFrame(this);
+	pFrame->setFrameStyle(QFrame::HLine | QFrame::Sunken);
+	g->addWidget(pFrame,1,0,1,-1);
 
 	KviTalHBox * hb = new KviTalHBox(this);
-	g->addWidget(hb,1,0,1,2);
+	g->addWidget(hb,2,0,1,2);
 
 	new QLabel(__tr2qs("Filter:"),hb);
 	m_pSearch = new QLineEdit(hb);
 	connect(m_pSearch,SIGNAL(textChanged ( const QString & ) ),this,SLOT(searchTextChanged ( const QString & )));
 
 	l = new QLabel(__tr2qs("Use double-click to edit item"),this);
-	g->addWidget(l,1,1);
-	g->addWidget(l,2,0,1,2);
+	g->addWidget(l,2,1);
+	g->addWidget(l,3,0,1,2);
 
 	m_pMaskBox = new QTreeWidget(this);
 	m_pMaskBox->setFocusPolicy(Qt::ClickFocus);
@@ -197,18 +202,18 @@ KviMaskEditor::KviMaskEditor(QWidget * par,KviChannelWindow * pChannel,KviWindow
 	m_pMaskBox->setAllColumnsShowFocus(true);
 	m_pMaskBox->setSortingEnabled(true);
 	connect(m_pMaskBox,SIGNAL(itemDoubleClicked(QTreeWidgetItem *,int)),this,SLOT(itemDoubleClicked( QTreeWidgetItem *,int)));
-	g->addWidget(m_pMaskBox,3,0,1,2);
+	g->addWidget(m_pMaskBox,4,0,1,2);
 
 	m_pRemoveMask  = new QPushButton(__tr2qs("Re&move"),this);
 
 	m_pRemoveMask->setFocusPolicy(Qt::ClickFocus);
 	m_pRemoveMask->setFocusProxy(this);
-	g->addWidget(m_pRemoveMask,4,1);
+	g->addWidget(m_pRemoveMask,5,1);
 	connect(m_pRemoveMask,SIGNAL(clicked()),this,SLOT(removeClicked()));
 	m_pRemoveMask->setIcon(*(g_pIconManager->getSmallIcon(KviIconManager::DeleteItem)));
 
 	m_pAddButton = new QPushButton(__tr2qs("&Add"),this);
-	g->addWidget(m_pAddButton,4,0);
+	g->addWidget(m_pAddButton,5,0);
 	connect(m_pAddButton,SIGNAL(clicked()),this,SLOT(addClicked()));
 	m_pAddButton->setIcon(*(g_pIconManager->getSmallIcon(KviIconManager::NewItem)));
 

--- a/src/modules/options/OptionsWidget_message.cpp
+++ b/src/modules/options/OptionsWidget_message.cpp
@@ -183,7 +183,7 @@ OptionsWidget_standardColors::OptionsWidget_standardColors(QWidget * parent)
 				"options"
 			)
 		);
-	l->setAlignment(Qt::AlignCenter);
+	l->setAlignment(Qt::AlignLeft);
 
 	addRowSpacer(0,5,3,5);
 

--- a/src/modules/options/OptionsWidget_servers.h
+++ b/src/modules/options/OptionsWidget_servers.h
@@ -164,7 +164,7 @@ public:
 
 
 #define KVI_OPTIONS_WIDGET_ICON_OptionsWidget_servers KviIconManager::Server
-#define KVI_OPTIONS_WIDGET_NAME_OptionsWidget_servers __tr2qs_no_lookup("Servers")
+#define KVI_OPTIONS_WIDGET_NAME_OptionsWidget_servers __tr2qs_no_lookup("Servers and Configuration")
 #define KVI_OPTIONS_WIDGET_KEYWORDS_OptionsWidget_servers __tr2qs_no_lookup("connection")
 //#define KVI_OPTIONS_WIDGET_NOPARENT_OptionsWidget_servers OptionsWidget_connection
 #define KVI_OPTIONS_WIDGET_PRIORITY_OptionsWidget_servers 99000
@@ -229,8 +229,8 @@ protected slots:
 	void detailsClicked();
 	void connectCurrentClicked();
 	void recentServersPopupAboutToShow();
-    void recentServersPopupClicked(QAction *pAction);
-    void importPopupActivated(QAction *pAction);
+	void recentServersPopupClicked(QAction *pAction);
+	void importPopupActivated(QAction *pAction);
 	void serverNetworkEditTextEdited(const QString &szNewText);
 	void filterTextEdited(const QString &szNewText);
 public:


### PR DESCRIPTION
@staticfox I managed to fix one dilaog message alignment

![lex7uc3d](https://cloud.githubusercontent.com/assets/3521959/11743733/b58e9976-a001-11e5-89bc-b4dd16be467a.png)

The other instances of alignment I couldn't figure it out ~~see https://github.com/kvirc/KVIrc/compare/master...un1versal:My-Favorite-Martian~~ only the ones on this PR worked, the rest either didnt work or made things look worst.

As you asked this is how it should be for the others.

![capture1](https://cloud.githubusercontent.com/assets/3521959/11743364/b3a2066e-9ffe-11e5-8868-c36ba8122309.PNG)

So these below ones I couldn't figure out ~~in https://github.com/kvirc/KVIrc/compare/master...un1versal:My-Favorite-Martian~~

> **Edit**: thx to Thereign for help with encryption menu text align.... looks great. (cut off text still not looked at)

![capture](https://cloud.githubusercontent.com/assets/3521959/11743363/b39e34a8-9ffe-11e5-8d44-85a67ee2cda5.PNG)

And another with two issues

![capture](https://cloud.githubusercontent.com/assets/3521959/11743834/92aebed0-a002-11e5-8826-4729d88991e5.PNG)

Any hints would be good I cant figure any of it out.
