### PR TITLE
Display host changes with CHGHOST

### DIFF
--- a/src/kvirc/sparser/KviIrcServerParser_literalHandlers.cpp
+++ b/src/kvirc/sparser/KviIrcServerParser_literalHandlers.cpp
@@ -207,6 +207,40 @@ void KviIrcServerParser::parseLiteralChghost(KviIrcMessage *msg)
 		e->setHost(szNewHost);
 	}
 
+	KviConsoleWindow * console = msg->console();
+	for(KviChannelWindow * c = console->connection()->channelList()->first();c;c = console->connection()->channelList()->next())
+	{
+		if(!msg->haltOutput())
+		{
+			if(szHost == szNewHost) {
+				c->output(KVI_OUT_NICK,__tr2qs("\r!n\r%Q\r [%Q@\r!h\r%Q\r] now has user %Q"),
+					&szNick,&szUser,&szHost,&szNewUser);
+			} else if(szUser == szNewUser) {
+				c->output(KVI_OUT_NICK,__tr2qs("\r!n\r%Q\r [%Q@\r!h\r%Q\r] now has host \r!h\r%Q\r"),
+					&szNick,&szUser,&szHost,&szNewHost);
+			} else {
+				c->output(KVI_OUT_NICK,__tr2qs("\r!n\r%Q\r [%Q@\r!h\r%Q\r] now has user@host %Q@\r!h\r%Q\r"),
+					&szNick,&szUser,&szHost,&szNewUser,&szNewHost);
+			}
+		}
+	}
+
+	KviQueryWindow * q = console->connection()->findQuery(szNick);
+	if(q)
+	{
+		if(szHost == szNewHost) {
+			q->output(KVI_OUT_NICK, __tr2qs("\r!n\r%Q\r [%Q@\r!h\r%Q\r] now has user %Q"),
+				&szNick,&szUser,&szHost,&szNewUser);
+		} else if(szUser == szNewUser) {
+			q->output(KVI_OUT_NICK, __tr2qs("\r!n\r%Q\r [%Q@\r!h\r%Q\r] now has host \r!h\r%Q\r"),
+				&szNick,&szUser,&szHost,&szNewHost);
+		} else {
+			q->output(KVI_OUT_NICK, __tr2qs("\r!n\r%Q\r [%Q@\r!h\r%Q\r] now has user@host %Q@\r!h\r%Q\r"),
+				&szNick,&szUser,&szHost,&szNewUser,&szNewHost);
+		}
+		q->updateLabelText();
+	}
+
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
@DarthGandalf are you OK with this? IMO It's better to just leave it as `KVI_OUT_NICK` since it implies a user-side identity change and adding _another_ kvi option would be eh for something so similar. As an aside, perhaps we could make a KVS event now for `OnUserHostChange` or something. _shrugs_
