### PR TITLE
travis: Don't build KDE builds for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ matrix:
           env: WANT_KDE=NO
           compiler: gcc
         - os: linux
-          env: WANT_KDE=YES
-          compiler: gcc
-        - os: linux
           env: DEBUILD=YES
           compiler: gcc
         - os: osx


### PR DESCRIPTION
travis' highest linux/debian based OS is 14.04, KDE5 doesn't support 14.04, so we're just basically duplicating an extra compilation cycle for no reason.

(yes I know the error in travis is related to ECM, but even with ECM installed it will still require kf5 which we can't get til travis supports 16.04)

edit: s/appveyor/travis/
