### PR TITLE
Hopefully fix WinXp support on AppVeyor builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1017,6 +1017,8 @@ endif()
 if(MSVC)
 	add_definitions(-D_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES -DNOMINMAX)
 	add_definitions(-DMSVC)
+	# Support from Windows XP
+	SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:WINDOWS,5.01")
 endif()
 
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "SunPro")


### PR DESCRIPTION
They install fine but then when running KVIrc i receive the infamous "... is not a valid Win32 application" (in the following example, localized in italian for your fetish pleasure)
![schermata 2016-03-03 alle 08 46 28](https://cloud.githubusercontent.com/assets/1631111/13487734/7e5f8634-e11c-11e5-9e80-bc5811b97a21.png)

Looking at the appveyor script the problem is that Visual Studio 2013 requires us to specify the use of the "vs120_xp" toolkit when building in order to build winxp compatible executables.

CMake has a specific command-line option for that ([-T <toolset-name>](https://cmake.org/cmake/help/v3.2/manual/cmake.1.html)), but it's obviously broken/unusable as everything else a bit advanced in cmake.

This PR takes a more direct approach, forcing a linker flag when MSVC is used.

Yeah i know that Xp is old, it's not secure, every time i boot it up a kitten dies, etc.. but if in order to support it we just need such a simple change, why not?
