### PR TITLE
rename applet labels to reflect what they affect

### DIFF
--- a/src/modules/options/OptionsWidget_theme.cpp
+++ b/src/modules/options/OptionsWidget_theme.cpp
@@ -166,8 +166,8 @@ OptionsWidget_themeToolBarApplets::OptionsWidget_themeToolBarApplets(QWidget * p
 
 	addColorSelector(0,1,0,1,__tr2qs_ctx("Background:","options"),KviOption_colorIrcToolBarAppletBackground);
 	addColorSelector(0,2,0,2,__tr2qs_ctx("Low-contrast foreground:","options"),KviOption_colorIrcToolBarAppletForegroundLowContrast);
-	addColorSelector(0,3,0,3,__tr2qs_ctx("Mid-contrast foreground:","options"),KviOption_colorIrcToolBarAppletForegroundMidContrast);
-	addColorSelector(0,4,0,4,__tr2qs_ctx("Active high-contrast foreground (primary):","options"),KviOption_colorIrcToolBarAppletForegroundHighContrastActive1);
+	addColorSelector(0,3,0,3,__tr2qs_ctx("Mid-contrast border foreground:","options"),KviOption_colorIrcToolBarAppletForegroundMidContrast);
+	addColorSelector(0,4,0,4,__tr2qs_ctx("Active high-contrast text foreground (primary):","options"),KviOption_colorIrcToolBarAppletForegroundHighContrastActive1);
 	addColorSelector(0,5,0,5,__tr2qs_ctx("Active high-contrast foreground (secondary):","options"),KviOption_colorIrcToolBarAppletForegroundHighContrastActive2);
 	addColorSelector(0,6,0,6,__tr2qs_ctx("Inactive high-contrast foreground (primary):","options"),KviOption_colorIrcToolBarAppletForegroundHighContrastInactive1);
 	addColorSelector(0,7,0,7,__tr2qs_ctx("Inactive high-contrast foreground (secondary):","options"),KviOption_colorIrcToolBarAppletForegroundHighContrastInactive2);


### PR DESCRIPTION
This needs more feedback as I cant make heads or tails of what other options affect.

Its silly to be honest to name things in a manner where the user would have to guess by trial and error.

tbh no idea what other options do and code is too cryptic to me.

![capture](https://cloud.githubusercontent.com/assets/3521959/12269087/8be599bc-b947-11e5-82ac-1aa23252f604.PNG)
