### PR TITLE
fix: OnServerLinkPopupRequest: add traceroute and ping for IPv4/v6

### DIFF
--- a/data/defscript/popups.kvs
+++ b/data/defscript/popups.kvs
@@ -1641,3 +1641,114 @@ defpopup(channel)
 	}
 }
 
+defpopup(serverpopup)
+{
+	popup($tr("&Information","defscript"),317) ($server)
+	{
+		item(/MOTD,30)
+		{
+			motd
+		}
+
+		item(/INFO,317)
+		{
+			info
+		}
+
+		item(/LUSERS,178)
+		{
+			lusers
+		}
+
+		popup(/STATS,205)
+		{
+			item($tr("d (Debug/DNS?)","defscript"))
+			{
+				stats d
+			}
+
+			item($tr("l (Connections)","defscript"))
+			{
+				stats l
+			}
+
+			item($tr("m (Command Usage)","defscript"))
+			{
+				stats m
+			}
+
+			item($tr("o (Operators)","defscript"))
+			{
+				stats o
+			}
+
+			item($tr("t (Connection Stats?)","defscript"))
+			{
+				stats t
+			}
+
+			item($tr("u (Uptime)","defscript"))
+			{
+				stats u
+			}
+
+			item($tr("y (Y-Lines)","defscript"))
+			{
+				stats y
+			}
+
+			item($tr("z (Debug Stats?)","defscript"))
+			{
+				stats z
+			}
+		}
+
+		item(/TIME,93)
+		{
+			time
+		}
+
+		item(/ADMIN,261)
+		{
+			admin
+		}
+
+		item(/VERSION,16)
+		{
+			version
+		}
+
+		item(/HELP,49)
+		{
+			raw help
+		}
+	}
+
+	separator
+
+	item($tr("Traceroute to ","defscript")$0,36)
+	{
+		if("$system.ostype" == "unix") system.runcmd traceroute $0
+		else system.runcmd tracert $0
+	}
+
+	item($tr("Traceroute6 to ","defscript")$0,36)
+	{
+		if("$system.ostype" == "unix") system.runcmd traceroute6 $0
+		else system.runcmd tracert -6 $0
+	}
+
+	item("Ping "$0,36)
+	{
+		system.runcmd ping $0
+	}
+
+	item("Ping6 "$0,36)
+	{
+		if("$system.ostype" == "unix") system.runcmd ping6 $0
+		else system.runcmd ping -6 $0
+	}
+
+	label($tr("You're not connected to a server","defscript")) (!$server)
+}
+


### PR DESCRIPTION
ping/and traceroute for both IPv4 (tested and works) and IPv6 (untested)

Also fix KVIrc stubborn way of ordering popups which @staticfox ignored in https://github.com/kvirc/KVIrc/commit/e7c3ef7db4922e974ae310eac800392552557dbd
