### PR TITLE
Candidate to fix #1829

### DIFF
--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -1771,6 +1771,7 @@ void KviInputEditor::internalCursorLeft(bool bShift)
 	
 }
 
+#if (QT_VERSION >= 0x050000)
 QVariant KviInputEditor::inputMethodQuery(Qt::InputMethodQuery query) const
 {
 	switch(query)
@@ -1788,6 +1789,7 @@ QVariant KviInputEditor::inputMethodQuery(Qt::InputMethodQuery query) const
 
 	return QWidget::inputMethodQuery(query);
 }
+#endif
 
 
 void KviInputEditor::inputMethodEvent(QInputMethodEvent * e)

--- a/src/kvirc/ui/KviInputEditor.h
+++ b/src/kvirc/ui/KviInputEditor.h
@@ -926,7 +926,9 @@ protected:
 	virtual void dragEnterEvent(QDragEnterEvent * e);
 	virtual void dropEvent(QDropEvent * e);
 	virtual void inputMethodEvent(QInputMethodEvent * e) ;
+#if (QT_VERSION >= 0x050000)
 	virtual QVariant inputMethodQuery(Qt::InputMethodQuery query) const;
+#endif
 	virtual void paintEvent(QPaintEvent * e);
 	bool checkWordSpelling(const QString &szWord);
 	void splitTextIntoSpellCheckerBlocks(const QString &szText,KviPointerList<KviInputEditorSpellCheckerBlock> &lBuffer);


### PR DESCRIPTION
So it seems were more and more venturing in to Qt5 territory and leaving behind Qt4... The issue is the enum flags that are erroring aren't apart of Qt4 (ImEnabled nor ImHints). I'm sure there are probably more complicated workarounds, but if we do plan to drop Qt4 at some point, maybe we should start here?

Side note, don't pull unless it's passed travis/appveyor and has been discussed.
