### PR TITLE
Fix typos in Events/function/variables/options names Estabilished -> Established

### DIFF
--- a/doc/FAQ
+++ b/doc/FAQ
@@ -545,7 +545,7 @@
   However, if you router's IP has a dns entry, you can ask KVIrc to fill
   this field with a simple script to be performed at every connection.
 
-  event(OnIRCConnectionEstabilished,updatedccsource)
+  event(OnIRCConnectionEstablished,updatedccsource)
   {
       ahost(yourrouterhostname.dyndns.org)
       {

--- a/src/kvilib/net/KviHttpRequest.cpp
+++ b/src/kvilib/net/KviHttpRequest.cpp
@@ -269,7 +269,7 @@ void KviHttpRequest::slotSocketConnected()
 		m_p->pConnectTimeoutTimer = NULL;
 	}
 
-	emit connectionEstabilished();
+	emit connectionEstablished();
 	emit status(
 			__tr2qs("Connected to %1:%2: sending request")
 					.arg(m_p->pSocket->peerAddress().toString())

--- a/src/kvilib/net/KviHttpRequest.h
+++ b/src/kvilib/net/KviHttpRequest.h
@@ -170,7 +170,7 @@ public:
 signals:
 	void resolvingHost(const QString &hostname);
 	void contactingHost(const QString &ipandport);
-	void connectionEstabilished();
+	void connectionEstablished();
 	void receivedResponse(const QString &response);
 
 	void terminated(bool bSuccess);

--- a/src/kvirc/kernel/KviIrcConnection.cpp
+++ b/src/kvirc/kernel/KviIrcConnection.cpp
@@ -316,7 +316,7 @@ void KviIrcConnection::start()
 	m_pLink->start();
 }
 
-void KviIrcConnection::linkEstabilished()
+void KviIrcConnection::linkEstablished()
 {
 	m_eState = Connected;
 
@@ -334,7 +334,7 @@ void KviIrcConnection::linkEstabilished()
 	}
 
 	// FIXME: With STARTTLS this is called TWICE!
-	context()->connectionEstabilished();
+	context()->connectionEstablished();
 
 	// Ok...we're loggin in now
 	resolveLocalHost();

--- a/src/kvirc/kernel/KviIrcConnection.h
+++ b/src/kvirc/kernel/KviIrcConnection.h
@@ -920,7 +920,7 @@ protected:
 	* \brief Called by KviIrcLink when the socket state changes to Connected
 	* \return void
 	*/
-	void linkEstabilished();
+	void linkEstablished();
 
 	/**
 	* \brief Called by KviIrcLink when the socket state changes to Ready

--- a/src/kvirc/kernel/KviIrcContext.cpp
+++ b/src/kvirc/kernel/KviIrcContext.cpp
@@ -681,9 +681,9 @@ enter_idle_state:
 	setState(Idle);
 }
 
-void KviIrcContext::connectionEstabilished()
+void KviIrcContext::connectionEstablished()
 {
-	//qDebug("context::connectionEstabilished");
+	//qDebug("context::connectionEstablished");
 	//
 	// The connection has been established, the
 	// KviIrcConnection will attempt to login now
@@ -694,7 +694,7 @@ void KviIrcContext::connectionEstabilished()
 
 	setState(LoggingIn); // this must be set in order for $server and other functions to return the correct values
 
-	bStopOutput = KVS_TRIGGER_EVENT_0_HALTED(KviEvent_OnIRCConnectionEstabilished,m_pConsole);
+	bStopOutput = KVS_TRIGGER_EVENT_0_HALTED(KviEvent_OnIRCConnectionEstablished,m_pConsole);
 
 	if(!bStopOutput)
 	{

--- a/src/kvirc/kernel/KviIrcContext.h
+++ b/src/kvirc/kernel/KviIrcContext.h
@@ -176,7 +176,7 @@ protected:
 	// KviIrcConnection interface
 	//
 	void connectionFailed(int iError);
-	void connectionEstabilished();
+	void connectionEstablished();
 	void connectionTerminated();
 signals:
 	void stateChanged();

--- a/src/kvirc/kernel/KviIrcLink.cpp
+++ b/src/kvirc/kernel/KviIrcLink.cpp
@@ -371,7 +371,7 @@ void KviIrcLink::socketStateChange()
 	{
 		case KviIrcSocket::Connected:
 			m_eState = Connected;
-			m_pConnection->linkEstabilished();
+			m_pConnection->linkEstablished();
 		break;
 		case KviIrcSocket::Idle:
 		{

--- a/src/kvirc/kernel/KviIrcSocket.cpp
+++ b/src/kvirc/kernel/KviIrcSocket.cpp
@@ -477,10 +477,10 @@ void KviIrcSocket::writeNotifierFired(int)
 	m_pWsn = 0;
 
 	//Successfully connected...
-	connectionEstabilished();
+	connectionEstablished();
 }
 
-void KviIrcSocket::connectionEstabilished()
+void KviIrcSocket::connectionEstablished()
 {
 	if(m_sock == KVI_INVALID_SOCKET)
 		return; // ops...disconnected in setState() ????

--- a/src/kvirc/kernel/KviIrcSocket.h
+++ b/src/kvirc/kernel/KviIrcSocket.h
@@ -287,13 +287,13 @@ protected:
 	void raiseError(KviError::Code eError);
 
 	/**
-	* \brief Called when the connection has been estabilished
+	* \brief Called when the connection has been established
 	*
 	* If it's a proxy we need to perform the login operations, otherwise
 	* we're connected to the irc server
 	* \return void
 	*/
-	void connectionEstabilished();
+	void connectionEstablished();
 
 	/**
 	* \brief Called when the connection to the proxy has been established

--- a/src/kvirc/kvs/event/KviKvsEventManager.cpp
+++ b/src/kvirc/kvs/event/KviKvsEventManager.cpp
@@ -127,7 +127,7 @@ unsigned int KviKvsEventManager::findAppEventIndexByName(const QString &szName)
 	{
 		if(KviQString::equalCI(szName,m_appEventTable[u].name()))return u;
 		//Backwards compatibility >_<
-		if((u == 4) && KviQString::equalCI(szName,"OnIrcConnectionEstabilished"))
+		if((u == 4) && KviQString::equalCI(szName,"OnIrcConnectionEstablished"))
 			return u;
 	}
 	return KVI_KVS_NUM_APP_EVENTS; // <-- invalid event number
@@ -139,7 +139,7 @@ KviKvsEvent * KviKvsEventManager::findAppEventByName(const QString &szName)
 	{
 		if(KviQString::equalCI(szName,m_appEventTable[u].name()))return &(m_appEventTable[u]);
 		//Backwards compatibility >_<
-		if((u == 4) && KviQString::equalCI(szName,"OnIrcConnectionEstabilished"))
+		if((u == 4) && KviQString::equalCI(szName,"OnIrcConnectionEstablished"))
 			return &(m_appEventTable[u]);
 	}
 	return 0;
@@ -597,7 +597,7 @@ void KviKvsEventManager::loadAppEvents(const QString & szFileName)
 		QString szEventName(m_appEventTable[i].name());
 		// Backwards compatibility >_<
 		if((i == 4) && !cfg.hasGroup(szEventName))
-			szEventName = "OnIrcConnectionEstabilished";
+			szEventName = "OnIrcConnectionEstablished";
 		if(cfg.hasGroup(szEventName))
 		{
 			cfg.setGroup(szEventName);
@@ -635,7 +635,7 @@ void KviKvsEventManager::saveAppEvents(const QString & szFileName)
 			// Backwards compatibility >_<
 			if((i == 4) && cfg.hasGroup(szEventName))
 			{
-				szEventName = "OnIRCConnectionEstabilished";
+				szEventName = "OnIRCConnectionEstablished";
 				bCompat = true;
 			}
 			cfg.setGroup(szEventName);

--- a/src/kvirc/kvs/event/KviKvsEventTable.h
+++ b/src/kvirc/kvs/event/KviKvsEventTable.h
@@ -87,7 +87,7 @@
 
 // Connection
 /**
-* \def KviEvent_OnIrcConnectionEstabilished Triggered when the IRC connection is established
+* \def KviEvent_OnIrcConnectionEstablished Triggered when the IRC connection is established
 * \def KviEvent_OnIrcConnectionTerminated Triggered when the IRC connection is terminated
 * \def KviEvent_OnIrc Triggered when the login is completed
 * \def KviEvent_OnNetsplit A netsplit has been detected
@@ -96,7 +96,7 @@
 * \def KviEvent_OnUnhandledLiteral An unhandled literal server message has been received
 * \def KviEvent_OnOutboundTraffic Triggered when text is sent to the server
 */
-#define KviEvent_OnIRCConnectionEstabilished 23
+#define KviEvent_OnIRCConnectionEstablished  23
 #define KviEvent_OnIRCConnectionTerminated   24
 #define KviEvent_OnIRC                       25
 #define KviEvent_OnNetsplit                  26

--- a/src/kvirc/ui/KviStatusBarApplet.cpp
+++ b/src/kvirc/ui/KviStatusBarApplet.cpp
@@ -710,7 +710,7 @@ void KviStatusBarUpdateIndicator::checkVersion()
 
 	m_pHttpRequest = new KviHttpRequest();
 	//connect(m_pHttpRequest,SIGNAL(resolvingHost(const QString &)),this,SLOT(hostResolved(const QString &)));
-	//connect(m_pHttpRequest,SIGNAL(connectionEstabilished()),this,SLOT(connectionEstabilished()));
+	//connect(m_pHttpRequest,SIGNAL(connectionEstablished()),this,SLOT(connectionEstablished()));
 	connect(m_pHttpRequest,SIGNAL(receivedResponse(const QString &)),this,SLOT(responseReceived(const QString &)));
 	connect(m_pHttpRequest,SIGNAL(binaryData(const KviDataBuffer &)),this,SLOT(binaryDataReceived(const KviDataBuffer &)));
 	connect(m_pHttpRequest,SIGNAL(terminated(bool)),this,SLOT(requestCompleted(bool)));

--- a/src/modules/http/HttpFileTransfer.cpp
+++ b/src/modules/http/HttpFileTransfer.cpp
@@ -65,7 +65,7 @@ HttpFileTransfer::HttpFileTransfer()
 	connect(m_pHttpRequest,SIGNAL(requestSent(const QStringList &)),this,SLOT(requestSent(const QStringList &)));
 	connect(m_pHttpRequest,SIGNAL(contactingHost(const QString &)),this,SLOT(contactingHost(const QString &)));
 	connect(m_pHttpRequest,SIGNAL(receivedResponse(const QString &)),this,SLOT(receivedResponse(const QString &)));
-	connect(m_pHttpRequest,SIGNAL(connectionEstabilished()),this,SLOT(connectionEstabilished()));
+	connect(m_pHttpRequest,SIGNAL(connectionEstablished()),this,SLOT(connectionEstablished()));
 
 	m_eGeneralStatus = Initializing;
 	m_szStatusString = __tr2qs_ctx("Initializing","http");
@@ -384,7 +384,7 @@ void HttpFileTransfer::requestSent(const QStringList &requestHeaders)
 	m_lRequest = requestHeaders;
 }
 
-void HttpFileTransfer::connectionEstabilished()
+void HttpFileTransfer::connectionEstablished()
 {
 	m_szStatusString = __tr2qs_ctx("Connection established: sending request","http");
 	displayUpdate();

--- a/src/modules/http/HttpFileTransfer.h
+++ b/src/modules/http/HttpFileTransfer.h
@@ -91,7 +91,7 @@ protected slots:
 	void resolvingHost(const QString &hostname);
 	void contactingHost(const QString &ipandport);
 	void receivedResponse(const QString &response);
-	void connectionEstabilished();
+	void connectionEstablished();
 	void abort();
 	void autoClean();
 };


### PR DESCRIPTION
#### Changes proposed

~~\- Fixes various typos and capitalization across varied files~~
~~\- Fixes remainder of bolierplating typos and omissions~~
- Fixes typos in Events/function/variables names containing Estabilished -> Established

@staticfox if you feel like having a looksee ;)
