### PR TITLE
Part 2 of 99925aa: Also check and conditionally disable buggy appmenu-qt5 against known buggy Qt version

### DIFF
--- a/src/kvirc/kernel/KviMain.cpp
+++ b/src/kvirc/kernel/KviMain.cpp
@@ -23,7 +23,7 @@
 //=============================================================================
 
 
-
+#include "KviRuntimeInfo.h"
 #include "KviApplication.h"
 #include "KviCString.h"
 #include "kvi_settings.h"
@@ -391,7 +391,9 @@ int main(int argc, char ** argv)
 	qputenv("QT_BEARER_POLL_TIMEOUT", QByteArray::number(-1));
 #endif
 
-	if(qgetenv("QT_QPA_PLATFORMTHEME") == QByteArray("appmenu-qt5"))
+	// appmenu-qt5 in Qt 5.2 is buggy and when installed breaks KVIrc's menu bar #1917
+	// Check if lib is installed and that Qt version is the known buggy and disable it only if those conditions are met.
+	if(qgetenv("QT_QPA_PLATFORMTHEME") == QByteArray("appmenu-qt5") && KviRuntimeInfo::qtVersion() == "5.2.1")
 		qunsetenv("QT_QPA_PLATFORMTHEME");
 
 	KviApplication * pTheApp = new KviApplication(argc,argv);


### PR DESCRIPTION
After the discussion in https://github.com/kvirc/KVIrc/commit/99925aa796ad1319f6f374fedc9a6d5907294b36  this approach would solve @TheReign concerns

> TheReign commented on 99925aa 12 hours ago
> 
> This patch breaks this feature and I'm now forced to run custom patches to run KVIrc as a proper app. This is really disappointing.

---

Seems the ideal thing is to only disable appmenu-qt5 if the Qt version is known to be buggy this is what @ctrlaltca indicated the issue only happens with Qt 5.2.1 which is widespread against LTS releases.

I suggested https://github.com/kvirc/KVIrc/commit/99925aa796ad1319f6f374fedc9a6d5907294b36#commitcomment-17085495 sort of similar to this and then it occurred to me why not this? So here it is this try

 Im not even sure if this is 100% correct, but the idea seems sound, I rather do this that waste time chasing future support and also not disappoint @TheReign and when this version is phased out the revert is obvious and simple

I would need guidance to implement this properly if this happens to be a total botch.
#### Changes proposed
- Also check for the known buggy Qt version and only disable if condition is met.

@Thereign @ctrlaltca for thoughts and feedback.
