### PR TITLE
fix recognizing https:// URL in CTCP AVATAR replies

### DIFF
--- a/src/kvirc/sparser/KviIrcServerParser_ctcp.cpp
+++ b/src/kvirc/sparser/KviIrcServerParser_ctcp.cpp
@@ -1629,7 +1629,10 @@ void KviIrcServerParser::parseCtcpReplyAvatar(KviCtcpMessage *msg)
 		if(_OUTPUT_VERBOSE)
 			KviQString::appendFormatted(textLine," (%Q %Q)",&szWhere,&szWhat);
 
-		bool bIsUrl = KviQString::equalCIN("http://",szRemoteFile,7) && (szRemoteFile.length() > 7);
+		bool bIsUrl = (
+				(KviQString::equalCIN("http://",szRemoteFile,7) && (szRemoteFile.length() > 7)) ||
+				(KviQString::equalCIN("https://",szRemoteFile,8) && (szRemoteFile.length() > 8))
+			);
 		if(!bIsUrl)
 		{
 			// no hacks

--- a/src/modules/avatar/libkviavatar.cpp
+++ b/src/modules/avatar/libkviavatar.cpp
@@ -240,7 +240,7 @@ static bool avatar_kvs_cmd_set(KviKvsModuleCommandCall * c)
 	} else {
 		bool bIsUrl = (
 				(KviQString::equalCIN(szAvatar,"http://",7) && (szAvatar.length() > 7)) ||
-				(KviQString::equalCIN(szAvatar,"https://",7) && (szAvatar.length() > 8))
+				(KviQString::equalCIN(szAvatar,"https://",8) && (szAvatar.length() > 8))
 			);
 
 		if(bIsUrl)


### PR DESCRIPTION
thx @Andrio for pointing it out.

Someone that understands this should review and merge.

Personally I cant see a difference and https://github.com/kvirc/KVIrc/issues/1835 is still buggy even with this.
