### PR TITLE
PopupEditorWindow: add contextRemove() to popup menu

### DIFF
--- a/src/modules/popupeditor/PopupEditorWindow.cpp
+++ b/src/modules/popupeditor/PopupEditorWindow.cpp
@@ -431,6 +431,11 @@ void SinglePopupEditor::customContextMenuRequested(const QPoint &pos)
         this,SLOT(contextCopy()))
             ->setEnabled(it);
 	m_pContextPopup->addAction(
+		*(g_pIconManager->getSmallIcon(KviIconManager::Discard)),
+		__tr2qs_ctx("Re&move","editor"),
+	this,SLOT(contextRemove()))
+		->setEnabled(it);
+	m_pContextPopup->addAction(
 		*(g_pIconManager->getSmallIcon(KviIconManager::Paste)),
         __tr2qs_ctx("&Paste Below","editor"),this,SLOT(contextPasteBelow()))
             ->setEnabled(m_pClipboard);
@@ -631,6 +636,16 @@ void SinglePopupEditor::contextCut()
 	m_pLastSelectedItem = 0;
 	delete it;
 	if(!m_pLastSelectedItem)selectionChanged();
+}
+
+void SinglePopupEditor::contextRemove()
+{
+	if(!m_pLastSelectedItem)return;
+
+	PopupTreeWidgetItem * it = m_pLastSelectedItem;
+	m_pLastSelectedItem = nullptr;
+	delete it;
+	selectionChanged();
 }
 
 void SinglePopupEditor::contextPasteBelow()

--- a/src/modules/popupeditor/PopupEditorWindow.cpp
+++ b/src/modules/popupeditor/PopupEditorWindow.cpp
@@ -183,10 +183,10 @@ void PopupTreeWidgetItem::setIcon(const QString & szIcon)
 SinglePopupEditor::SinglePopupEditor(QWidget * par)
 : QWidget(par)
 {
-	m_pLastSelectedItem = 0;
+	m_pLastSelectedItem = nullptr;
 	m_pContextPopup = new QMenu(this);
-	m_pClipboard = 0;
-	m_pTestPopup = 0;
+	m_pClipboard = nullptr;
+	m_pTestPopup = nullptr;
 
 	QGridLayout * g = new QGridLayout(this);
 	g->setMargin(0);
@@ -628,7 +628,7 @@ void SinglePopupEditor::contextCut()
 	contextCopy();
 
 	PopupTreeWidgetItem * it = m_pLastSelectedItem;
-	m_pLastSelectedItem = 0;
+	m_pLastSelectedItem = nullptr;
 	delete it;
 	if(!m_pLastSelectedItem)selectionChanged();
 }
@@ -983,7 +983,7 @@ void SinglePopupEditor::edit(MenuTreeWidgetItem * it)
 {
 	saveLastSelectedItem();
 
-	m_pLastSelectedItem = 0;
+	m_pLastSelectedItem = nullptr;
 
 	m_pTreeWidget->clear();
 
@@ -1060,7 +1060,7 @@ PopupEditorWidget::PopupEditorWidget(QWidget * par)
 	m_pEditor = new SinglePopupEditor(spl);
 
 	m_bOneTimeSetupDone = false;
-	m_pLastEditedItem = 0;
+	m_pLastEditedItem = nullptr;
 
 	m_pContextPopup = new QMenu(this);
 	m_pEmptyContextPopup = new QMenu(this);
@@ -1257,7 +1257,7 @@ void PopupEditorWidget::removeCurrentPopup()
 	if(m_pLastEditedItem)
 	{
 		MenuTreeWidgetItem * it = m_pLastEditedItem;
-		m_pLastEditedItem = 0;
+		m_pLastEditedItem = nullptr;
 		delete it;
 		if(!m_pLastEditedItem)currentItemChanged(0,0);
 	}
@@ -1408,7 +1408,7 @@ PopupEditorWindow::PopupEditorWindow()
 
 PopupEditorWindow::~PopupEditorWindow()
 {
-	g_pPopupEditorWindow = 0;
+	g_pPopupEditorWindow = nullptr;
 }
 
 void PopupEditorWindow::okClicked()

--- a/src/modules/popupeditor/PopupEditorWindow.cpp
+++ b/src/modules/popupeditor/PopupEditorWindow.cpp
@@ -184,14 +184,13 @@ SinglePopupEditor::SinglePopupEditor(QWidget * par)
 : QWidget(par)
 {
 	m_pLastSelectedItem = 0;
-    m_pContextPopup = new QMenu(this);
+	m_pContextPopup = new QMenu(this);
 	m_pClipboard = 0;
 	m_pTestPopup = 0;
 
 	QGridLayout * g = new QGridLayout(this);
 	g->setMargin(0);
 	g->setSpacing(2);
-
 
 	m_pNameEditor = new QLineEdit(this);
 	m_pNameEditor->setToolTip(__tr2qs_ctx("Popup name","editor"));
@@ -381,82 +380,78 @@ void SinglePopupEditor::customContextMenuRequested(const QPoint &pos)
 	}
 
 	m_pContextPopup->addAction(__tr2qs_ctx("New Separator Below","editor"),this,SLOT(contextNewSeparatorBelow()));
-    m_pContextPopup->addAction(__tr2qs_ctx("New Separator Above","editor"),this,SLOT(contextNewSeparatorAbove()))
-            ->setEnabled(it);
-    m_pContextPopup->addAction(__tr2qs_ctx("New Separator Inside","editor"),this,SLOT(contextNewSeparatorInside()))
-            ->setEnabled(it && bIsMenu);
+	m_pContextPopup->addAction(__tr2qs_ctx("New Separator Above","editor"),this,SLOT(contextNewSeparatorAbove()))
+		->setEnabled(it);
+	m_pContextPopup->addAction(__tr2qs_ctx("New Separator Inside","editor"),this,SLOT(contextNewSeparatorInside()))
+		->setEnabled(it && bIsMenu);
 
-    m_pContextPopup->addSeparator();
+	m_pContextPopup->addSeparator();
 
 	m_pContextPopup->addAction(__tr2qs_ctx("New Label Below","editor"),this,SLOT(contextNewLabelBelow()));
-    m_pContextPopup->addAction(__tr2qs_ctx("New Label Above","editor"),this,SLOT(contextNewLabelAbove()))
-            ->setEnabled(it);
-    m_pContextPopup->addAction(__tr2qs_ctx("New Label Inside","editor"),this,SLOT(contextNewLabelInside()))
-            ->setEnabled(it && bIsMenu);
+	m_pContextPopup->addAction(__tr2qs_ctx("New Label Above","editor"),this,SLOT(contextNewLabelAbove()))
+		->setEnabled(it);
+	m_pContextPopup->addAction(__tr2qs_ctx("New Label Inside","editor"),this,SLOT(contextNewLabelInside()))
+		->setEnabled(it && bIsMenu);
 
-    m_pContextPopup->addSeparator();
+	m_pContextPopup->addSeparator();
 
 	m_pContextPopup->addAction(__tr2qs_ctx("New Item Below","editor"),this,SLOT(contextNewItemBelow()));
-    m_pContextPopup->addAction(__tr2qs_ctx("New Item Above","editor"),this,SLOT(contextNewItemAbove()))
-            ->setEnabled(it);
-    m_pContextPopup->addAction(__tr2qs_ctx("New Item Inside","editor"),this,SLOT(contextNewItemInside()))
-            ->setEnabled(it && bIsMenu);
+	m_pContextPopup->addAction(__tr2qs_ctx("New Item Above","editor"),this,SLOT(contextNewItemAbove()))
+		->setEnabled(it);
+	m_pContextPopup->addAction(__tr2qs_ctx("New Item Inside","editor"),this,SLOT(contextNewItemInside()))
+		->setEnabled(it && bIsMenu);
 
-    m_pContextPopup->addSeparator();
+	m_pContextPopup->addSeparator();
 
 	m_pContextPopup->addAction(__tr2qs_ctx("New Menu Below","editor"),this,SLOT(contextNewMenuBelow()));
-    m_pContextPopup->addAction(__tr2qs_ctx("New Menu Above","editor"),this,SLOT(contextNewMenuAbove()))
-            ->setEnabled(it);
-    m_pContextPopup->addAction(__tr2qs_ctx("New Menu Inside","editor"),this,SLOT(contextNewMenuInside()))
-            ->setEnabled(it && bIsMenu);
+	m_pContextPopup->addAction(__tr2qs_ctx("New Menu Above","editor"),this,SLOT(contextNewMenuAbove()))
+		->setEnabled(it);
+	m_pContextPopup->addAction(__tr2qs_ctx("New Menu Inside","editor"),this,SLOT(contextNewMenuInside()))
+		->setEnabled(it && bIsMenu);
 
-    m_pContextPopup->addSeparator();
+	m_pContextPopup->addSeparator();
 
 	m_pContextPopup->addAction(__tr2qs_ctx("New External Menu Below","editor"),this,SLOT(contextNewExtMenuBelow()));
-    m_pContextPopup->addAction(__tr2qs_ctx("New External Menu Above","editor"),this,SLOT(contextNewExtMenuAbove()))
-            ->setEnabled(it);
-    m_pContextPopup->addAction(__tr2qs_ctx("New External Menu Inside","editor"),this,SLOT(contextNewExtMenuInside()))
-            ->setEnabled(it && bIsMenu);
+	m_pContextPopup->addAction(__tr2qs_ctx("New External Menu Above","editor"),this,SLOT(contextNewExtMenuAbove()))
+		->setEnabled(it);
+	m_pContextPopup->addAction(__tr2qs_ctx("New External Menu Inside","editor"),this,SLOT(contextNewExtMenuInside()))
+		->setEnabled(it && bIsMenu);
 
-    m_pContextPopup->addSeparator();
+	m_pContextPopup->addSeparator();
 
 	m_pContextPopup->addAction(
 		*(g_pIconManager->getSmallIcon(KviIconManager::Cut)),
-		__tr2qs_ctx("Cu&t","editor"),
-        this,SLOT(contextCut()))
-            ->setEnabled(it);
+		__tr2qs_ctx("Cu&t","editor"),this,SLOT(contextCut()))
+		->setEnabled(it);
 	m_pContextPopup->addAction(
 		*(g_pIconManager->getSmallIcon(KviIconManager::Copy)),
-		__tr2qs_ctx("&Copy","editor"),
-        this,SLOT(contextCopy()))
-            ->setEnabled(it);
+		__tr2qs_ctx("&Copy","editor"),this,SLOT(contextCopy()))
+		->setEnabled(it);
 	m_pContextPopup->addAction(
 		*(g_pIconManager->getSmallIcon(KviIconManager::Discard)),
-		__tr2qs_ctx("Re&move","editor"),
-	this,SLOT(contextRemove()))
+		__tr2qs_ctx("Re&move","editor"),this,SLOT(contextRemove()))
 		->setEnabled(it);
 	m_pContextPopup->addAction(
 		*(g_pIconManager->getSmallIcon(KviIconManager::Paste)),
-        __tr2qs_ctx("&Paste Below","editor"),this,SLOT(contextPasteBelow()))
-            ->setEnabled(m_pClipboard);
+		__tr2qs_ctx("&Paste Below","editor"),this,SLOT(contextPasteBelow()))
+		->setEnabled(m_pClipboard);
 	m_pContextPopup->addAction(
 		*(g_pIconManager->getSmallIcon(KviIconManager::Paste)),
-        __tr2qs_ctx("Paste Above","editor"),this,SLOT(contextPasteAbove()))
-            ->setEnabled(it && m_pClipboard);
+		__tr2qs_ctx("Paste Above","editor"),this,SLOT(contextPasteAbove()))
+		->setEnabled(it && m_pClipboard);
 	m_pContextPopup->addAction(
 		*(g_pIconManager->getSmallIcon(KviIconManager::Paste)),
-        __tr2qs_ctx("Paste Inside","editor"),this,SLOT(contextPasteInside()))
-            ->setEnabled(it && bIsMenu && m_pClipboard);
+		__tr2qs_ctx("Paste Inside","editor"),this,SLOT(contextPasteInside()))
+		->setEnabled(it && bIsMenu && m_pClipboard);
 
 	bool bSeparatorInserted = false;
 
 //	if(!findPrologue(parentMenu))
 //	{
         m_pContextPopup->addSeparator();
-		bSeparatorInserted = true;
-		m_pContextPopup->addAction(
-				*(g_pIconManager->getSmallIcon(KviIconManager::Prologue)),
-				__tr2qs_ctx("New Menu Prologue","editor"),this,SLOT(contextNewPrologue()));
+	bSeparatorInserted = true;
+	m_pContextPopup->addAction(*(g_pIconManager->getSmallIcon(KviIconManager::Prologue)),
+			__tr2qs_ctx("New Menu Prologue","editor"),this,SLOT(contextNewPrologue()));
 //	}
 
 //	if(!findEpilogue(parentMenu))
@@ -595,7 +590,7 @@ void SinglePopupEditor::contextNewPrologue()
 	PopupTreeWidgetItem * it = m_pLastSelectedItem ? (PopupTreeWidgetItem *)m_pLastSelectedItem->parent() : 0;
 //	if(!findPrologue(it))
 //	{
-		m_pTreeWidget->setCurrentItem(newItem(it,it,PopupTreeWidgetItem::Prologue));
+	m_pTreeWidget->setCurrentItem(newItem(it,it,PopupTreeWidgetItem::Prologue));
 //	}
 }
 
@@ -604,18 +599,18 @@ void SinglePopupEditor::contextNewEpilogue()
 	PopupTreeWidgetItem * it = m_pLastSelectedItem ? (PopupTreeWidgetItem *)m_pLastSelectedItem->parent() : 0;
 //	if(!findEpilogue(it))
 //	{
-		PopupTreeWidgetItem * after = it ? (PopupTreeWidgetItem *)it->child(0) : (PopupTreeWidgetItem *)m_pTreeWidget->topLevelItem(0);
-		if(after)
+	PopupTreeWidgetItem * after = it ? (PopupTreeWidgetItem *)it->child(0) : (PopupTreeWidgetItem *)m_pTreeWidget->topLevelItem(0);
+	if(after)
+	{
+		while(m_pTreeWidget->itemAbove(after))
 		{
-			while(m_pTreeWidget->itemAbove(after))
-			{
-				if(after->parent()==m_pTreeWidget->itemAbove(after)->parent())
-					after = (PopupTreeWidgetItem *)m_pTreeWidget->itemAbove(after);
-			}
-		} else {
-			after = it;
+			if(after->parent()==m_pTreeWidget->itemAbove(after)->parent())
+				after = (PopupTreeWidgetItem *)m_pTreeWidget->itemAbove(after);
 		}
-		m_pTreeWidget->setCurrentItem(newItem(it,after,PopupTreeWidgetItem::Epilogue));
+	} else {
+		after = it;
+	}
+	m_pTreeWidget->setCurrentItem(newItem(it,after,PopupTreeWidgetItem::Epilogue));
 //	}
 }
 
@@ -1067,8 +1062,8 @@ PopupEditorWidget::PopupEditorWidget(QWidget * par)
 	m_bOneTimeSetupDone = false;
 	m_pLastEditedItem = 0;
 
-    m_pContextPopup = new QMenu(this);
-    m_pEmptyContextPopup = new QMenu(this);
+	m_pContextPopup = new QMenu(this);
+	m_pEmptyContextPopup = new QMenu(this);
 
 	spl->setStretchFactor (0,20);
 	spl->setStretchFactor (1,80);
@@ -1164,14 +1159,14 @@ void PopupEditorWidget::customContextMenuRequested(const QPoint &pos)
 		m_pContextPopup->addAction(
 			*(g_pIconManager->getSmallIcon(KviIconManager::Discard)),
 			__tr2qs_ctx("Re&move Popup","editor"),
-            this,SLOT(removeCurrentPopup()))
-                    ->setEnabled(it);
+			this,SLOT(removeCurrentPopup()))
+		->setEnabled(it);
 
 		m_pContextPopup->addAction(
 			*(g_pIconManager->getSmallIcon(KviIconManager::Save)),
 			__tr2qs_ctx("&Export Popup to...","editor"),
-            this,SLOT(exportCurrentPopup()))
-                ->setEnabled(it);
+			this,SLOT(exportCurrentPopup()))
+		->setEnabled(it);
 
 		m_pContextPopup->popup(QCursor::pos());
 	} else {

--- a/src/modules/popupeditor/PopupEditorWindow.h
+++ b/src/modules/popupeditor/PopupEditorWindow.h
@@ -71,19 +71,19 @@ public:
 	SinglePopupEditor(QWidget * par);
 	~SinglePopupEditor();
 protected:
-	QPushButton          * m_pMenuButton;
-	KviKvsPopupMenu      * m_pClipboard;
-	KviKvsPopupMenu      * m_pTestPopup;
-	PopupTreeWidgetItem * m_pLastSelectedItem;
-	QTreeWidget     * m_pTreeWidget;
-	QLineEdit            * m_pNameEditor;
-	KviScriptEditor      * m_pEditor;
-	QLineEdit            * m_pTextEditor;
-	QLineEdit            * m_pIdEditor;
-	QLineEdit            * m_pIconEditor;
-	QLineEdit            * m_pConditionEditor;
-	QLineEdit            * m_pExtNameEditor;
-    QMenu      * m_pContextPopup;
+	QPushButton           * m_pMenuButton;
+	KviKvsPopupMenu       * m_pClipboard;
+	KviKvsPopupMenu	      * m_pTestPopup;
+	PopupTreeWidgetItem   * m_pLastSelectedItem;
+	QTreeWidget           * m_pTreeWidget;
+	QLineEdit             * m_pNameEditor;
+	KviScriptEditor       * m_pEditor;
+	QLineEdit             * m_pTextEditor;
+	QLineEdit             * m_pIdEditor;
+	QLineEdit             * m_pIconEditor;
+	QLineEdit             * m_pConditionEditor;
+	QLineEdit             * m_pExtNameEditor;
+	QMenu                 * m_pContextPopup;
 public:
 	void edit(MenuTreeWidgetItem * it);
 	KviKvsPopupMenu * getMenu();
@@ -153,13 +153,13 @@ public:
 	PopupEditorWidget(QWidget * par);
 	~PopupEditorWidget();
 public:
-	SinglePopupEditor * m_pEditor;
-	QTreeWidget     * m_pTreeWidget;
-	MenuTreeWidgetItem  * m_pLastEditedItem;
-	bool                   m_bOneTimeSetupDone;
-    QMenu      * m_pContextPopup;
-    QMenu      * m_pEmptyContextPopup;
-	bool                   m_bSaving;
+	SinglePopupEditor       * m_pEditor;
+	QTreeWidget             * m_pTreeWidget;
+	MenuTreeWidgetItem      * m_pLastEditedItem;
+	bool                      m_bOneTimeSetupDone;
+	QMenu                   * m_pContextPopup;
+	QMenu                   * m_pEmptyContextPopup;
+	bool                      m_bSaving;
 public:
 	void commit();
 	void exportPopups(bool);

--- a/src/modules/popupeditor/PopupEditorWindow.h
+++ b/src/modules/popupeditor/PopupEditorWindow.h
@@ -103,6 +103,7 @@ protected:
 protected slots:
 	void contextCut();
 	void contextCopy();
+	void contextRemove();
 	void contextPasteBelow();
 	void contextPasteAbove();
 	void contextPasteInside();


### PR DESCRIPTION
Implements #1944 Feature Request: 

Tested in Linux seems to be working, just giving a chance to see if appveyor and travis like this and to see if anyone has any thing to say 
#### Changes proposed
- add remove item to popup editor context menu

resolves #1944
