### PR TITLE
Fix various dialogs sizes/alignments and messages + consistent "Browse..." button label

### DIFF
--- a/src/kvirc/ui/KviSelectors.cpp
+++ b/src/kvirc/ui/KviSelectors.cpp
@@ -316,7 +316,7 @@ KviPixmapSelector::KviPixmapSelector(QWidget * par,const QString & txt,KviPixmap
 	if(m_localPixmap.pixmap())m_pFileNameLabel->setText(m_localPixmap.path());
 	g->addWidget(m_pFileNameLabel,2,0);
 
-	m_pChooseButton = new QPushButton("...",this);
+	m_pChooseButton = new QPushButton("&Browse...",this);
 	g->addWidget(m_pChooseButton,2,1);
 	connect(m_pChooseButton,SIGNAL(clicked()),this,SLOT(choosePixmap()));
 

--- a/src/modules/avatar/libkviavatar.cpp
+++ b/src/modules/avatar/libkviavatar.cpp
@@ -73,9 +73,8 @@ KviAsyncAvatarSelectionDialog::KviAsyncAvatarSelectionDialog(QWidget * par,const
 	QString msg = "<center>";
 	msg += __tr2qs("Please select an avatar image. " \
 		"The full path to a local file or an image on the Web can be used.<br>" \
-		"If you wish to use a local image file, click the \"<b>Browse</b>\"" \
-		"button to browse local folders.<br>" \
-		"The full URL for an image (including <b>http://</b> or <b>https://</b>) can be entered manually.");
+		"If you wish to use a local image file, click the \"<b>Browse</b>\" button to select the desired file.<br>" \
+		"The full URL for an image (including <b>http://</b> or <b>https://</b>) can also be entered manually.");
 	msg += "</center><br>";
 
 	QLabel * l = new QLabel(msg,this);

--- a/src/modules/avatar/libkviavatar.cpp
+++ b/src/modules/avatar/libkviavatar.cpp
@@ -75,7 +75,7 @@ KviAsyncAvatarSelectionDialog::KviAsyncAvatarSelectionDialog(QWidget * par,const
 		"The full path to a local file or an image on the Web can be used.<br>" \
 		"If you wish to use a local image file, click the \"<b>Browse</b>\"" \
 		"button to browse local folders.<br>" \
-		"The full URL for an image (including <b>http://</b> or  <b>https://</b> ) can be entered manually.");
+		"The full URL for an image (including <b>http://</b> or <b>https://</b>) can be entered manually.");
 	msg += "</center><br>";
 
 	QLabel * l = new QLabel(msg,this);

--- a/src/modules/options/OptionsWidget_identity.cpp
+++ b/src/modules/options/OptionsWidget_identity.cpp
@@ -203,45 +203,50 @@ AvatarSelectionDialog::AvatarSelectionDialog(QWidget * par,const QString &szInit
 {
 	setWindowTitle(__tr2qs_ctx("Choose Avatar - KVIrc","options"));
 
-	QGridLayout * g = new QGridLayout(this);
+	QVBoxLayout * layout = new QVBoxLayout(this);
 
-	QString msg = "<left>";
-	msg += __tr2qs_ctx("Please select an avatar image. " \
-				"The full path to a local file or an image on the Web can be used.<br>" \
-				"If you wish to use a local image file, click the \"<b>Browse</b>\"" \
-				"button to browse local folders.<br>" \
-				"The full URL for an image (including <b>http://</b>) can be entered manually.","options");
-	msg += "</left><br>";
+	QString msg = __tr2qs_ctx("Please select an avatar image.\n\n" \
+				"The full path to a local file or an image on the Web can be used. " \
+				"If you wish to use a local image file, click the \"Browse\"" \
+				"button to browse local folders. " \
+				"The full URL for an image (including http:// or https://) can be entered manually.","options");
 
-	QLabel * l = new QLabel(msg,this);
+	QLabel * l = new QLabel(msg);
 	l->setMinimumWidth(250);
+	l->setWordWrap(true);
 
-	g->addWidget(l,0,0);
+	layout->addWidget(l);
 
-	m_pLineEdit = new QLineEdit(this);
+	m_pLineEdit = new QLineEdit;
 	m_pLineEdit->setText(szInitialPath);
-	m_pLineEdit->setMinimumWidth(100);
 
-	g->addWidget(m_pLineEdit,1,0,1,2);
+	m_pLineEdit->setMinimumWidth(300);
 
-	QPushButton * b = new QPushButton(__tr2qs_ctx("&Browse...","options"),this);
+	QHBoxLayout * pLineEditLayout = new QHBoxLayout;
+
+	pLineEditLayout->addWidget(m_pLineEdit,1);
+
+	QPushButton * b = new QPushButton(__tr2qs_ctx("&Browse...","options"));
+	b->setFixedWidth(80);
 	connect(b,SIGNAL(clicked()),this,SLOT(chooseFileClicked()));
-	g->addWidget(b,1,2);
+	pLineEditLayout->addWidget(b,1);
 
-	KviTalHBox * h = new KviTalHBox(this);
-	h->setSpacing(8);
-	g->addWidget(h,2,1,1,2);
-	b = new QPushButton(__tr2qs_ctx("&OK","options"),h);
-	b->setMinimumWidth(80);
+	layout->addLayout(pLineEditLayout);
+
+	QHBoxLayout * h = new QHBoxLayout;
+
+	h->setAlignment(Qt::AlignRight);
+	layout->addLayout(h);
+	b = new QPushButton(__tr2qs_ctx("&OK","options"));
+	b->setFixedWidth(80);
 	b->setDefault(true);
 	connect(b,SIGNAL(clicked()),this,SLOT(okClicked()));
+	h->addWidget(b);
 
-	b = new QPushButton(__tr2qs_ctx("Cancel","options"),h);
-	b->setMinimumWidth(80);
+	b = new QPushButton(__tr2qs_ctx("Cancel","options"));
+	b->setFixedWidth(80);
 	connect(b,SIGNAL(clicked()),this,SLOT(cancelClicked()));
-
-	g->setRowStretch(0,1);
-	g->setColumnStretch(0,1);
+	h->addWidget(b);
 }
 
 AvatarSelectionDialog::~AvatarSelectionDialog()

--- a/src/modules/options/OptionsWidget_identity.cpp
+++ b/src/modules/options/OptionsWidget_identity.cpp
@@ -207,8 +207,8 @@ AvatarSelectionDialog::AvatarSelectionDialog(QWidget * par,const QString &szInit
 
 	QString msg = __tr2qs_ctx("Please select an avatar image.\n\n" \
 				"The full path to a local file or an image on the Web can be used.\n" \
-				"If you wish to use a local image file, click the \"Browse\" button to browse local folders.\n\n" \
-				"The full URL for an image (including http:// or https://) can be entered manually.","options");
+				"If you wish to use a local image file, click the \"Browse\" button to select the desired file.\n\n" \
+				"The full URL for an image (including http:// or https://) can also be entered manually.","options");
 
 	QLabel * l = new QLabel(msg);
 	l->setMinimumWidth(250);

--- a/src/modules/options/OptionsWidget_identity.cpp
+++ b/src/modules/options/OptionsWidget_identity.cpp
@@ -206,9 +206,8 @@ AvatarSelectionDialog::AvatarSelectionDialog(QWidget * par,const QString &szInit
 	QVBoxLayout * layout = new QVBoxLayout(this);
 
 	QString msg = __tr2qs_ctx("Please select an avatar image.\n\n" \
-				"The full path to a local file or an image on the Web can be used. " \
-				"If you wish to use a local image file, click the \"Browse\"" \
-				"button to browse local folders. " \
+				"The full path to a local file or an image on the Web can be used.\n" \
+				"If you wish to use a local image file, click the \"Browse\" button to browse local folders.\n\n" \
 				"The full URL for an image (including http:// or https://) can be entered manually.","options");
 
 	QLabel * l = new QLabel(msg);
@@ -220,7 +219,7 @@ AvatarSelectionDialog::AvatarSelectionDialog(QWidget * par,const QString &szInit
 	m_pLineEdit = new QLineEdit;
 	m_pLineEdit->setText(szInitialPath);
 
-	m_pLineEdit->setMinimumWidth(300);
+	m_pLineEdit->setMinimumWidth(450);
 
 	QHBoxLayout * pLineEditLayout = new QHBoxLayout;
 

--- a/src/modules/options/OptionsWidget_identity.cpp
+++ b/src/modules/options/OptionsWidget_identity.cpp
@@ -61,8 +61,8 @@ NickAlternativesDialog::NickAlternativesDialog(QWidget * par,const QString &n1,c
 	setWindowTitle(__tr2qs_ctx("Nickname Alternatives","options"));
 
 	QLabel * l = new QLabel(this);
-	l->setText(__tr2qs_ctx("Here you can choose up to three nicknames " \
-		"alternative to the primary one. KVIrc will use the alternatives " \
+	l->setText(__tr2qs_ctx("Here you can choose up to three nickname " \
+		"alternatives to the primary one. KVIrc will use the alternatives " \
 		"if the primary nick is already used by someone else on a particular " \
 		"IRC network.","options"));
 	l->setWordWrap(true);

--- a/src/modules/options/OptionsWidget_identity.cpp
+++ b/src/modules/options/OptionsWidget_identity.cpp
@@ -210,17 +210,17 @@ AvatarSelectionDialog::AvatarSelectionDialog(QWidget * par,const QString &szInit
 				"The full path to a local file or an image on the Web can be used.<br>" \
 				"If you wish to use a local image file, click the \"<b>Browse</b>\"" \
 				"button to browse local folders.<br>" \
-				"The full URL for an image (including <b>http:// or https://</b>) can be entered manually.","options");
+				"The full URL for an image (including <b>http://</b>) can be entered manually.","options");
 	msg += "</left><br>";
 
 	QLabel * l = new QLabel(msg,this);
 	l->setMinimumWidth(250);
 
-	g->addWidget(l,0,0,1,3);
+	g->addWidget(l,0,0);
 
 	m_pLineEdit = new QLineEdit(this);
 	m_pLineEdit->setText(szInitialPath);
-	m_pLineEdit->setMinimumWidth(180);
+	m_pLineEdit->setMinimumWidth(100);
 
 	g->addWidget(m_pLineEdit,1,0,1,2);
 
@@ -395,7 +395,7 @@ KviIdentityGeneralOptionsWidget::KviIdentityGeneralOptionsWidget(QWidget * paren
 	sel = addStringSelector(gbox,__tr2qs_ctx("Languages:","options"),KviOption_stringCtcpUserInfoLanguages);
 	sel->setMinimumLabelWidth(120);
 	mergeTip(sel,szCenterBegin + __tr2qs_ctx("You can put here the short names of the languages you can speak. " \
-				"An example might be \"EN,IT\" that would mean that you speak both Italian and English.","options") + szTrailing);
+				"An example might be \"EN, IT\" that would mean that you speak both Italian and English.","options") + szTrailing);
 
 	sel = addStringSelector(gbox,__tr2qs_ctx("Other:","options"),KviOption_stringCtcpUserInfoOther);
 	sel->setMinimumLabelWidth(120);
@@ -716,9 +716,9 @@ OptionsWidget_identityProfile::OptionsWidget_identityProfile(QWidget * pParent)
 	labels.append(__tr2qs_ctx("Name","options"));
 	labels.append(__tr2qs_ctx("Network","options"));
 	labels.append(__tr2qs_ctx("Nickname","options"));
-	labels.append(__tr2qs_ctx("Alt. Nick","options"));
+	labels.append(__tr2qs_ctx("Alternate nickname","options"));
 	labels.append(__tr2qs_ctx("Username","options"));
-	labels.append(__tr2qs_ctx("Realname","options"));
+	labels.append(__tr2qs_ctx("Real name","options"));
 	m_pTreeWidget->setHeaderLabels(labels);
 
 	KviTalToolTip::add(m_pTreeWidget, \
@@ -733,7 +733,7 @@ OptionsWidget_identityProfile::OptionsWidget_identityProfile(QWidget * pParent)
 
 	// Buttons box
 	KviTalHBox * pBtnBox = new KviTalHBox(this);
-	pLayout->addWidget(pBtnBox,2,0);
+	pLayout->addWidget(pBtnBox,2,0,1,3);
 
 	m_pBtnAddProfile = new QPushButton(__tr2qs_ctx("Add Profile","options"),pBtnBox);
 	connect(m_pBtnAddProfile,SIGNAL(clicked()),this,SLOT(addProfileEntry()));
@@ -946,7 +946,7 @@ IdentityProfileEditor::IdentityProfileEditor(QWidget * pParent)
 
 	KviTalHBox * pBox = new KviTalHBox(this);
 	pBox->setAlignment(Qt::AlignRight);
-	pLayout->addWidget(pBox,6,0);
+	pLayout->addWidget(pBox,6,1,1,2);
 
 	QPushButton * p = new QPushButton(__tr2qs_ctx("Cancel","options"),pBox);
 	//p->setMinimumWidth(100);

--- a/src/modules/options/OptionsWidget_identity.cpp
+++ b/src/modules/options/OptionsWidget_identity.cpp
@@ -210,7 +210,7 @@ AvatarSelectionDialog::AvatarSelectionDialog(QWidget * par,const QString &szInit
 				"The full path to a local file or an image on the Web can be used.<br>" \
 				"If you wish to use a local image file, click the \"<b>Browse</b>\"" \
 				"button to browse local folders.<br>" \
-				"The full URL for an image (including <b>http://</b>) can be entered manually.","options");
+				"The full URL for an image (including <b>http:// or https://</b>) can be entered manually.","options");
 	msg += "</left><br>";
 
 	QLabel * l = new QLabel(msg,this);

--- a/src/modules/options/OptionsWidget_nickserv.cpp
+++ b/src/modules/options/OptionsWidget_nickserv.cpp
@@ -52,7 +52,7 @@ NickServRuleEditor::NickServRuleEditor(QWidget * par,bool bUseServerMaskField)
 
 	QGridLayout * gl = new QGridLayout(this);//,bUseServerMaskField ? 7 : 6,4,10,5);
 
-	QLabel * l = new QLabel(__tr2qs_ctx("Registered nickname","options"),this);
+	QLabel * l = new QLabel(__tr2qs_ctx("Registered nickname:","options"),this);
 	gl->addWidget(l,0,0);
 
 	m_pRegisteredNickEdit = new QLineEdit(this);
@@ -60,7 +60,7 @@ NickServRuleEditor::NickServRuleEditor(QWidget * par,bool bUseServerMaskField)
 	gl->addWidget(m_pRegisteredNickEdit,0,1,1,3);
 //	gl->addMultiCellWidget(m_pRegisteredNickEdit,0,0,1,3);
 
-	l = new QLabel(__tr2qs_ctx("NickServ mask","options"),this);
+	l = new QLabel(__tr2qs_ctx("NickServ mask:","options"),this);
 	gl->addWidget(l,1,0);
 
 	m_pNickServMaskEdit = new QLineEdit(this);
@@ -73,7 +73,7 @@ NickServRuleEditor::NickServRuleEditor(QWidget * par,bool bUseServerMaskField)
 	gl->addWidget(m_pNickServMaskEdit,1,1,1,3);
 //	gl->addMultiCellWidget(m_pNickServMaskEdit,1,1,1,3);
 
-	l = new QLabel(__tr2qs_ctx("Message regexp","options"),this);
+	l = new QLabel(__tr2qs_ctx("Message regexp:","options"),this);
 	gl->addWidget(l,2,0);
 
 	m_pMessageRegexpEdit = new QLineEdit(this);
@@ -86,7 +86,7 @@ NickServRuleEditor::NickServRuleEditor(QWidget * par,bool bUseServerMaskField)
 			"The message is usually something like \"To identify yourself please use /ns IDENTIFY password\" " \
 			"and it is sent when the NickServ wants you to authenticate yourself. " \
 			"You can use the * and ? wildcards.","options") + html_center_end);
-	l = new QLabel(__tr2qs_ctx("Identify command","options"),this);
+	l = new QLabel(__tr2qs_ctx("Identify command:","options"),this);
 	gl->addWidget(l,3,0);
 
 	m_pIdentifyCommandEdit = new QLineEdit(this);
@@ -103,7 +103,7 @@ NickServRuleEditor::NickServRuleEditor(QWidget * par,bool bUseServerMaskField)
 
 	if(bUseServerMaskField)
 	{
-		l = new QLabel(__tr2qs_ctx("Server mask","options"),this);
+		l = new QLabel(__tr2qs_ctx("Server mask:","options"),this);
 		gl->addWidget(l,4,0);
 
 		m_pServerMaskEdit = new QLineEdit(this);


### PR DESCRIPTION
Avatar choose dialog is broken enterily and other dialogs just are slightly all over the place also.

This PR fixes:
- the avatar choose dialog (kudos to @TheReign for coming up with a better solution than mine) for this dialog. (good team effort :+1: )

![capture](https://cloud.githubusercontent.com/assets/3521959/11972367/422b46f0-a943-11e5-8c3c-35356609c64d.PNG)
- Browse buttons have 3 types atm, in some dialogs (general preferences) they are labeled "Browse...."  in others (Theme preferences) they are labeled "..." and everywhere else they are the folder icon.

I tried making these all folder icons **preferred** as its the international recognized pictograph for this browse function. However the SetupWizard,cpp changes made the KVirc segfault so this solution was chosen instead.
- fix broken text and add https:// to avatar messages as that was added recently by pragma (it works when setting up directly not tested via here)
- minor string fixes that were missed in the massive sea of strings that make up kvirc.

Will merge this as soon as appveyor is happy to give a chance to catch any missed bits.
