### PR TITLE
QMessageBox/setWindowTitle: fix headers titles: capitalization, syntax + try to improve entries.

### DIFF
--- a/src/kvirc/kernel/KviApplication.cpp
+++ b/src/kvirc/kernel/KviApplication.cpp
@@ -957,7 +957,7 @@ void KviApplication::checkSuggestRestoreDefaultScript()
 	if(!KviDefaultScriptManager::instance()->isDefscriptUpToDate())
 	{
 		switch(
-			QMessageBox::question(0,__tr2qs("Update default scripts"),
+			QMessageBox::question(0,__tr2qs("Update Default Scripts - KVIrc"),
 				__tr2qs("<b>Hi!</b><br><br>" \
 					"<b>It seems that you have just upgraded KVIrc from a previous version.</b><br><br>" \
 					"The KVIrc default scripts needs to be updated too, to play nice with your fresh new KVIrc.<br>" \
@@ -1023,10 +1023,10 @@ void KviApplication::checkSuggestRestoreDefaultScript()
 	bSuggestedOnce = true;
 
 	switch(
-		QMessageBox::question(0,__tr2qs("Installation problems?"),
-			__tr2qs("<b>Oops...</b><br><br>" \
-				"<b>There are some reasons that make me think that your KVIrc installation is incomplete.</b><br><br>" \
-				"I might be wrong, but you seem to miss some of the features that the default KVIrc script provides." \
+		QMessageBox::question(0,__tr2qs("Detected Installation Problems - KVIrc"),
+			__tr2qs("<b>Oops!</b><br><br>" \
+				"<b>There are some reasons that make me think your KVIrc installation is incomplete.</b><br><br>" \
+				"I might be wrong, but you seem to be missing some of the features that the default KVIrc script provides." \
 				"This may happen because you have upgraded to an unstable Git version, " \
 				"because you have accidentally deleted or damaged your configuration files, " \
 				"because you have installed an incomplete script " \

--- a/src/kvirc/kernel/KviCoreActions.cpp
+++ b/src/kvirc/kernel/KviCoreActions.cpp
@@ -301,7 +301,7 @@ void register_core_actions(KviActionManager * m)
 
 	SCRIPT_ACTION(
 		KVI_COREACTION_EXECUTEKVS,
-		"dialog.file(open,$tr(\"Select a Script File\")){ if(!$str.isEmpty($0))parse $0; }",
+		"dialog.file(open,$tr(\"Select a Script File - KVIrc\")){ if(!$str.isEmpty($0))parse $0; }",
 		__tr2qs("Execute Script..."),
 		__tr2qs("Allows executing a KVS script from file"),
 		KviActionManager::categoryScripting(),

--- a/src/kvirc/kernel/KviDefaultScript.cpp
+++ b/src/kvirc/kernel/KviDefaultScript.cpp
@@ -123,13 +123,13 @@ void KviDefaultScriptManager::restore()
 	// Check data
 	if(!compareVersions(szGlobal,&szError))
 	{
-		QMessageBox::warning(0,__tr2qs("Restore Default Script - Error"),szError,QMessageBox::Ok,QMessageBox::NoButton,QMessageBox::NoButton);
+		QMessageBox::warning(0,__tr2qs("Restore Default Script - KVIrc"),szError,QMessageBox::Ok,QMessageBox::NoButton,QMessageBox::NoButton);
 		return;
 	}
 
 	if(m_bNoNeedToRestore)
 	{
-		if(QMessageBox::warning(0,__tr2qs("Restore Default Script - Warning"),szError,QMessageBox::Yes, QMessageBox::No) != QMessageBox::Yes)
+		if(QMessageBox::warning(0,__tr2qs("Restore Default Script - KVIrc"),szError,QMessageBox::Yes, QMessageBox::No) != QMessageBox::Yes)
 			return;
 	}
 

--- a/src/kvirc/kernel/KviIconManager.cpp
+++ b/src/kvirc/kernel/KviIconManager.cpp
@@ -438,7 +438,7 @@ KviIconWidget::KviIconWidget(QWidget * pPar)
 
 void KviIconWidget::init()
 {
-	setWindowTitle(__tr2qs("Icon Table"));
+	setWindowTitle(__tr2qs("Icon Table - KVIrc"));
 	setWindowIcon(QIcon(*(g_pIconManager->getSmallIcon(KviIconManager::IconManager))));
 
 	int iRows = KviIconManager::IconCount / 20;

--- a/src/kvirc/kernel/KviInternalCommand.cpp
+++ b/src/kvirc/kernel/KviInternalCommand.cpp
@@ -84,7 +84,7 @@ static const char * internalCommandTable[KVI_NUM_INTERNAL_COMMANDS] =
 	"openurl https://github.com/kvirc/KVIrc/issues",
 	"raweditor.open",
 	"popupeditor.open",
-	"dialog.file(open,\"Select a Script File\"){ if(!$str.isEmpty($0))parse $0; }",
+	"dialog.file(open,\"Select a Script File - KVIrc\"){ if(!$str.isEmpty($0))parse $0; }",
 	"actioneditor.open",
 	"quit",
 	"openurl http://www.kvirc.ru",

--- a/src/kvirc/kernel/KviIpcSentinel.cpp
+++ b/src/kvirc/kernel/KviIpcSentinel.cpp
@@ -217,7 +217,7 @@
 	{
 		setObjectName("kvirc4_ipc_sentinel");
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
-		setWindowTitle("kvirc4_ipc_sentinel");
+		setWindowTitle("KVIrc4 IPC Sentinel - KVIrc");
 		setWindowFlags(Qt::FramelessWindowHint);
 #else
 	#if defined(COMPILE_X11_SUPPORT) && defined(COMPILE_QX11INFO_SUPPORT)

--- a/src/kvirc/kernel/KviMain.cpp
+++ b/src/kvirc/kernel/KviMain.cpp
@@ -448,7 +448,7 @@ int main(int argc, char ** argv)
 				KviCString szTmp(KviCString::Format,"Another KVIrc session is already running on this display and with this user ID.\nUse %s -f if you want to force a new session.",argv[0]);
 				if(a.bShowPopup)
 				{
-					QMessageBox::information(0,"Session - KVIrc",szTmp.ptr(),QMessageBox::Ok);
+					QMessageBox::information(0,"Duplicate Session Warning - KVIrc",szTmp.ptr(),QMessageBox::Ok);
 				} else {
 					qDebug("%s",szTmp.ptr());
 				}

--- a/src/kvirc/ui/KviFileDialog.cpp
+++ b/src/kvirc/ui/KviFileDialog.cpp
@@ -117,7 +117,7 @@ bool KviFileDialog::askForSaveFileName(QString & szBuffer, const QString & szCap
 
 			QString szTmp = QString(__tr2qs("The file %1 already exists.<br>Do you wish to overwrite it?")).arg(szBuffer);
 
-			switch(QMessageBox::information(pParent,__tr2qs("File Exists - KVIrc"),szTmp,QMessageBox::Yes,QMessageBox::No | QMessageBox::Default,QMessageBox::Cancel | QMessageBox::Escape))
+			switch(QMessageBox::information(pParent,__tr2qs("File Already Exists - KVIrc"),szTmp,QMessageBox::Yes,QMessageBox::No | QMessageBox::Default,QMessageBox::Cancel | QMessageBox::Escape))
 			{
 				case QMessageBox::Cancel:
 					return false;
@@ -161,7 +161,7 @@ bool KviFileDialog::askForSaveFileName(QString & szBuffer, const QString & szCap
 			{
 				QString szTmp = QString(__tr2qs("The file %1 already exists.<br>Do you wish to overwrite it?")).arg(szBuffer);
 
-				switch(QMessageBox::information(pDialog,__tr2qs("File Exists - KVIrc"),szTmp,QMessageBox::Yes,QMessageBox::No | QMessageBox::Default,QMessageBox::Cancel | QMessageBox::Escape))
+				switch(QMessageBox::information(pDialog,__tr2qs("File Already Exists - KVIrc"),szTmp,QMessageBox::Yes,QMessageBox::No | QMessageBox::Default,QMessageBox::Cancel | QMessageBox::Escape))
 				{
 					case QMessageBox::Cancel:
 						delete pDialog;

--- a/src/kvirc/ui/KviImageDialog.cpp
+++ b/src/kvirc/ui/KviImageDialog.cpp
@@ -104,7 +104,7 @@ KviImageDialog::KviImageDialog(QWidget * par,
 	setModal(modal);
 	m_iMaxPreviewFileSize = maxPreviewFileSize;
 
-	setWindowTitle(szCaption.isEmpty() ? __tr2qs("Choose image ...") : szCaption);
+	setWindowTitle(szCaption.isEmpty() ? __tr2qs("Choose an Image File - KVIrc") : szCaption);
 
 	m_pTimer = new QTimer(this);
 	connect(m_pTimer,SIGNAL(timeout()),this,SLOT(heartbeat()));

--- a/src/kvirc/ui/KviInput.cpp
+++ b/src/kvirc/ui/KviInput.cpp
@@ -247,7 +247,7 @@ void KviInput::keyPressEvent(QKeyEvent * e)
 										"Some IRC servers may also consider %1 lines of text a flood, " \
 										"in which case you will be disconnected from said server.<br><br>" \
 										"Do you still want the message to be sent?").arg(nLines));
-									pMsgBox.setWindowTitle(__tr2qs("Confirm Sending a Large Multi-line Message"));
+									pMsgBox.setWindowTitle(__tr2qs("Confirm Sending a Large Multi-line Message - KVIrc"));
 									pMsgBox.setIcon(QMessageBox::Question);
 									QAbstractButton *pAlwaysButton = pMsgBox.addButton(__tr2qs("Always"), QMessageBox::YesRole);
 									/* QAbstractButton *pYesButton = */ pMsgBox.addButton(__tr2qs("Yes"), QMessageBox::YesRole);

--- a/src/kvirc/ui/KviIrcView.cpp
+++ b/src/kvirc/ui/KviIrcView.cpp
@@ -2155,7 +2155,7 @@ void KviIrcView::chooseBackground()
 	QPixmap p(f);
 	if(p.isNull())
 	{
-		QMessageBox::information(this,__tr2qs("Invalid image"),__tr2qs("Failed to load the selected image"),__tr2qs("OK"));
+		QMessageBox::information(this,__tr2qs("Invalid Image Notice - KVIrc"),__tr2qs("Failed to load the selected image!"),__tr2qs("OK"));
 		return;
 	}
 

--- a/src/kvirc/ui/KviMainWindow.cpp
+++ b/src/kvirc/ui/KviMainWindow.cpp
@@ -858,7 +858,7 @@ void KviMainWindow::closeEvent(QCloseEvent *e)
 			txt += __tr2qs("quit KVIrc?");
 			txt += "</p>";
 
-			switch(QMessageBox::warning(this,__tr2qs("Confirmation - KVIrc"),txt,__tr2qs("&Yes"),__tr2qs("&Always"),__tr2qs("&No"),2,2))
+			switch(QMessageBox::warning(this,__tr2qs("Confirm Connections Close - KVIrc"),txt,__tr2qs("&Yes"),__tr2qs("&Always"),__tr2qs("&No"),2,2))
 			{
 				case 0:
 					// ok to close

--- a/src/kvirc/ui/KviStatusBar.cpp
+++ b/src/kvirc/ui/KviStatusBar.cpp
@@ -536,7 +536,7 @@ void KviStatusBar::mousePressEvent(QMouseEvent * e)
 
 void KviStatusBar::mouseDoubleClickEvent(QMouseEvent *)
 {
-	const QString szTitle = __tr2qs("Network information");
+	const QString szTitle = __tr2qs("Network Information - KVIrc");
 	QString szText, szUserModes, szAway;
 
 	KviIrcContext * c = m_pFrame->activeContext();
@@ -584,7 +584,7 @@ void KviStatusBar::mouseDoubleClickEvent(QMouseEvent *)
 	szText += ": ";
 	szText += c->connection()->userInfo()->localHostIp();
 	szText += "\n";
-	szText += __tr2qs("User Modes");
+	szText += __tr2qs("User modes");
 	szText += ": ";
 	szText += szUserModes;
 	szText += "\n";

--- a/src/modules/about/AboutDialog.cpp
+++ b/src/modules/about/AboutDialog.cpp
@@ -76,7 +76,7 @@ extern AboutDialog * g_pAboutDialog;
 AboutDialog::AboutDialog()
 : KviTalTabDialog(0)
 {
-	setWindowTitle(__tr2qs_ctx("About KVIrc...","about"));
+	setWindowTitle(__tr2qs_ctx("About KVIrc","about"));
 	setOkButton(__tr2qs_ctx("Close","about"));
 
 	// About tab

--- a/src/modules/actioneditor/ActionEditor.cpp
+++ b/src/modules/actioneditor/ActionEditor.cpp
@@ -721,7 +721,7 @@ void ActionEditor::exportActions()
 
 	if(!KviFileUtils::writeFile(szFile,szCode))
 	{
-		QMessageBox::warning(this,__tr2qs_ctx("Write Failed - KVIrc","editor"),__tr2qs_ctx("Unable to write to the actions file.","editor"),__tr2qs_ctx("OK","editor"));
+		QMessageBox::warning(this,__tr2qs_ctx("Write to File Failed - KVIrc","editor"),__tr2qs_ctx("Unable to write to the actions file.","editor"),__tr2qs_ctx("OK","editor"));
 	}
 }
 
@@ -738,7 +738,7 @@ void ActionEditor::deleteActions()
 
 	if(l.isEmpty())return;
 
-	//if(QMessageBox::question(this,__tr2qs_ctx("Confirm Deletion","editor"),__tr2qs_ctx("Do you really want to delete the selected actions ?","editor"),__tr2qs_ctx("Yes","editor"),__tr2qs_ctx("No","editor")) != 0)
+	//if(QMessageBox::question(this,__tr2qs_ctx("Confirm Actions Deletion - KVIrc","editor"),__tr2qs_ctx("Do you really want to delete the selected actions?","editor"),__tr2qs_ctx("Yes","editor"),__tr2qs_ctx("No","editor")) != 0)
 	//	return;
 
 	for(ActionEditorTreeWidgetItem * i = l.first();i;i = l.next())

--- a/src/modules/addon/AddonFunctions.cpp
+++ b/src/modules/addon/AddonFunctions.cpp
@@ -241,7 +241,7 @@ namespace AddonFunctions
 		}
 
 		if(!KviFileUtils::deleteDir(szUnpackPath))
-			QMessageBox::warning(NULL,__tr2qs_ctx("Warning While Unpacking Addon","addon"),__tr2qs_ctx("Failed to delete the directory '%1'","addon").arg(szUnpackPath));
+			QMessageBox::warning(NULL,__tr2qs_ctx("Warning While Unpacking Addon - KVIrc","addon"),__tr2qs_ctx("Failed to delete the directory '%1'","addon").arg(szUnpackPath));
 
 		return true;
 	}

--- a/src/modules/addon/AddonManagementDialog.cpp
+++ b/src/modules/addon/AddonManagementDialog.cpp
@@ -98,7 +98,7 @@ AddonListViewItem::~AddonListViewItem()
 AddonManagementDialog::AddonManagementDialog(QWidget * p)
 : QWidget(p)
 {
-	setWindowTitle(__tr2qs_ctx("Manage Script-Based Addons","addon"));
+	setWindowTitle(__tr2qs_ctx("Manage Script-based Addons - KVIrc","addon"));
 	setObjectName("Addon manager");
 	setWindowIcon(*(g_pIconManager->getSmallIcon(KviIconManager::Addons)));
 

--- a/src/modules/addon/AddonManagementDialog.cpp
+++ b/src/modules/addon/AddonManagementDialog.cpp
@@ -275,7 +275,7 @@ void AddonManagementDialog::uninstallScript()
 
 	if(QMessageBox::question(
 		this,
-		__tr2qs_ctx("Confirm addon uninstallation","addon"),
+		__tr2qs_ctx("Confirm Addon Uninstallation - KVIrc","addon"),
 		txt, __tr2qs_ctx("Yes","addon"), __tr2qs_ctx("No","addon"),0,1
 		) != 0) return;
 

--- a/src/modules/addon/PackAddonDialog.cpp
+++ b/src/modules/addon/PackAddonDialog.cpp
@@ -157,7 +157,7 @@ bool PackAddonDialog::packAddon()
 	{
 		if(QMessageBox::question(
 				this,
-				__tr2qs_ctx("Export Addon - KVIrc","addon"),
+				__tr2qs_ctx("Exporting Addon Confirmation - KVIrc","addon"),
 				__tr2qs_ctx("File %1 already exists. Do you want to overwrite it?","addon").arg(info.szSavePath),
 				QMessageBox::Yes,
 				QMessageBox::No
@@ -179,13 +179,13 @@ bool PackAddonDialog::packAddon()
 	if(!AddonFunctions::pack(info,szError))
 	{
 		QMessageBox::critical(this,
-			__tr2qs_ctx("Addon Packaging Error","addon"),
+			__tr2qs_ctx("Addon Packaging Error - KVIrc","addon"),
 			szError,QMessageBox::Ok,QMessageBox::NoButton,QMessageBox::NoButton
 		);
 		return false;
 	}
 
-	QMessageBox::information(this,__tr2qs_ctx("Export Addon - KVIrc","addon"),__tr2qs_ctx("Package saved successfully in %1","addon").arg(m_szSavePath),QMessageBox::Ok,QMessageBox::NoButton,QMessageBox::NoButton);
+	QMessageBox::information(this,__tr2qs_ctx("Exporting Addon Completed - KVIrc","addon"),__tr2qs_ctx("The Package was saved successfully in %1","addon").arg(m_szSavePath),QMessageBox::Ok,QMessageBox::NoButton,QMessageBox::NoButton);
 
 	return true;
 }
@@ -399,7 +399,7 @@ PackAddonSummaryFilesWidget::PackAddonSummaryFilesWidget(PackAddonDialog * pPare
 : QDialog(pParent)
 {
 	setObjectName("addon_package_summary_file_dialog");
-	setWindowTitle(__tr2qs_ctx("File Summary","addon"));
+	setWindowTitle(__tr2qs_ctx("Review File Summary - KVIrc","addon"));
 	setWindowModality(Qt::WindowModal);
 	setModal(true);
 

--- a/src/modules/addon/WebAddonInterfaceDialog.cpp
+++ b/src/modules/addon/WebAddonInterfaceDialog.cpp
@@ -40,7 +40,7 @@
 WebAddonInterfaceDialog::WebAddonInterfaceDialog(QWidget * par)
 : KviWebPackageManagementDialog(par)
 {
-	setWindowTitle(__tr2qs_ctx("KVIrc : Download Addons","theme"));
+	setWindowTitle(__tr2qs_ctx("Download Addons - KVIrc","theme"));
 
 	setPackagePageUrl(
 			QString::fromLatin1("http://www.kvirc.de/app/addons.php?version=" KVI_VERSION "&lang=%1")

--- a/src/modules/aliaseditor/AliasEditorWindow.cpp
+++ b/src/modules/aliaseditor/AliasEditorWindow.cpp
@@ -321,7 +321,7 @@ void AliasEditorWidget::aliasRefresh(const QString &szName)
 		return;
 	}
 	if(
-		QMessageBox::warning(0,__tr2qs_ctx("OverWrite Current Alias","editor"),
+		QMessageBox::warning(0,__tr2qs_ctx("Overwrite Current Alias - KVIrc","editor"),
 				__tr2qs_ctx("An external script has changed the alias you are currently editing. Do you want to accept the external changes?","editor"),
 				QMessageBox::Yes,QMessageBox::No|QMessageBox::Default|QMessageBox::Escape) != QMessageBox::Yes
 		)
@@ -426,9 +426,9 @@ void AliasEditorWidget::renameItem()
 	bool bAlias = m_pLastEditedItem->isAlias();
 
 	if(bAlias)
-		szNewName = askForAliasName(__tr2qs_ctx("Rename Alias","editor"),__tr2qs_ctx("Please enter the new name for the alias","editor"),szName);
+		szNewName = askForAliasName(__tr2qs_ctx("Enter a New Name - KVIrc","editor"),__tr2qs_ctx("Please enter the new name for the alias.","editor"),szName);
 	else
-		szNewName = askForNamespaceName(__tr2qs_ctx("Rename Namespace","editor"),__tr2qs_ctx("Please enter the new name for the namespace","editor"),szName);
+		szNewName = askForNamespaceName(__tr2qs_ctx("Enter a New Name - KVIrc","editor"),__tr2qs_ctx("Please enter the new name for the namespace.","editor"),szName);
 	if(szNewName.isEmpty())return;
 
 	if(szName == szNewName)return;
@@ -440,7 +440,7 @@ void AliasEditorWidget::renameItem()
 		{
 			g_pAliasEditorModule->lock();
 			QMessageBox::information(this,
-				__tr2qs_ctx("Alias already exists","editor"),
+				__tr2qs_ctx("Name Already Exists - KVIrc","editor"),
 				__tr2qs_ctx("This name is already in use. Please choose another one.","editor"),
 				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pAliasEditorModule->unlock();
@@ -452,7 +452,7 @@ void AliasEditorWidget::renameItem()
 		{
 			g_pAliasEditorModule->lock();
 			QMessageBox::information(this,
-				__tr2qs_ctx("Namespace already exists","editor"),
+				__tr2qs_ctx("Name Already Exists - KVIrc","editor"),
 				__tr2qs_ctx("This name is already in use. Please choose another one.","editor"),
 				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pAliasEditorModule->unlock();
@@ -716,7 +716,7 @@ void AliasEditorWidget::exportSelectionInSinglesFiles(KviPointerList<AliasEditor
 	if (!l->first())
 	{
 		g_pAliasEditorModule->lock();
-		QMessageBox::warning(this,__tr2qs_ctx("Alias Export","editor"),__tr2qs_ctx("There is no selection!","editor"),__tr2qs_ctx("OK","editor"));
+		QMessageBox::warning(this,__tr2qs_ctx("Warning While Exporting - KVIrc","editor"),__tr2qs_ctx("There is no selection!","editor"),__tr2qs_ctx("OK","editor"));
 		g_pAliasEditorModule->unlock();
 		return;
 	}
@@ -752,7 +752,7 @@ void AliasEditorWidget::exportSelectionInSinglesFiles(KviPointerList<AliasEditor
 		{
 			QString szMsg;
 			szMsg = QString(__tr2qs_ctx("The file \"%1\" exists. Do you want to replace it?","editor")).arg(szFileName);
-			int ret = QMessageBox::question(this,__tr2qs_ctx("Replace file","editor"),szMsg,__tr2qs_ctx("Yes","editor"),__tr2qs_ctx("Yes to All","editor"),__tr2qs_ctx("No","editor"));
+			int ret = QMessageBox::question(this,__tr2qs_ctx("Confirm Replacing File - KVIrc","editor"),szMsg,__tr2qs_ctx("Yes","editor"),__tr2qs_ctx("Yes to All","editor"),__tr2qs_ctx("No","editor"));
 			if (ret!=2)
 			{
 				KviFileUtils::writeFile(szCompletePath,tmp);
@@ -793,7 +793,7 @@ void AliasEditorWidget::exportAliases(bool bSelectedOnly,bool bSingleFiles)
 	if(szOut.isEmpty())
 	{
 		g_pAliasEditorModule->lock();
-		QMessageBox::warning(this,__tr2qs_ctx("Alias Export","editor"),__tr2qs_ctx("The exported file would be empty: cowardly refusing to write it","editor"),__tr2qs_ctx("OK","editor"));
+		QMessageBox::warning(this,__tr2qs_ctx("Warning While Exporting - KVIrc","editor"),__tr2qs_ctx("The exported file could be empty: cowardly refusing to write it.","editor"),__tr2qs_ctx("OK","editor"));
 		g_pAliasEditorModule->unlock();
 		return;
 	}
@@ -833,7 +833,7 @@ void AliasEditorWidget::exportAliases(bool bSelectedOnly,bool bSingleFiles)
 	if(!KviFileUtils::writeFile(szFile,szOut))
 	{
 		g_pAliasEditorModule->lock();
-		QMessageBox::warning(this,__tr2qs_ctx("Write Failed - KVIrc","editor"),__tr2qs_ctx("Unable to write to the alias file.","editor"),__tr2qs_ctx("OK","editor"));
+		QMessageBox::warning(this,__tr2qs_ctx("Write to File Failed - KVIrc","editor"),__tr2qs_ctx("Unable to write to the aliases file.","editor"),__tr2qs_ctx("OK","editor"));
 		g_pAliasEditorModule->unlock();
 	}
 }
@@ -944,7 +944,7 @@ bool AliasEditorWidget::removeItem(AliasEditorTreeWidgetItem *it,bool * pbYesToA
 		}
 
 		g_pAliasEditorModule->lock();
-		int ret = QMessageBox::question(this,__tr2qs_ctx("Remove item","editor"),szMsg,__tr2qs_ctx("Yes","editor"),__tr2qs_ctx("Yes to All","editor"),__tr2qs_ctx("No","editor"));
+		int ret = QMessageBox::question(this,__tr2qs_ctx("Confirm Removing Item - KVIrc","editor"),szMsg,__tr2qs_ctx("Yes","editor"),__tr2qs_ctx("Yes to All","editor"),__tr2qs_ctx("No","editor"));
 		g_pAliasEditorModule->unlock();
 		switch(ret)
 		{
@@ -1002,8 +1002,8 @@ QString AliasEditorWidget::askForAliasName(const QString &szAction,const QString
 		{
 			g_pAliasEditorModule->lock();
 			QMessageBox::warning(this,
-				__tr2qs_ctx("Missing Alias Name","editor"),
-				__tr2qs_ctx("You must specify a valid name for the alias","editor"),
+				__tr2qs_ctx("Invalid or Missing Name - KVIrc","editor"),
+				__tr2qs_ctx("You must specify a valid name for the alias.","editor"),
 				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pAliasEditorModule->unlock();
 			continue;
@@ -1015,8 +1015,8 @@ QString AliasEditorWidget::askForAliasName(const QString &szAction,const QString
 		{
 			g_pAliasEditorModule->lock();
 			QMessageBox::information(this,
-				__tr2qs_ctx("Bad Alias Name","editor"),
-				__tr2qs_ctx("Alias names can contain only letters, digits, underscores and '::' namespace separators","editor"),
+				__tr2qs_ctx("Invalid Name Notice - KVIrc","editor"),
+				__tr2qs_ctx("Aliases names can contain only letters, digits, underscores and '::' namespace separators.","editor"),
 				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pAliasEditorModule->unlock();
 			szNewName = "";
@@ -1029,7 +1029,7 @@ QString AliasEditorWidget::askForAliasName(const QString &szAction,const QString
 		{
 			g_pAliasEditorModule->lock();
 			QMessageBox::information(this,
-				__tr2qs_ctx("Bad Alias Name","editor"),
+				__tr2qs_ctx("Invalid Name Notice - KVIrc","editor"),
 				__tr2qs_ctx("Stray ':' character in alias name: did you mean ...<namespace>::<name>?","editor"),
 				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pAliasEditorModule->unlock();
@@ -1040,8 +1040,8 @@ QString AliasEditorWidget::askForAliasName(const QString &szAction,const QString
 		{
 			g_pAliasEditorModule->lock();
 			QMessageBox::information(this,
-				__tr2qs_ctx("Bad Alias Name","editor"),
-				__tr2qs_ctx("Found an empty namespace in alias name","editor"),
+				__tr2qs_ctx("Invalid Name Notice - KVIrc","editor"),
+				__tr2qs_ctx("Found an empty namespace in alias name.","editor"),
 				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pAliasEditorModule->unlock();
 			szNewName = "";
@@ -1070,8 +1070,8 @@ QString AliasEditorWidget::askForNamespaceName(const QString &szAction,const QSt
 		{
 			g_pAliasEditorModule->lock();
 			QMessageBox::warning(this,
-				__tr2qs_ctx("Missing Namespace Name","editor"),
-				__tr2qs_ctx("You must specify a valid name for the namespace","editor"),
+				__tr2qs_ctx("Invalid or Missing Name - KVIrc","editor"),
+				__tr2qs_ctx("You must specify a valid name for the namespace.","editor"),
 				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pAliasEditorModule->unlock();
 			continue;
@@ -1083,8 +1083,8 @@ QString AliasEditorWidget::askForNamespaceName(const QString &szAction,const QSt
 		{
 			g_pAliasEditorModule->lock();
 			QMessageBox::information(this,
-				__tr2qs_ctx("Bad Namespace Name","editor"),
-				__tr2qs_ctx("Namespace names can contain only letters, digits, underscores and '::' namespace separators","editor"),
+				__tr2qs_ctx("Invalid Name Notice - KVIrc","editor"),
+				__tr2qs_ctx("Namespace names can contain only letters, digits, underscores and '::' namespace separators.","editor"),
 				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pAliasEditorModule->unlock();
 			szNewName = "";
@@ -1097,7 +1097,7 @@ QString AliasEditorWidget::askForNamespaceName(const QString &szAction,const QSt
 		{
 			g_pAliasEditorModule->lock();
 			QMessageBox::information(this,
-				__tr2qs_ctx("Bad Namespace Name","editor"),
+				__tr2qs_ctx("Invalid Name Notice - KVIrc","editor"),
 				__tr2qs_ctx("Stray ':' character in namespace name: did you mean ...<namespace>::<name>?","editor"),
 				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pAliasEditorModule->unlock();
@@ -1108,8 +1108,8 @@ QString AliasEditorWidget::askForNamespaceName(const QString &szAction,const QSt
 		{
 			g_pAliasEditorModule->lock();
 			QMessageBox::information(this,
-				__tr2qs_ctx("Bad Namespace Name","editor"),
-				__tr2qs_ctx("Found an empty namespace in namespace name","editor"),
+				__tr2qs_ctx("Invalid Name Notice - KVIrc","editor"),
+				__tr2qs_ctx("Found an empty namespace in namespace name.","editor"),
 				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pAliasEditorModule->unlock();
 			szNewName = "";
@@ -1136,14 +1136,14 @@ void AliasEditorWidget::activateItem(QTreeWidgetItem * it)
 }
 void AliasEditorWidget::newAlias()
 {
-	QString szNewName = askForAliasName(__tr2qs_ctx("Add Alias","editor"),__tr2qs_ctx("Please enter the name for the new alias","editor"),"myfunction");
+	QString szNewName = askForAliasName(__tr2qs_ctx("Choose a Name - KVIrc","editor"),__tr2qs_ctx("Please enter the name for the new alias","editor"),"myfunction");
 	if(szNewName.isEmpty())return;
 	newItem(szNewName,AliasEditorTreeWidgetItem::Alias);
 }
 
 void AliasEditorWidget::newNamespace()
 {
-	QString szName = askForNamespaceName(__tr2qs_ctx("Add Namespace","editor"),__tr2qs_ctx("Please enter the name for the new namespace","editor"),"mynamespace");
+	QString szName = askForNamespaceName(__tr2qs_ctx("Choose a Name - KVIrc","editor"),__tr2qs_ctx("Please enter the name for the new namespace","editor"),"mynamespace");
 	if(szName.isEmpty())return;
 	newItem(szName,AliasEditorTreeWidgetItem::Namespace);
 }

--- a/src/modules/channelsjoin/ChannelsJoinDialog.cpp
+++ b/src/modules/channelsjoin/ChannelsJoinDialog.cpp
@@ -60,7 +60,7 @@ ChannelsJoinDialog::ChannelsJoinDialog(const char * name)
 : QDialog(g_pMainWindow)
 {
 	setObjectName(name);
-	setWindowTitle(__tr2qs("Join Channels"));
+	setWindowTitle(__tr2qs("Join Channels - KVIrc"));
 	setWindowIcon(*(g_pIconManager->getSmallIcon(KviIconManager::Channel)));
 
 	m_pConsole = 0;

--- a/src/modules/classeditor/ClassEditorWindow.cpp
+++ b/src/modules/classeditor/ClassEditorWindow.cpp
@@ -1964,7 +1964,7 @@ KviClassEditorDialog::KviClassEditorDialog(QWidget * pParent, const QString & sz
 
 	pLabel = new QLabel(pHBox);
 	pLabel->setObjectName("Inheritsclasslabel");
-	pLabel->setText(__tr2qs_ctx("Inherits Class:","editor"));
+	pLabel->setText(__tr2qs_ctx("Inherits class:","editor"));
 
 	m_pInheritsClassComboBox = new QComboBox(pHBox);
 	pLabel->setBuddy(m_pInheritsClassComboBox);

--- a/src/modules/classeditor/ClassEditorWindow.cpp
+++ b/src/modules/classeditor/ClassEditorWindow.cpp
@@ -476,7 +476,7 @@ void ClassEditorWidget::classRefresh(const QString & szName)
 		return;
 	}
 	if(
-		QMessageBox::warning(0,__tr2qs_ctx("OverWrite Current Class","editor"),
+		QMessageBox::warning(0,__tr2qs_ctx("Overwrite Current Class","editor"),
 				__tr2qs_ctx("An external script has changed the class you are currently editing. Do you want to accept the external changes?","editor"),
 				QMessageBox::Yes,QMessageBox::No|QMessageBox::Default|QMessageBox::Escape) != QMessageBox::Yes
 		)
@@ -538,8 +538,8 @@ void ClassEditorWidget::renameFunction()
 		} else {
 			g_pClassEditorModule->lock();
 			QMessageBox::information(this,
-			__tr2qs_ctx("Function already exists","editor"),
-			__tr2qs_ctx("This name is already in use. Please choose another one.","editor"),
+			__tr2qs_ctx("Name Already Exists - KVIrc","editor"),
+			__tr2qs_ctx("This function name is already in use. Please choose another one.","editor"),
 			__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pClassEditorModule->unlock();
 			return;
@@ -600,8 +600,8 @@ void ClassEditorWidget::renameClass(ClassEditorTreeWidgetItem * pClassItem)
 	{
 		g_pClassEditorModule->lock();
 		QMessageBox::information(this,
-			__tr2qs_ctx("Class already exists","editor"),
-			__tr2qs_ctx("This name is already in use. Please choose another one.","editor"),
+			__tr2qs_ctx("Name Already Exists - KVIrc","editor"),
+			__tr2qs_ctx("This class name is already in use. Please choose another one.","editor"),
 			__tr2qs_ctx("OK, Let me try again...","editor"));
 		g_pClassEditorModule->unlock();
 		return;
@@ -673,7 +673,7 @@ void ClassEditorWidget::renameNamespace(ClassEditorTreeWidgetItem * pOldNamespac
 {
 	QString szOldNameSpaceName = buildFullClassName(m_pLastEditedItem);
 	QString szNewNameSpaceName;
-	if(!askForNamespaceName(__tr2qs_ctx("Rename Namespace","editor"),__tr2qs_ctx("Please enter the new name for the namespace","editor"),szOldNameSpaceName,szNewNameSpaceName))
+	if(!askForNamespaceName(__tr2qs_ctx("Enter a New Name - KVIrc","editor"),__tr2qs_ctx("Please enter the new name for the namespace.","editor"),szOldNameSpaceName,szNewNameSpaceName))
 		return;
 	if(KviQString::equalCI(szOldNameSpaceName,szNewNameSpaceName))
 		return;
@@ -684,13 +684,13 @@ void ClassEditorWidget::renameNamespace(ClassEditorTreeWidgetItem * pOldNamespac
 		if(pNewItem->isClass())
 		{
 			QMessageBox::information(this,
-				__tr2qs_ctx("Name already exists as class name","editor"),
-				__tr2qs_ctx("This name is already in use as class name. Please choose another one.","editor"),
+				__tr2qs_ctx("Name Already Exists - KVIrc","editor"),
+				__tr2qs_ctx("This class name is already in use. Please choose another one.","editor"),
 				__tr2qs_ctx("OK, Let me try again...","editor"));
 		} else {
 			QMessageBox::information(this,
-			__tr2qs_ctx("Namespace already exists","editor"),
-			__tr2qs_ctx("This name is already in use. Please choose another one.","editor"),
+			__tr2qs_ctx("Name Already Exists - KVIrc","editor"),
+			__tr2qs_ctx("This namespace name is already in use. Please choose another one.","editor"),
 			__tr2qs_ctx("OK, Let me try again...","editor"));
 		}
 		g_pClassEditorModule->unlock();
@@ -1108,7 +1108,7 @@ void ClassEditorWidget::exportSelectionInSinglesFiles(KviPointerList<ClassEditor
 	if(!pList->first())
 	{
 		g_pClassEditorModule->lock();
-		QMessageBox::warning(this,__tr2qs_ctx("Class Export","editor"),__tr2qs_ctx("There is no selection!","editor"),__tr2qs_ctx("OK","editor"));
+		QMessageBox::warning(this,__tr2qs_ctx("Warning While Exporting - KVIrc","editor"),__tr2qs_ctx("Must select a class entry from list to export!","editor"),__tr2qs_ctx("OK","editor"));
 		g_pClassEditorModule->unlock();
 		return;
 	}
@@ -1142,7 +1142,7 @@ void ClassEditorWidget::exportSelectionInSinglesFiles(KviPointerList<ClassEditor
 		if(KviFileUtils::fileExists(szCompletePath) && !bReplaceAll)
 		{
 			QString szMsg = __tr2qs_ctx("The file \"%1\" exists. Do you want to replace it?","editor").arg(szFileName);
-			int iRet = QMessageBox::question(this,__tr2qs_ctx("Replace file","editor"),szMsg,__tr2qs_ctx("Yes","editor"),__tr2qs_ctx("Yes to All","editor"),__tr2qs_ctx("No","editor"));
+			int iRet = QMessageBox::question(this,__tr2qs_ctx("Confirm Replacing File - KVIrc","editor"),szMsg,__tr2qs_ctx("Yes","editor"),__tr2qs_ctx("Yes to All","editor"),__tr2qs_ctx("No","editor"));
 			if(iRet != 2)
 			{
 				KviFileUtils::writeFile(szCompletePath,szTmp);
@@ -1211,7 +1211,7 @@ void ClassEditorWidget::exportClasses(bool bSelectedOnly, bool bSingleFiles)
 	if(szOut.isEmpty())
 	{
 		g_pClassEditorModule->lock();
-		QMessageBox::warning(this,__tr2qs_ctx("Class Export","editor"),__tr2qs_ctx("The exported file would be empty: cowardly refusing to write it","editor"),__tr2qs_ctx("OK","editor"));
+		QMessageBox::warning(this,__tr2qs_ctx("Warning While Exporting - KVIrc","editor"),__tr2qs_ctx("The exported class file could be empty: cowardly refusing to write it","editor"),__tr2qs_ctx("OK","editor"));
 		g_pClassEditorModule->unlock();
 		return;
 	}
@@ -1252,7 +1252,7 @@ void ClassEditorWidget::exportClasses(bool bSelectedOnly, bool bSingleFiles)
 	if(!KviFileUtils::writeFile(szFile,szOut))
 	{
 		g_pClassEditorModule->lock();
-		QMessageBox::warning(this,__tr2qs_ctx("Write Failed - KVIrc","editor"),__tr2qs_ctx("Unable to write to the class file.","editor"),__tr2qs_ctx("OK","editor"));
+		QMessageBox::warning(this,__tr2qs_ctx("Write to Classes File Failed - KVIrc","editor"),__tr2qs_ctx("Unable to write to the classes file.","editor"),__tr2qs_ctx("OK","editor"));
 		g_pClassEditorModule->unlock();
 	}
 }
@@ -1374,14 +1374,14 @@ bool ClassEditorWidget::removeItem(ClassEditorTreeWidgetItem * pItem, KviPointer
 		{
 			szMsg = QString(__tr2qs_ctx("Do you really want to remove the namespace \"%1\"?","editor")).arg(szName);
 			szMsg += "<br>";
-			szMsg += __tr2qs_ctx("Please note that all the child classes/functions will be deleted too.","editor");
+			szMsg += __tr2qs_ctx("Please note that all the child classes/functions will also be deleted.","editor");
 		} else if(pItem->isMethod())
 		{
 			szMsg = QString(__tr2qs_ctx("Do you really want to remove the function \"%1\"?","editor")).arg(szName);
 		}
 
 		g_pClassEditorModule->lock();
-		int iRet = QMessageBox::question(this,__tr2qs_ctx("Remove item","editor"),szMsg,__tr2qs_ctx("Yes","editor"),__tr2qs_ctx("Yes to All","editor"),__tr2qs_ctx("No","editor"));
+		int iRet = QMessageBox::question(this,__tr2qs_ctx("Confirm Removing Item - KVIrc","editor"),szMsg,__tr2qs_ctx("Yes","editor"),__tr2qs_ctx("Yes to All","editor"),__tr2qs_ctx("No","editor"));
 		g_pClassEditorModule->unlock();
 		switch(iRet)
 		{
@@ -1420,7 +1420,7 @@ bool ClassEditorWidget::removeItem(ClassEditorTreeWidgetItem * pItem, KviPointer
 			QDir d(szPath);
 			if(d.exists(szFileName))
 			{
-				qDebug("rimuovo dal disco il file %s",szFileName.toUtf8().data());
+				qDebug("Removing file %s from disk",szFileName.toUtf8().data());
 				d.remove(szFileName);
 			}
 		}
@@ -1519,8 +1519,8 @@ bool ClassEditorWidget::askForNamespaceName(const QString & szAction, const QStr
 		{
 			g_pClassEditorModule->lock();
 			QMessageBox::warning(this,
-				__tr2qs_ctx("Missing Namespace Name","editor"),
-				__tr2qs_ctx("You must specify a valid name for the namespace","editor"),
+				__tr2qs_ctx("Invalid or Missing Name - KVIrc","editor"),
+				__tr2qs_ctx("You must specify a valid name for the namespace.","editor"),
 				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pClassEditorModule->unlock();
 			continue;
@@ -1532,8 +1532,8 @@ bool ClassEditorWidget::askForNamespaceName(const QString & szAction, const QStr
 		{
 			g_pClassEditorModule->lock();
 			QMessageBox::information(this,
-				__tr2qs_ctx("Bad Namespace Name","editor"),
-				__tr2qs_ctx("Namespace names can contain only letters, digits, underscores and '::' namespace separators","editor"),
+				__tr2qs_ctx("Invalid Name Notice - KVIrc","editor"),
+				__tr2qs_ctx("Namespace names can contain only letters, digits, underscores and '::' namespace separators.","editor"),
 				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pClassEditorModule->unlock();
 			szNewName = "";
@@ -1546,7 +1546,7 @@ bool ClassEditorWidget::askForNamespaceName(const QString & szAction, const QStr
 		{
 			g_pClassEditorModule->lock();
 			QMessageBox::information(this,
-				__tr2qs_ctx("Bad Namespace Name","editor"),
+				__tr2qs_ctx("Invalid Name Notice - KVIrc","editor"),
 				__tr2qs_ctx("Stray ':' character in namespace name: did you mean ...<namespace>::<name>?","editor"),
 				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pClassEditorModule->unlock();
@@ -1557,8 +1557,8 @@ bool ClassEditorWidget::askForNamespaceName(const QString & szAction, const QStr
 		{
 			g_pClassEditorModule->lock();
 			QMessageBox::information(this,
-				__tr2qs_ctx("Bad Namespace Name","editor"),
-				__tr2qs_ctx("Found an empty namespace in namespace name","editor"),
+				__tr2qs_ctx("Invalid Name Notice - KVIrc","editor"),
+				__tr2qs_ctx("Found an empty namespace in namespace name.","editor"),
 				__tr2qs_ctx("OK, Let me try again...","editor"));
 			g_pClassEditorModule->unlock();
 			szNewName = "";
@@ -1609,7 +1609,7 @@ void ClassEditorWidget::newClass()
 void ClassEditorWidget::newNamespace()
 {
 	QString szName;
-	if(!askForNamespaceName(__tr2qs_ctx("Add Namespace","editor"),__tr2qs_ctx("Please enter the name for the new namespace","editor"),"mynamespace",szName))
+	if(!askForNamespaceName(__tr2qs_ctx("Add Namespace - KVIrc","editor"),__tr2qs_ctx("Please enter the name for the new namespace","editor"),"mynamespace",szName))
 		return;
 	if(szName.isEmpty())
 		return;
@@ -1722,7 +1722,7 @@ void ClassEditorWidget::build()
 							skipClasses.append(lInheritedClasses.at(u));
 						}
 					}
-					QMessageBox::critical(this,__tr2qs_ctx("Compilation error - KVIrc","editor"),szError,
+					QMessageBox::critical(this,__tr2qs_ctx("Compilation Error - KVIrc","editor"),szError,
 					QMessageBox::Ok,QMessageBox::NoButton,QMessageBox::NoButton);
 					break;
 				}

--- a/src/modules/dialog/libkvidialog.cpp
+++ b/src/modules/dialog/libkvidialog.cpp
@@ -162,7 +162,7 @@ void KviKvsCallbackMessageBox::done(int code)
 		to be the escape button of the dialog.[br]
 		<magic1>, <magic2>... are the magic parameters - evaluated at dialog.message call time and passed
 		to the <callback_command> as positional parameters.[br]
-		If the -b or -modal switch is specified the dialog will have blocking modal behaviour -
+		If the -b or -modal switch is specified the dialog will have blocking modal behavior -
 		it will appear above its parent widget and block its input until the dialog is closed.[br]
 		Once the dialog is displayed, the user will click one of the buttons. At this point the dialog
 		is hidden and the <callback_command> is executed, passing the number of the button clicked

--- a/src/modules/editor/ScriptEditorImplementation.cpp
+++ b/src/modules/editor/ScriptEditorImplementation.cpp
@@ -955,7 +955,7 @@ void ScriptEditorImplementation::saveToFile()
 		{
 			QString szTmp;
 			QMessageBox::warning(this,
-				__tr2qs_ctx("Save Failed - KVIrc","editor"),
+				__tr2qs_ctx("Saving File Failed - KVIrc","editor"),
 				szTmp = QString(__tr2qs_ctx("Can't open the file %1 for writing.","editor")).arg(szFileName));
 		}
 	}
@@ -1030,7 +1030,7 @@ void ScriptEditorImplementation::loadFromFile()
 {
 	QString szFileName;
 	if(KviFileDialog::askForOpenFileName(szFileName,
-		__tr2qs_ctx("Load Script File - KVIrc","editor"),
+		__tr2qs_ctx("Load a Script File - KVIrc","editor"),
 		QString::null,KVI_FILTER_SCRIPT,false,true,this))
 	{
 		QString szBuffer;
@@ -1043,7 +1043,7 @@ void ScriptEditorImplementation::loadFromFile()
 		} else {
 			QString szTmp;
 			QMessageBox::warning(this,
-				__tr2qs_ctx("Open Failed - KVIrc","editor"),
+				__tr2qs_ctx("Opening File Failed - KVIrc","editor"),
 				szTmp = QString(__tr2qs_ctx("Can't open the file %1 for reading.","editor")).arg(szFileName));
 		}
 	}

--- a/src/modules/editor/ScriptEditorImplementation.cpp
+++ b/src/modules/editor/ScriptEditorImplementation.cpp
@@ -538,7 +538,7 @@ ScriptEditorWidgetColorOptions::ScriptEditorWidgetColorOptions(QWidget * pParent
 {
 	m_pSelectorInterfaceList = new KviPointerList<KviSelectorInterface>;
 	m_pSelectorInterfaceList->setAutoDelete(false);
-	setWindowTitle(__tr2qs_ctx("Preferences","editor"));
+	setWindowTitle(__tr2qs_ctx("Editor Configuration - KVIrc","editor"));
 	QGridLayout * g = new QGridLayout(this);
 	KviTalVBox * box = new KviTalVBox(this);
 	g->addWidget(box,0,0);

--- a/src/modules/eventeditor/EventEditorWindow.cpp
+++ b/src/modules/eventeditor/EventEditorWindow.cpp
@@ -467,7 +467,7 @@ void EventEditor::exportCurrentHandler()
 
 	if(!KviFileUtils::writeFile(szFile,szOut))
 	{
-		QMessageBox::warning(this,__tr2qs_ctx("Write Failed - KVIrc","editor"),__tr2qs_ctx("Unable to write to the event file.","editor"),__tr2qs_ctx("&OK","editor"));
+		QMessageBox::warning(this,__tr2qs_ctx("Write to File Failed - KVIrc","editor"),__tr2qs_ctx("Unable to write to the events file.","editor"),__tr2qs_ctx("&OK","editor"));
 	}
 }
 
@@ -505,7 +505,7 @@ void EventEditor::exportAllEvents()
 
 	if(!KviFileUtils::writeFile(szFile,out))
 	{
-		QMessageBox::warning(this,__tr2qs_ctx("Write Failed - KVIrc","editor"),__tr2qs_ctx("Unable to write to the events file.","editor"),__tr2qs_ctx("OK","editor"));
+		QMessageBox::warning(this,__tr2qs_ctx("Write to File Failed","editor"),__tr2qs_ctx("Unable to write to the events file.","editor"),__tr2qs_ctx("OK","editor"));
 	}
 }
 

--- a/src/modules/filetransferwindow/FileTransferWindow.cpp
+++ b/src/modules/filetransferwindow/FileTransferWindow.cpp
@@ -624,12 +624,12 @@ void FileTransferWindow::deleteLocalFile()
 	QString szName = pTransfer->localFileName();
 	QString szTmp = QString(__tr2qs_ctx("Do you really want to delete the file %1?","filetransferwindow")).arg(szName);
 
-	if(QMessageBox::warning(this,__tr2qs_ctx("Confirm Delete","filetransferwindow"),
+	if(QMessageBox::warning(this,__tr2qs_ctx("Confirm File Delete - KVIrc","filetransferwindow"),
 			szTmp,__tr2qs_ctx("Yes","filetransferwindow"),__tr2qs_ctx("No","filetransferwindow")) != 0)
 		return;
 
 	if(!QFile::remove(szName))
-		QMessageBox::warning(this,__tr2qs_ctx("Delete failed","filetransferwindow"),
+		QMessageBox::warning(this,__tr2qs_ctx("Deleting File Failed - KVIrc","filetransferwindow"),
 			__tr2qs_ctx("Failed to remove the file","filetransferwindow"),
 			__tr2qs_ctx("OK","filetransferwindow"));
 }
@@ -791,7 +791,7 @@ void FileTransferWindow::clearAll()
 
 	// If any transfer is active asks for confirm
 	if(!bHaveAllTerminated)
-		if(QMessageBox::warning(this,__tr2qs_ctx("Clear All Transfers? - KVIrc","filetransferwindow"), szTmp,__tr2qs_ctx("Yes","filetransferwindow"),__tr2qs_ctx("No","filetransferwindow")) != 0)
+		if(QMessageBox::warning(this,__tr2qs_ctx("Confirm Clearing All Transfers - KVIrc","filetransferwindow"), szTmp,__tr2qs_ctx("Yes","filetransferwindow"),__tr2qs_ctx("No","filetransferwindow")) != 0)
 			return;
 
 	KviFileTransferManager::instance()->killAllTransfers();

--- a/src/modules/help/HelpWindow.cpp
+++ b/src/modules/help/HelpWindow.cpp
@@ -215,7 +215,7 @@ void HelpWindow::startSearch()
 				s = s.toLower();
 				s = s.simplified();
 				if ( s.contains( '*' ) ) {
-				QMessageBox::warning( this, tr( "Full Text Search" ),
+				QMessageBox::warning( this, tr( "Full Text Search - KVIrc" ),
 					tr( "Using a wildcard within phrases is not allowed." ) );
 				return;
 				}
@@ -224,7 +224,7 @@ void HelpWindow::startSearch()
 				beg = str.indexOf( '\"', end + 1);
 			}
 		} else {
-			QMessageBox::warning( this, tr( "Full Text Search" ),
+			QMessageBox::warning( this, tr( "Full Text Search - KVIrc" ),
 				tr( "The closing quotation mark is missing." ) );
 			return;
 		}

--- a/src/modules/mircimport/libkvimircimport.cpp
+++ b/src/modules/mircimport/libkvimircimport.cpp
@@ -114,7 +114,7 @@ int KviMircServersIniImport::doImport(const QString& filename)
 		} while(!entry.isEmpty());
 	} else {
 		QString szTmp = QString(__tr2qs("%1 doesn't look like a servers.ini file.\nImport failed.")).arg(filename);
-		QMessageBox::warning(0,__tr2qs("Warning - KVIrc"),szTmp);
+		QMessageBox::warning(0,__tr2qs("File Import Warning - KVIrc"),szTmp);
 	}
 	return iCount;
 }

--- a/src/modules/objects/KvsObject_painter.cpp
+++ b/src/modules/objects/KvsObject_painter.cpp
@@ -492,7 +492,7 @@ const char * const brushstyles_tbl[] = {
 		}[br]
 		[br]
 		%Hello=$new(hello)[br]
-		%Hello->$setWindowTitle("Painter effects" );[br]
+		%Hello->$setWindowTitle("Painter Effects" );[br]
 		%Hello->$setFont(28,"times",bold);[br]
 		%Btn=$new(button,%Hello)[br]
 		%Btn->$setmaximumwidth(80)[br]

--- a/src/modules/options/OptionsWidget_identity.cpp
+++ b/src/modules/options/OptionsWidget_identity.cpp
@@ -58,7 +58,7 @@ NickAlternativesDialog::NickAlternativesDialog(QWidget * par,const QString &n1,c
 {
 	QGridLayout * g = new QGridLayout(this);
 
-	setWindowTitle(__tr2qs_ctx("Nickname Alternatives","options"));
+	setWindowTitle(__tr2qs_ctx("Nickname Alternatives - KVIrc","options"));
 
 	QLabel * l = new QLabel(this);
 	l->setText(__tr2qs_ctx("Here you can choose up to three nickname " \

--- a/src/modules/options/OptionsWidget_identity.cpp
+++ b/src/modules/options/OptionsWidget_identity.cpp
@@ -598,7 +598,7 @@ void OptionsWidget_identityAvatar::chooseAvatar()
 		{
 			QMessageBox::warning(
 					this,
-					__tr2qs_ctx("Avatar Might Be Too Big - KVIrc","options"),
+					__tr2qs_ctx("Avatar File Dimensions Warning - KVIrc","options"),
 					__tr2qs_ctx(
 							"The avatar you have chosen is bigger than 1024x768 pixels.<br>" \
 							"Such a big image will not be seen on all the user monitors<br>" \
@@ -614,7 +614,7 @@ void OptionsWidget_identityAvatar::chooseAvatar()
 			{
 				QMessageBox::warning(
 						this,
-						__tr2qs_ctx("Avatar Might Be Too Big - KVIrc","options"),
+						__tr2qs_ctx("Avatar File Size Warning - KVIrc","options"),
 						__tr2qs_ctx(
 								"The avatar you have chosen is bigger than 500 KiB<br>" \
 								"and most clients will refuse to download it.<br>" \
@@ -832,7 +832,7 @@ void OptionsWidget_identityProfile::editProfileOkPressed()
 	{
 		if(m_pEditor->m_pNameEdit->text() == m_pTreeWidget->topLevelItem(i)->text(0) && i!=m_iCurrentEditedProfile)
 		{
-			QMessageBox::warning(this,__tr2qs_ctx("Invalid Profile Rule","options"),__tr2qs_ctx("There is already a profile with that name","options"),__tr2qs_ctx("OK","options"));
+			QMessageBox::warning(this,__tr2qs_ctx("Invalid Profile Rule - KVIrc","options"),__tr2qs_ctx("There is already a profile with that name","options"),__tr2qs_ctx("OK","options"));
 			return;
 		}
 	}

--- a/src/modules/options/OptionsWidget_nickserv.cpp
+++ b/src/modules/options/OptionsWidget_nickserv.cpp
@@ -45,7 +45,7 @@ extern KVIRC_API KviNickServRuleSet * g_pNickServRuleSet;
 NickServRuleEditor::NickServRuleEditor(QWidget * par,bool bUseServerMaskField)
 : QDialog(par)
 {
-	setWindowTitle(__tr2qs_ctx("NickServ Authentication Rule","options"));
+	setWindowTitle(__tr2qs_ctx("NickServ Authentication Rule - KVIrc","options"));
 
 	QString html_center_begin = "";
 	QString html_center_end = "";

--- a/src/modules/options/OptionsWidget_nickserv.cpp
+++ b/src/modules/options/OptionsWidget_nickserv.cpp
@@ -150,7 +150,7 @@ bool NickServRuleEditor::validate()
 {
 	QString s = m_pRegisteredNickEdit->text();
 
-	QString m = __tr2qs_ctx("Invalid NickServ Rule","options");
+	QString m = __tr2qs_ctx("Invalid NickServ Rule - KVIrc","options");
 	QString o = __tr2qs_ctx("OK","options");
 
 	if(s.isEmpty())

--- a/src/modules/options/OptionsWidget_servers.cpp
+++ b/src/modules/options/OptionsWidget_servers.cpp
@@ -102,7 +102,7 @@ IrcNetworkDetailsWidget::IrcNetworkDetailsWidget(QWidget * par,KviIrcNetwork * n
 
 	QGridLayout * g = new QGridLayout(this);
 
-	setWindowTitle(__tr2qs_ctx("Network Details","options"));
+	setWindowTitle(__tr2qs_ctx("Network Details and Configuration - KVIrc","options"));
 	setWindowIcon(QIcon(*(g_pIconManager->getSmallIcon(KviIconManager::World))));
 
 	QString szTmp = "<font size=\"+1\"><b>";
@@ -522,7 +522,7 @@ IrcServerDetailsWidget::IrcServerDetailsWidget(QWidget * par,KviIrcServer * s)
 	m_szHostname = s->hostName();
 	QGridLayout * g = new QGridLayout(this);
 
-	setWindowTitle(__tr2qs_ctx("Server Details","options"));
+	setWindowTitle(__tr2qs_ctx("Server Details and Configuration - KVIrc","options"));
 	setWindowIcon(QIcon(*(g_pIconManager->getSmallIcon(KviIconManager::Server))));
 
 	m_pHeaderLabel = new QLabel("",this); // the text will be set later

--- a/src/modules/options/OptionsWidget_servers.cpp
+++ b/src/modules/options/OptionsWidget_servers.cpp
@@ -2136,7 +2136,7 @@ void OptionsWidget_servers::clearList()
 	txt += "</p>";
 
 	if(QMessageBox::question(this,
-		__tr2qs_ctx("Confirm Clear Server List - KVIrc","options"),txt,
+		__tr2qs_ctx("Confirm Clearing Server List - KVIrc","options"),txt,
 		__tr2qs_ctx("Yes","options"), __tr2qs_ctx("No","options"),0,1
 		) != 0) return;
 

--- a/src/modules/popupeditor/PopupEditorWindow.cpp
+++ b/src/modules/popupeditor/PopupEditorWindow.cpp
@@ -1111,7 +1111,7 @@ void PopupEditorWidget::popupRefresh(const QString &szName)
 			if(ch==m_pLastEditedItem)
 			{
 				if(
-					QMessageBox::warning(0,__tr2qs_ctx("OverWrite Current Popup","editor"),
+					QMessageBox::warning(0,__tr2qs_ctx("Overwrite Current Popup - KVIrc","editor"),
 						__tr2qs_ctx("An external script has changed the popup you are currently editing. Do you want to accept the external changes?","editor"),
 						QMessageBox::Yes,QMessageBox::No|QMessageBox::Default|QMessageBox::Escape) != QMessageBox::Yes
 				) return;
@@ -1190,7 +1190,7 @@ void PopupEditorWidget::exportCurrentPopup()
 
 	if(!KviFileUtils::writeFile(szFile,szOut))
 	{
-		QMessageBox::warning(this,__tr2qs_ctx("Write Failed - KVIrc","editor"),__tr2qs_ctx("Unable to write to the popup file.","editor"),__tr2qs_ctx("OK","editor"));
+		QMessageBox::warning(this,__tr2qs_ctx("Write to File Failed - KVIrc","editor"),__tr2qs_ctx("Unable to write to the popups file.","editor"),__tr2qs_ctx("OK","editor"));
 	}
 }
 
@@ -1238,7 +1238,7 @@ void PopupEditorWidget::exportPopups(bool bSelectedOnly)
 
 	if(!KviFileUtils::writeFile(szFile,out))
 	{
-		QMessageBox::warning(this,__tr2qs_ctx("Write Failed - KVIrc","editor"),__tr2qs_ctx("Unable to write to the alias file.","editor"),__tr2qs_ctx("OK","editor"));
+		QMessageBox::warning(this,__tr2qs_ctx("Write to File Failed - KVIrc","editor"),__tr2qs_ctx("Unable to write to the popups file.","editor"),__tr2qs_ctx("OK","editor"));
 	}
 }
 

--- a/src/modules/raweditor/RawEditorWindow.cpp
+++ b/src/modules/raweditor/RawEditorWindow.cpp
@@ -423,7 +423,7 @@ void RawEditorWidget::exportCurrentHandler()
 
 	if(!KviFileUtils::writeFile(szFile,szOut))
 	{
-		QMessageBox::warning(this,__tr2qs_ctx("Write Failed - KVIrc","editor"),__tr2qs_ctx("Unable to write to the RAW event file.","editor"),__tr2qs_ctx("&OK","editor"));
+		QMessageBox::warning(this,__tr2qs_ctx("Write to File Failed - KVIrc","editor"),__tr2qs_ctx("Unable to write to the RAW events file.","editor"),__tr2qs_ctx("&OK","editor"));
 	}
 }
 
@@ -458,7 +458,7 @@ void RawEditorWidget::exportAllEvents()
 
 	if(!KviFileUtils::writeFile(szFile,out))
 	{
-		QMessageBox::warning(this,__tr2qs_ctx("Write Failed - KVIrc","editor"),__tr2qs_ctx("Unable to write to the RAW events file.","editor"),__tr2qs_ctx("OK","editor"));
+		QMessageBox::warning(this,__tr2qs_ctx("Write to File Failed - KVIrc","editor"),__tr2qs_ctx("Unable to write to the RAW events file.","editor"),__tr2qs_ctx("OK","editor"));
 	}
 }
 

--- a/src/modules/reguser/RegisteredUserEntryDialog.cpp
+++ b/src/modules/reguser/RegisteredUserEntryDialog.cpp
@@ -74,7 +74,7 @@ RegisteredUserPropertiesDialog::RegisteredUserPropertiesDialog(QWidget * p,KviPo
 	setWindowModality(Qt::WindowModal);
 	m_pPropertyDict = dict;
 
-	setWindowTitle(__tr2qs_ctx("Property Editor","register"));
+	setWindowTitle(__tr2qs_ctx("Property Editor - KVirc","register"));
 	setWindowIcon(*(g_pIconManager->getSmallIcon(KviIconManager::Linux)));
 
 	QGridLayout * g = new QGridLayout(this);
@@ -208,7 +208,7 @@ RegisteredUserMaskDialog::RegisteredUserMaskDialog(QWidget * p,KviIrcMask * m)
 	setWindowModality(Qt::WindowModal);
 	m_pMask = m;
 
-	setWindowTitle(__tr2qs_ctx("Mask Editor","register"));
+	setWindowTitle(__tr2qs_ctx("Mask Editor - KVIrc","register"));
 
 	QGridLayout * g = new QGridLayout(this);
 
@@ -316,7 +316,7 @@ RegisteredUserEntryDialog::RegisteredUserEntryDialog(QWidget *p,KviRegisteredUse
 	//setMinimumSize(400,450);
 
 	setWindowIcon(*(g_pIconManager->getSmallIcon(KviIconManager::Linux)));
-	setWindowTitle(__tr2qs_ctx("Registered User Entry","register"));
+	setWindowTitle(__tr2qs_ctx("Registered User Entry - KVIrc","register"));
 
 	QWidget * p1 = new QWidget(this);
 

--- a/src/modules/reguser/RegisteredUsersDialog.cpp
+++ b/src/modules/reguser/RegisteredUsersDialog.cpp
@@ -222,7 +222,7 @@ RegisteredUsersDialog::RegisteredUsersDialog(QWidget * par)
 	g_pLocalRegisteredUserDataBase->copyFrom(g_pRegisteredUserDataBase);
 
 	setWindowIcon(*(g_pIconManager->getSmallIcon(KviIconManager::RegUsers)));
-	setWindowTitle(__tr2qs_ctx("Registered Users - KVIrc","register"));
+	setWindowTitle(__tr2qs_ctx("Registered Users and Configuration - KVIrc","register"));
 
 	QGridLayout * g = new QGridLayout(this);
 

--- a/src/modules/setup/SetupWizard.cpp
+++ b/src/modules/setup/SetupWizard.cpp
@@ -932,7 +932,7 @@ void SetupWizard::setUrlHandlers()
 
 void SetupWizard::reject()
 {
-	if(QMessageBox::warning(this,__tr2qs("Abort Setup - KVIrc Setup"),
+	if(QMessageBox::warning(this,__tr2qs("Confirm Aborting Setup - KVIrc"),
 		__tr2qs("You have chosen to abort the setup.<br>KVIrc can't run until you complete this procedure.<br><br>Do you really wish to abort?"),
 		QMessageBox::Yes,QMessageBox::No|QMessageBox::Default|QMessageBox::Escape) != QMessageBox::Yes)return;
 

--- a/src/modules/setup/SetupWizard.cpp
+++ b/src/modules/setup/SetupWizard.cpp
@@ -134,7 +134,7 @@ SetupPage::~SetupPage()
 SetupWizard::SetupWizard()
 : KviTalWizard(0)
 {
-	setWindowTitle(__tr2qs("KVIrc Setup"));
+	setWindowTitle(__tr2qs("Setup Wizard - KVIrc"));
 
 	setWindowModality(Qt::NonModal); // non modal, otherwise the dialogs we show will not be usable
 

--- a/src/modules/sharedfileswindow/SharedFilesWindow.cpp
+++ b/src/modules/sharedfileswindow/SharedFilesWindow.cpp
@@ -156,7 +156,7 @@ void SharedFileEditDialog::okClicked()
 	bool bExpires = m_pExpireCheckBox->isChecked();
 	if(bExpires && (dt <= QDateTime::currentDateTime()))
 	{
-		QMessageBox::warning(this,__tr2qs_ctx("Invalid Expiry Time","sharedfileswindow"),
+		QMessageBox::warning(this,__tr2qs_ctx("Invalid Expiry Time - KVIrc","sharedfileswindow"),
 			__tr2qs_ctx("The expiry date/time is in the past: please either remove the \"Expires at\"" \
 					"check mark or specify a expiry date/time in the future","sharedfileswindow"),
 					__tr2qs_ctx("OK","sharedfileswindow"));
@@ -165,7 +165,7 @@ void SharedFileEditDialog::okClicked()
 
 	if(szName.isEmpty())
 	{
-		QMessageBox::warning(this,__tr2qs_ctx("Invalid Share Name","sharedfileswindow"),
+		QMessageBox::warning(this,__tr2qs_ctx("Invalid Share Name - KVIrc","sharedfileswindow"),
 			__tr2qs_ctx("The share name can't be empty, please correct it","sharedfileswindow"),
 			__tr2qs_ctx("OK","sharedfileswindow"));
 		return;
@@ -174,7 +174,7 @@ void SharedFileEditDialog::okClicked()
 	QFileInfo f(szPath);
 	if(!(f.exists() && f.isFile() && f.isReadable()))
 	{
-		QMessageBox::warning(this,__tr2qs_ctx("Can't open the file","sharedfileswindow"),
+		QMessageBox::warning(this,__tr2qs_ctx("Error Opening File - KVIrc","sharedfileswindow"),
 			__tr2qs_ctx("The file doesn't exist or it is not readable, please check the path","sharedfileswindow"),
 			__tr2qs_ctx("OK","sharedfileswindow"));
 		return;

--- a/src/modules/theme/PackThemeDialog.cpp
+++ b/src/modules/theme/PackThemeDialog.cpp
@@ -364,7 +364,7 @@ void PackThemeImageWidget::imageSelectionChanged(const QString & szImagePath)
 		return;
 	}
 
-	QMessageBox::critical(this,__tr2qs_ctx("Export Theme - KVIrc","theme"),__tr2qs_ctx("Failed to load the selected image","theme"),
+	QMessageBox::critical(this,__tr2qs_ctx("Export Theme Error - KVIrc","theme"),__tr2qs_ctx("Failed to load the selected image.","theme"),
 		QMessageBox::Ok,QMessageBox::NoButton,QMessageBox::NoButton);
 
 	m_pImageSelector->setSelection("");

--- a/src/modules/theme/SaveThemeDialog.cpp
+++ b/src/modules/theme/SaveThemeDialog.cpp
@@ -231,7 +231,7 @@ void SaveThemeDialog::imageSelectionChanged(const QString &szImagePath)
 		return;
 	}
 
-	QMessageBox::critical(this,__tr2qs_ctx("Save Current Theme - KVIrc","theme"),__tr2qs_ctx("Failed to load the selected image","theme"),
+	QMessageBox::critical(this,__tr2qs_ctx("Save Current Theme Error - KVIrc","theme"),__tr2qs_ctx("Failed to load the selected image.","theme"),
 		QMessageBox::Ok,QMessageBox::NoButton,QMessageBox::NoButton);
 
 	m_pImageSelector->setSelection("");
@@ -252,7 +252,7 @@ void SaveThemeDialog::makeScreenshot()
 	g_pApp->getTmpFileName(szFileName,"screenshot.png");
 	if(!ThemeFunctions::makeKVIrcScreenshot(szFileName))
 	{
-		QMessageBox::critical(this,__tr2qs_ctx("Acquire Screenshot - KVIrc","theme"),__tr2qs_ctx("Failed to make screenshot","theme"),
+		QMessageBox::critical(this,__tr2qs_ctx("Acquire Screenshot Error - KVIrc","theme"),__tr2qs_ctx("Failed to make a screenshot.","theme"),
 			QMessageBox::Ok,QMessageBox::NoButton,QMessageBox::NoButton);
 		return;
 	}
@@ -268,7 +268,7 @@ bool SaveThemeDialog::saveTheme()
 	sto.setName(m_pThemeNameEdit->text());
 	if(sto.name().isEmpty())
 	{
-		QMessageBox::critical(this,__tr2qs_ctx("Save Current Theme - KVIrc","theme"),__tr2qs_ctx("You must choose a theme name!","theme"),QMessageBox::Ok,
+		QMessageBox::critical(this,__tr2qs_ctx("Save Current Theme Error - KVIrc","theme"),__tr2qs_ctx("You must choose a theme name.","theme"),QMessageBox::Ok,
 			QMessageBox::NoButton,QMessageBox::NoButton);
 		return false;
 	}
@@ -290,7 +290,7 @@ bool SaveThemeDialog::saveTheme()
 	QString szAbsDir = sto.directory();
 	if(!KviFileUtils::makeDir(szAbsDir))
 	{
-		QMessageBox::critical(this,__tr2qs_ctx("Save Current Theme - KVIrc","theme"),__tr2qs_ctx("Unable to create theme directory.","theme"),
+		QMessageBox::critical(this,__tr2qs_ctx("Save Current Theme Error - KVIrc","theme"),__tr2qs_ctx("Unable to create theme directory.","theme"),
 			QMessageBox::Ok,QMessageBox::NoButton,QMessageBox::NoButton);
 		return false;
 	}
@@ -299,7 +299,7 @@ bool SaveThemeDialog::saveTheme()
 	{
 		QString szErr = sto.lastError();
 		QString szMsg2 = QString(__tr2qs_ctx("Unable to save theme: %1","theme")).arg(szErr);
-		QMessageBox::critical(this,__tr2qs_ctx("Save Current Theme - KVIrc","theme"),szMsg2,
+		QMessageBox::critical(this,__tr2qs_ctx("Save Current Theme Error - KVIrc","theme"),szMsg2,
 			QMessageBox::Ok,QMessageBox::NoButton,QMessageBox::NoButton);
 		return false;
 	}
@@ -309,7 +309,7 @@ bool SaveThemeDialog::saveTheme()
 	{
 		if(!KviTheme::saveScreenshots(sto,m_szScreenshotPath))
 		{
-			QMessageBox::critical(this,__tr2qs_ctx("Save Current Theme - KVIrc","theme"),__tr2qs_ctx("Failed to load the selected screenshot image: please fix it","theme"),
+			QMessageBox::critical(this,__tr2qs_ctx("Save Current Theme Error - KVIrc","theme"),__tr2qs_ctx("Failed to load the selected screenshot image: please fix it","theme"),
 				QMessageBox::Ok,QMessageBox::NoButton,QMessageBox::NoButton);
 			setCurrentPage(m_pImageSelectionPage);
 			return false;
@@ -318,7 +318,7 @@ bool SaveThemeDialog::saveTheme()
 
 	QString szMsg = __tr2qs_ctx("Theme saved successfully to %1","theme").arg(szAbsDir);
 
-	QMessageBox::information(this,__tr2qs_ctx("Save Theme - KVIrc","theme"),szMsg,QMessageBox::Ok,
+	QMessageBox::information(this,__tr2qs_ctx("Save Theme Notice - KVIrc","theme"),szMsg,QMessageBox::Ok,
 		QMessageBox::NoButton,QMessageBox::NoButton);
 
 	return true;

--- a/src/modules/theme/ThemeManagementDialog.cpp
+++ b/src/modules/theme/ThemeManagementDialog.cpp
@@ -365,7 +365,7 @@ void ThemeManagementDialog::applyCurrentTheme()
 	{
 		QString szErr = out.lastError();
 		QString szMsg = QString(__tr2qs_ctx("Failed to apply the specified theme: %1","theme")).arg(szErr);
-		QMessageBox::critical(this,__tr2qs_ctx("Apply Theme - KVIrc","theme"),szMsg,
+		QMessageBox::critical(this,__tr2qs_ctx("Apply Theme Error - KVIrc","theme"),szMsg,
 			QMessageBox::Ok,QMessageBox::NoButton,QMessageBox::NoButton);
 		return;
 	}

--- a/src/modules/tip/libkvitip.cpp
+++ b/src/modules/tip/libkvitip.cpp
@@ -93,7 +93,7 @@ TipWindow::TipWindow()
 
 	setWindowIcon(*(g_pIconManager->getSmallIcon(KviIconManager::Idea)));
 
-	setWindowTitle(__tr2qs("Did You Know..."));
+	setWindowTitle(__tr2qs("Did You Know...")); //leave title as is
 
 	QGridLayout *layout = new QGridLayout(this);
 	layout->addWidget(m_pTipFrame,0,0,1,5);

--- a/src/modules/toolbareditor/CustomizeToolBarsDialog.cpp
+++ b/src/modules/toolbareditor/CustomizeToolBarsDialog.cpp
@@ -134,7 +134,7 @@ CustomToolBarPropertiesDialog::CustomToolBarPropertiesDialog(QWidget * p,const Q
 	m_szOriginalId = szId;
 	m_szLabel = szLabel;
 
-	setWindowTitle(__tr2qs_ctx("Toolbar Properties","editor"));
+	setWindowTitle(__tr2qs_ctx("Toolbar Properties - KVIrc","editor"));
 	setWindowIcon(QIcon(*(g_pIconManager->getSmallIcon(KviIconManager::ToolBarEditor))));
 	setModal(true);
 
@@ -215,7 +215,7 @@ void CustomToolBarPropertiesDialog::iconSelected(const QString &szIconId)
 		m_szIconId = szIconId;
 		m_pIconEdit->setText(szIconId);
 	} else {
-		m_pIconButton->setText("...");
+		m_pIconButton->setText("Browse...");
 		m_szIconId = "";
 		m_pIconEdit->setText("");
 	}
@@ -247,7 +247,7 @@ void CustomToolBarPropertiesDialog::okClicked()
 {
 	if(m_szLabel.isEmpty())
 	{
-		QMessageBox::information(this,__tr2qs_ctx("Invalid Toolbar Label","editor"),__tr2qs_ctx("The toolbar label can't be empty!","editor"),__tr2qs_ctx("OK","editor"));
+		QMessageBox::information(this,__tr2qs_ctx("Invalid Toolbar Label Notice - KVIrc","editor"),__tr2qs_ctx("The toolbar label can't be empty!","editor"),__tr2qs_ctx("OK","editor"));
 		return;
 	}
 
@@ -260,7 +260,7 @@ void CustomToolBarPropertiesDialog::okClicked()
 	{
 		if(m_szId != m_szOriginalId)
 		{
-			if(QMessageBox::information(this,__tr2qs_ctx("Duplicate Toolbar ID","editor"),
+			if(QMessageBox::information(this,__tr2qs_ctx("Duplicate Toolbar ID Notice - KVIrc","editor"),
 				__tr2qs_ctx("The specified toolbar ID already exists.<br>" \
 					"Would you like KVIrc to assign it automatically (so it doesn't "
 					"collide with any other toolbar) or you prefer to do it manually?","editor"),
@@ -378,7 +378,7 @@ void CustomizeToolBarsDialog::deleteToolBar()
 	KviCustomToolBar * t = KviActionManager::currentToolBar();
 	if(!t)return;
 	if(QMessageBox::question(this,
-			__tr2qs_ctx("Confirm Toolbar Deletion","editor"),
+			__tr2qs_ctx("Confirm Toolbar Deletion - KVIrc","editor"),
 			__tr2qs_ctx("Do you really want to delete toolbar \"%1\"?","editor").arg(t->windowTitle()),
 			QMessageBox::Yes | QMessageBox::No,
 			QMessageBox::No) != QMessageBox::Yes)return;
@@ -402,7 +402,7 @@ void CustomizeToolBarsDialog::exportToolBar()
 	QString szCode;
 
 	int ret = QMessageBox::question(this,
-			__tr2qs_ctx("Toolbar Export","editor"),
+			__tr2qs_ctx("Confirm Toolbar Export - KVIrc","editor"),
 			__tr2qs_ctx("Do you want the associated actions to be exported with the toolbar?","editor"),
 			__tr2qs_ctx("Yes","editor"),
 			__tr2qs_ctx("No","editor"),
@@ -459,7 +459,7 @@ void CustomizeToolBarsDialog::exportToolBar()
 
 	if(!KviFileUtils::writeFile(szFile,szCode))
 	{
-		QMessageBox::warning(this,__tr2qs_ctx("Write Failed - KVIrc","editor"),__tr2qs_ctx("Unable to write to the toolbar file.","editor"),__tr2qs_ctx("OK","editor"));
+		QMessageBox::warning(this,__tr2qs_ctx("Write to Toolbar File Failed - KVIrc","editor"),__tr2qs_ctx("Unable to write to the toolbar file.","editor"),__tr2qs_ctx("OK","editor"));
 	}
 }
 

--- a/src/modules/toolbareditor/CustomizeToolBarsDialog.cpp
+++ b/src/modules/toolbareditor/CustomizeToolBarsDialog.cpp
@@ -223,7 +223,7 @@ void CustomToolBarPropertiesDialog::iconSelected(const QString &szIconId)
 
 void CustomToolBarPropertiesDialog::iconButtonClicked()
 {
-	KviImageDialog * dlg = new KviImageDialog(this,__tr2qs_ctx("Please Choose the Icon for the Toolbar","editor"));
+	KviImageDialog * dlg = new KviImageDialog(this,__tr2qs_ctx("Choose a Toolbar Icon - KVIrc","editor"));
 	if(dlg->exec() != QDialog::Accepted)
 	{
 		delete dlg;
@@ -292,7 +292,7 @@ CustomizeToolBarsDialog::CustomizeToolBarsDialog(QWidget * p)
 : QWidget(p)
 {
 	setObjectName("Toolbar_editor");
-	setWindowTitle(__tr2qs_ctx("Customize Toolbars","editor"));
+	setWindowTitle(__tr2qs_ctx("Customize Toolbars - KVIrc","editor"));
 	setWindowIcon(*(g_pIconManager->getSmallIcon(KviIconManager::ToolBarEditor)));
 
 	m_pInstance = this;

--- a/src/modules/url/libkviurl.cpp
+++ b/src/modules/url/libkviurl.cpp
@@ -396,7 +396,7 @@ UrlDialog::~UrlDialog()
 ConfigDialog::ConfigDialog()
 :QDialog()
 {
-	setWindowTitle(__tr2qs("URL Module Configuration"));
+	setWindowTitle(__tr2qs("URL Module Configuration - KVIrc"));
 
 	QGridLayout *g = new QGridLayout(this);
 

--- a/src/modules/url/libkviurl.cpp
+++ b/src/modules/url/libkviurl.cpp
@@ -238,7 +238,7 @@ void UrlDialog::close_slot()
 void UrlDialog::remove()
 {
 	if (!m_pUrlList->currentItem()) {
-		QMessageBox::warning(0,__tr2qs("Warning - KVIrc"),__tr2qs("Select an URL."),QMessageBox::Ok,QMessageBox::NoButton,QMessageBox::NoButton);
+		QMessageBox::warning(0,__tr2qs("Entry Selection Warning - KVIrc"),__tr2qs("Must select a URL entry from the list to remove it."),QMessageBox::Ok,QMessageBox::NoButton,QMessageBox::NoButton);
 		return;
 	}
 
@@ -331,7 +331,7 @@ void UrlDialog::sayToWin(QAction * act)
 		KviKvsScript::run(say,wnd);
 		g_pMainWindow->setActiveWindow(wnd);
 	} else {
-		QMessageBox::warning(0,__tr2qs("Warning - KVIrc"),__tr2qs("Window not found."),QMessageBox::Ok,QMessageBox::NoButton,QMessageBox::NoButton);
+		QMessageBox::warning(0,__tr2qs("Window Not Found Warning - KVIrc"),__tr2qs("Window not found."),QMessageBox::Ok,QMessageBox::NoButton,QMessageBox::NoButton);
 	}
 }
 
@@ -514,7 +514,7 @@ void BanFrame::enableClicked()
 void BanFrame::addBan()
 {
 	bool ok = false;
-	QString *pText = new QString(QInputDialog::getText(this, __tr2qs("URL Ban List"),__tr2qs("Add a URL to ban"),QLineEdit::Normal,QString(),&ok));
+	QString *pText = new QString(QInputDialog::getText(this, __tr2qs("URL Ban List - KVIrc"),__tr2qs("Enter a URL to ban."),QLineEdit::Normal,QString(),&ok));
 	if (ok && !pText->isEmpty()) {
 		g_pBanList->append(pText);
 		m_pBanList->addItem(*pText);
@@ -527,7 +527,7 @@ void BanFrame::removeBan()
 		return;
 
 	if (!m_pBanList->currentItem()->isSelected()) {
-		QMessageBox::warning(0,__tr2qs("Warning - KVIrc"),__tr2qs("Select a ban."),QMessageBox::Ok,QMessageBox::NoButton,QMessageBox::NoButton);
+		QMessageBox::warning(0,__tr2qs("Entry Selection Warning - KVIrc"),__tr2qs("Must select a ban entry from the list to remove it."),QMessageBox::Ok,QMessageBox::NoButton,QMessageBox::NoButton);
 		return;
 	}
 	QString item(m_pBanList->currentItem()->text());


### PR DESCRIPTION
This pretty much squashes all the remainder dialog titles that were inconsistent, vague and incomplete or confusing to some translators.

Finally honor the dialog titles tips from https://github.com/kvirc/KVIrc/blob/master/doc/ui-style.tips.txt   like adding **\- KVIrc** to the title

Probably could be improved slightly hence the PR to gain valuable feedback.
