### PR TITLE
KviTopicWidget/KviChannelWindowcontext/KviConsoleWindow: fix & improve some tootltips

### DIFF
--- a/src/kvirc/kernel/KviOptions.h
+++ b/src/kvirc/kernel/KviOptions.h
@@ -712,7 +712,7 @@ extern KVIRC_API KviStringListOption g_stringlistOptionsTable[KVI_NUM_STRINGLIST
 #define _OUTPUT_QUIET (KVI_OPTION_UINT(KviOption_uintOutputVerbosityLevel) <= KVI_VERBOSITY_LEVEL_QUIET)
 #define _OUTPUT_MUTE (KVI_OPTION_UINT(KviOption_uintOutputVerbosityLevel) <= KVI_VERBOSITY_LEVEL_MUTE)
 
-	#define START_TABLE_BOLD_ROW "<tr><td style=\"background-color: rgb(0,0,0); font-weight: bold; color: rgb(200,200,255); text-indent: 5px;\">"
+	#define START_TABLE_BOLD_ROW "<tr><td style=\"background-color: rgb(48,48,48); font-weight: bold; color: rgb(255,255,255); text-indent: 5px;\">"
 	#define END_TABLE_BOLD_ROW "</td></tr>"
 
 	#define START_TABLE_NORMAL_ROW "<tr><td>"

--- a/src/kvirc/ui/KviChannelWindow.cpp
+++ b/src/kvirc/ui/KviChannelWindow.cpp
@@ -1939,7 +1939,18 @@ void KviChannelWindow::internalMask(const QString & szMask, bool bAdd, const QSt
 
 void KviChannelWindow::updateModeLabel()
 {
-	QString szTip = __tr2qs("<b>Channel mode:</b>");
+	QString szTip = \
+	"<html>" \
+		"<body>" \
+			"<table width=\"100%\">";
+	szTip +=	START_TABLE_BOLD_ROW;
+	szTip +=	"<b><center>";
+	szTip += __tr2qs("Channel Mode");
+	szTip +=	"</b></center>";
+	szTip +=	END_TABLE_BOLD_ROW;
+	szTip +=	"</table>" \
+		"</body>" \
+	"</html>";
 	KviCString szMod = m_szChannelMode;
 	const char * pcAux = szMod.ptr();
 	KviIrcConnectionServerInfo * pServerInfo = serverInfo();

--- a/src/kvirc/ui/KviConsoleWindow.cpp
+++ b/src/kvirc/ui/KviConsoleWindow.cpp
@@ -305,13 +305,15 @@ void KviConsoleWindow::getUserTipText(const QString &nick,KviIrcUserEntry *e,QSt
 		u->mask()->mask(mask);
 		buffer += "<tr bgcolor=\"#F0F0F0\"><td><font color=\"#000000\">";
 		buffer += __tr2qs("Registered as");
-		buffer += " <b>";
+		buffer += ": <b>";
 		buffer += KviQString::toHtmlEscaped(u->user()->name());
-		buffer += "</b>; Group ";
+		buffer += "</b>;";
+		buffer += "Group";
+		buffer += ": ";
 		buffer += KviQString::toHtmlEscaped(u->user()->group());
 		buffer += "</font></td></tr><tr bgcolor=\"#F0F0F0\"><td><font size=\"-1\" color=\"#000000\">";
 		buffer += __tr2qs("(Matched by");
-		buffer += " ";
+		buffer += ": ";
 		buffer += KviQString::toHtmlEscaped(mask);
 		buffer += ")</font></td></tr>";
 	}
@@ -322,7 +324,8 @@ void KviConsoleWindow::getUserTipText(const QString &nick,KviIrcUserEntry *e,QSt
 		if(connection()->getCommonChannels(nick,chans,false))
 		{
 			buffer += "<tr><td bgcolor=\"#F0F0F0\"><font color=\"#000000\">";
-			buffer += __tr2qs("On <b>");
+			buffer += __tr2qs("On");
+			buffer += ": <b>";
 			buffer += KviQString::toHtmlEscaped(chans);
 			buffer += "</b></font></td></tr>";
 		}
@@ -331,7 +334,7 @@ void KviConsoleWindow::getUserTipText(const QString &nick,KviIrcUserEntry *e,QSt
 	if(e->hasServer())
 	{
 		buffer += "<tr><td bgcolor=\"#F0F0F0\"><nobr><font color=\"#000000\">";
-		buffer += __tr2qs("Using server <b>%1</b>").arg(KviQString::toHtmlEscaped(e->server()));
+		buffer += __tr2qs("Using server: <b>%1</b>").arg(KviQString::toHtmlEscaped(e->server()));
 
 		if(e->hasHops())
 		{

--- a/src/kvirc/ui/KviConsoleWindow.cpp
+++ b/src/kvirc/ui/KviConsoleWindow.cpp
@@ -1266,9 +1266,8 @@ void KviConsoleWindow::getWindowListTipText(QString &buffer)
 		buffer += START_TABLE_NORMAL_ROW;
 
 		buffer += __tr2qs("Connected since");
+		buffer += ":";
 		buffer += html_space;
-		buffer += html_br;
-		buffer += html_tab;
 		buffer += html_bold;
 		buffer += szTmp;
 		buffer += html_eofbold;
@@ -1280,6 +1279,7 @@ void KviConsoleWindow::getWindowListTipText(QString &buffer)
 			KviTimeUtils::NoLeadingEmptyIntervals | KviTimeUtils::NoLeadingZeroes);
 
 		buffer += __tr2qs("Online for");
+		buffer += ":";
 		buffer += html_space;
 		buffer += html_bold;
 		buffer += tspan;
@@ -1292,6 +1292,7 @@ void KviConsoleWindow::getWindowListTipText(QString &buffer)
 			KviTimeUtils::NoLeadingEmptyIntervals | KviTimeUtils::NoLeadingZeroes);
 
 		buffer += __tr2qs("Server idle for");
+		buffer += ":";
 		buffer += html_space;
 		buffer += html_bold;
 		buffer += tspan;

--- a/src/kvirc/ui/KviTopicWidget.cpp
+++ b/src/kvirc/ui/KviTopicWidget.cpp
@@ -357,11 +357,11 @@ void KviTopicWidget::updateToolTip()
 	if(!m_szTopic.isEmpty())
 	{
 		txt +=          START_TABLE_BOLD_ROW;
-		txt += __tr2qs("Channel topic:");
-		txt +=              END_TABLE_BOLD_ROW;
-
+		txt +=          "<center>";
+		txt +=  __tr2qs("Channel Topic");
+		txt +=          "</center>";
+		txt +=          END_TABLE_BOLD_ROW;
 		txt +=          "<tr><td>";
-
 		txt += KviHtmlGenerator::convertToHtml(KviQString::toHtmlEscaped(m_szTopic));
 		txt +=          "</td></tr>";
 
@@ -369,13 +369,13 @@ void KviTopicWidget::updateToolTip()
 		if(!m_szSetBy.isEmpty())
 		{
 			txt +=      "<tr><td bgcolor=\"#D0D0D0\"><font color=\"#000000\">";
-			txt +=       __tr2qs("Set by") + " <b>" + m_szSetBy + "</b>";
+			txt +=       __tr2qs("Set by") + ":" + " <b>" + m_szSetBy + "</b>";
 			txt +=      "</font></td></tr>";
 
 			if(!m_szSetAt.isEmpty())
 			{
 				txt +=      "<tr><td bgcolor=\"#D0D0D0\"><font color=\"#000000\">";
-				txt +=       __tr2qs("Set on") + " <b>" + m_szSetAt + "</b>";
+				txt +=       __tr2qs("Set on") + ":" + " <b>" + m_szSetAt + "</b>";
 				txt +=      "</font></td></tr>";
 			}
 		}
@@ -393,9 +393,9 @@ void KviTopicWidget::updateToolTip()
 		txt +=          "</td></tr>";
 	}
 
-	txt += "</table>" \
-		"</body>" \
-	"<html>";
+			txt += "</table>" \
+			"</body>" \
+		"</html>";
 
 	KviTalToolTip::add(this,txt);
 }


### PR DESCRIPTION
Improved consistency of START_TABLE_BOLD_ROW colors, our tooltips of this kind have many many many styles, this goes in one way to reduce the variety and start making these more consistent.

Also The topic tooltip header title text needed to be centered to match the other similar type styles + appended colons to Set by: and Set on: labels 
@wodim if you have any tips on how to strip the topic colors from `txt += KviHtmlGenerator::convertToHtml(KviQString::toHtmlEscaped(m_szTopic));` Line 365 that would be nice, because when topics are colored they mostly become unreadable on this tooltip in some cases.

~~Also libkvitrayicon added a marginally better title for that context menu @wodim, would be nice if you also had a tip on how to add some indenting to this header..~~ merged in master still need solution
