### PR TITLE
Add option to hide the taskbar button.

### DIFF
--- a/src/kvirc/kernel/KviApplication.cpp
+++ b/src/kvirc/kernel/KviApplication.cpp
@@ -1605,7 +1605,14 @@ void KviApplication::createFrame()
 {
 	Q_ASSERT(g_pMainWindow == nullptr);
 
-	new KviMainWindow();
+#if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
+	if(KVI_OPTION_BOOL(KviOption_boolShowTaskBarButton))
+		new KviMainWindow(0);
+	else
+		new KviMainWindow(new QWidget(0, 0));
+#else
+	new KviMainWindow(0);
+#endif
 
 	Q_ASSERT(g_pMainWindow != nullptr);
 

--- a/src/kvirc/kernel/KviOptions.cpp
+++ b/src/kvirc/kernel/KviOptions.cpp
@@ -341,6 +341,7 @@ KviBoolOption g_boolOptionsTable[KVI_NUM_BOOL_OPTIONS]=
 	BOOL_OPTION("MenuBarVisible",true,KviOption_sectFlagFrame | KviOption_resetUpdateGui),
 	BOOL_OPTION("WarnAboutHidingMenuBar",true,KviOption_sectFlagFrame),
 	BOOL_OPTION("WhoRepliesToActiveWindow",false,KviOption_sectFlagConnection),
+	BOOL_OPTION("ShowTaskBarButton",true,KviOption_sectFlagFrame)
 };
 
 #define STRING_OPTION(_txt,_val,_flags) KviStringOption(KVI_STRING_OPTIONS_PREFIX _txt,_val,_flags)

--- a/src/kvirc/kernel/KviOptions.h
+++ b/src/kvirc/kernel/KviOptions.h
@@ -356,8 +356,9 @@ DECLARE_OPTION_STRUCT(KviStringListOption,QStringList)
 #define KviOption_boolMenuBarVisible 266
 #define KviOption_boolWarnAboutHidingMenuBar 267
 #define KviOption_boolWhoRepliesToActiveWindow 268                       /* irc::output */
+#define KviOption_boolShowTaskBarButton 269                              /* windows only, used in KviApplication::createFrame only */
 
-#define KVI_NUM_BOOL_OPTIONS 269
+#define KVI_NUM_BOOL_OPTIONS 270
 
 
 #define KVI_STRING_OPTIONS_PREFIX "string"

--- a/src/kvirc/ui/KviMainWindow.cpp
+++ b/src/kvirc/ui/KviMainWindow.cpp
@@ -93,8 +93,8 @@
 extern KviConfigurationFile * g_pWinPropertiesConfig;
 KVIRC_API KviMainWindow * g_pMainWindow = NULL; // the one and only frame object
 
-KviMainWindow::KviMainWindow()
-: KviTalMainWindow(0,"kvirc_frame")
+KviMainWindow::KviMainWindow(QWidget * pParent)
+: KviTalMainWindow(pParent,"kvirc_frame")
 {
 	g_pMainWindow = this;
 	setAttribute(Qt::WA_DeleteOnClose);

--- a/src/kvirc/ui/KviMainWindow.h
+++ b/src/kvirc/ui/KviMainWindow.h
@@ -74,7 +74,7 @@ class KVIRC_API KviMainWindow : public KviTalMainWindow //, public KviIrcContext
 	friend class KviUserListViewArea;
 	Q_OBJECT
 public:
-	KviMainWindow();
+	KviMainWindow(QWidget *pParent);
 	~KviMainWindow();
 protected:
 	// subwindows

--- a/src/modules/options/OptionsWidget_interfaceFeatures.cpp
+++ b/src/modules/options/OptionsWidget_interfaceFeatures.cpp
@@ -53,14 +53,23 @@ OptionsWidget_interfaceFeatures::OptionsWidget_interfaceFeatures(QWidget * paren
 #else
 	addBoolSelector(0,5,0,5,__tr2qs_ctx("Require Ctrl to be held down to copy text","options"),KviOption_boolRequireControlToCopy);
 #endif
+#if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
+	addBoolSelector(0,6,0,6,__tr2qs_ctx("Show taskbar button (change requires restart)","options"),KviOption_boolShowTaskBarButton);
+	g = addGroupBox(0,7,0,7,Qt::Horizontal,__tr2qs_ctx("Open Dialog Window for","options"));
+#else
 	g = addGroupBox(0,6,0,6,Qt::Horizontal,__tr2qs_ctx("Open Dialog Window for","options"));
+#endif
 	addBoolSelector(g,__tr2qs_ctx("Preferences","options"),KviOption_boolShowGeneralOptionsDialogAsToplevel);
 	addBoolSelector(g,__tr2qs_ctx("Registered users","options"),KviOption_boolShowRegisteredUsersDialogAsToplevel);
 	addBoolSelector(g,__tr2qs_ctx("Identity","options"),KviOption_boolShowIdentityDialogAsToplevel);
 	addBoolSelector(g,__tr2qs_ctx("Servers","options"),KviOption_boolShowServersConnectDialogAsToplevel);
 	addBoolSelector(g,__tr2qs_ctx("Join channels","options"),KviOption_boolShowChannelsJoinDialogAsToplevel);
 
+#if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
+	addRowSpacer(0,8,0,8);
+#else
 	addRowSpacer(0,7,0,7);
+#endif
 }
 
 OptionsWidget_interfaceFeatures::~OptionsWidget_interfaceFeatures()


### PR DESCRIPTION
Adds an option to hide/show the taskbar button, useful for when you have a second screen for kvirc only. Recommended to be used in combination with the trayicon. Needs a restart for the option to take effect.
Tested on Win7 only.
