### PR TITLE
OptionsWidget: rename option labels to reflect current function

### DIFF
--- a/src/modules/options/OptionsWidget_channel.cpp
+++ b/src/modules/options/OptionsWidget_channel.cpp
@@ -74,14 +74,13 @@ OptionsWidget_channelGeneral::OptionsWidget_channelGeneral(QWidget * pParent)
 	mergeTip(b,
 		__tr2qs_ctx("This option will cause KVIrc to automatically " \
 			"join a channel when an INVITE message for that channel is received.<br>" \
-			"<b>Warning:</b> this may help spammers harass you. :)","options"));
+			"<b>Warning:</b> this may help spammers harass you.","options"));
 
-	b = addBoolSelector(0,3,0,3, __tr2qs_ctx("Always open channels as minimized","options"),KviOption_boolCreateMinimizedChannels);
-	mergeTip(b,
-		__tr2qs_ctx("This option causes newly created " \
-			"channel windows to be immediately minimized.<br>" \
+	b = addBoolSelector(0,3,0,3, __tr2qs_ctx("Open channel windows without focus","options"),KviOption_boolCreateMinimizedChannels);
+	mergeTip(b, __tr2qs_ctx("This option prevents newly created " \
+			"channel windows from diverting application focus.<br>" \
 			"Enable this if you don't like channels " \
-			"popping up while you're typing something in a channel. :D","options"));
+			"popping up while you're typing something in a channel.","options"));
 
 	addRowSpacer(0,4,0,4);
 }

--- a/src/modules/options/OptionsWidget_channel.cpp
+++ b/src/modules/options/OptionsWidget_channel.cpp
@@ -36,6 +36,7 @@
 
 #include <QComboBox>
 
+
 OptionsWidget_channel::OptionsWidget_channel(QWidget * pParent)
 : KviOptionsWidget(pParent)
 {
@@ -52,35 +53,32 @@ OptionsWidget_channelGeneral::OptionsWidget_channelGeneral(QWidget * pParent)
 
 	KviTalGroupBox * g = addGroupBox(0,0,0,0,Qt::Horizontal,__tr2qs_ctx("On Channel Kick","options"));
 
- 	KviBoolSelector *b = addBoolSelector(g,__tr2qs_ctx("Rejoin channel","options"),KviOption_boolRejoinChannelOnKick);
-	mergeTip(b,
-		__tr2qs_ctx("This option will cause KVIrc to attempt " \
-		"to rejoin a channel after being kicked.","options"));
+	KviBoolSelector *b = addBoolSelector(g,__tr2qs_ctx("Rejoin channel","options"),KviOption_boolRejoinChannelOnKick);
+	mergeTip(b,__tr2qs_ctx("This option will cause KVIrc to attempt " \
+				"to rejoin a channel after being kicked.","options"));
+
 	b = addBoolSelector(g,__tr2qs_ctx("Keep channel open","options"),KviOption_boolKeepChannelOpenOnKick);
-	mergeTip(b,
-		__tr2qs_ctx("This option will cause KVIrc to keep " \
-			"the channel window open after being kicked.<br>" \
-			"It might be a good idea to also enable the " \
-			"\"Rejoin channel\" option.","options"));
+	mergeTip(b,__tr2qs_ctx("This option will cause KVIrc to keep " \
+				"the channel window open after being kicked.<br>" \
+				"It might be a good idea to also enable the " \
+				"\"Rejoin channel\" option.","options"));
 
 	g = addGroupBox(0,1,0,1,Qt::Horizontal,__tr2qs_ctx("On Channel Part","options"));
 
 	b = addBoolSelector(g,__tr2qs_ctx("Keep channel open","options"),KviOption_boolKeepChannelOpenOnPart);
-	mergeTip(b,
-		__tr2qs_ctx("This option will cause KVIrc to keep " \
-			"the channel window open after leaving it.","options"));
+	mergeTip(b,__tr2qs_ctx("This option will cause KVIrc to keep " \
+				"the channel window open after leaving it.","options"));
 
 	b = addBoolSelector(0,2,0,2,__tr2qs_ctx("Automatically join channel on invite","options"),KviOption_boolAutoJoinOnInvite);
-	mergeTip(b,
-		__tr2qs_ctx("This option will cause KVIrc to automatically " \
-			"join a channel when an INVITE message for that channel is received.<br>" \
-			"<b>Warning:</b> this may help spammers harass you.","options"));
+	mergeTip(b,__tr2qs_ctx("This option will cause KVIrc to automatically " \
+				"join a channel when an INVITE message for that channel is received.<br>" \
+				"<b>Warning:</b> this may help spammers harass you.","options"));
 
 	b = addBoolSelector(0,3,0,3, __tr2qs_ctx("Open channel windows without focus","options"),KviOption_boolCreateMinimizedChannels);
-	mergeTip(b, __tr2qs_ctx("This option prevents newly created " \
-			"channel windows from diverting application focus.<br>" \
-			"Enable this if you don't like channels " \
-			"popping up while you're typing something in a channel.","options"));
+	mergeTip(b,__tr2qs_ctx("This option prevents newly created " \
+				"channel windows from diverting application focus.<br>" \
+				"Enable this if you don't like channels " \
+				"popping up while you're typing something in a channel.","options"));
 
 	addRowSpacer(0,4,0,4);
 }
@@ -106,19 +104,22 @@ OptionsWidget_channelAdvanced::OptionsWidget_channelAdvanced(QWidget * pParent)
 	KviIrcMask ipmask("nick!user@192.168.1.2");
 	QString tmp1;
 	QString tmp2;
+
 	for(int i=0;i<=26;i++)
 	{
-
 		hostmask.mask(tmp1,(KviIrcMask::MaskType)i);
 		ipmask.mask(tmp2,(KviIrcMask::MaskType)i);
-        m_pBanTypeCombo->insertItem(m_pBanTypeCombo->count(),QString("%1 (%2)").arg(tmp1, tmp2));
+		m_pBanTypeCombo->insertItem(m_pBanTypeCombo->count(),QString("%1 (%2)").arg(tmp1, tmp2));
 	}
+
 	m_pBanTypeCombo->setCurrentIndex(KVI_OPTION_UINT(KviOption_uintDefaultBanType));
 
 	KviTalGroupBox * g = addGroupBox(0,2,4,2,Qt::Horizontal,__tr2qs_ctx("On Channel Join","options"));
 	KviUIntSelector *u = addUIntSelector(g,__tr2qs_ctx("Minimum delay between two channel requests:","options"),KviOption_uintOnJoinRequestsDelay,0,10,1);
 	u->setSuffix(__tr2qs_ctx(" sec","options"));
-	mergeTip(u,__tr2qs_ctx("This is an artificial delay for the channel requests made on join.<br>You may increase it if your server complains about flooding when joining many channels at once.<br>Minimum value: <b>0 secs</b><br>Maximum value: <b>10 secs</b>","options"));
+	mergeTip(u,__tr2qs_ctx("This is an artificial delay for the channel requests made on join.<br>" \
+				"You may increase it if your server complains about flooding when joining " \
+				"many channels at once.<br>Minimum value: <b>0 secs</b><br>Maximum value: <b>10 secs</b>","options"));
 
 	addBoolSelector(g,__tr2qs_ctx("Do not send /WHO request","options"),KviOption_boolDisableWhoRequestOnJoin);
 	addBoolSelector(g,__tr2qs_ctx("Do not request ban list","options"),KviOption_boolDisableBanListRequestOnJoin);
@@ -129,22 +130,23 @@ OptionsWidget_channelAdvanced::OptionsWidget_channelAdvanced(QWidget * pParent)
 	addBoolSelector(g,__tr2qs_ctx("Show channel sync time","options"),KviOption_boolShowChannelSyncTime);
 
 	b = addBoolSelector(g,__tr2qs_ctx("Paste last channel log","options"),KviOption_boolPasteLastLogOnChannelJoin);
-
 	KviTalHBox * box = new KviTalHBox(g);
 	u = addUIntSelector(box,__tr2qs_ctx("Paste up to:","options"),KviOption_uintLinesToPasteOnChannelJoin,0,50,10,KVI_OPTION_BOOL(KviOption_boolPasteLastLogOnChannelJoin));
 	u->setSuffix(__tr2qs_ctx(" lines","options"));
 	mergeTip(u,__tr2qs_ctx("Minimum value: <b>0 lines</b><br>Maximum value: <b>50 lines</b>","options"));
+	
 	connect(b,SIGNAL(toggled(bool)),u,SLOT(setEnabled(bool)));
+	
 	u = addUIntSelector(box,__tr2qs_ctx("Interval:","options"),KviOption_uintDaysIntervalToPasteOnChannelJoin,1,10,10,KVI_OPTION_BOOL(KviOption_boolPasteLastLogOnChannelJoin));
 	u->setSuffix(__tr2qs_ctx(" days","options"));
 	mergeTip(u,__tr2qs_ctx("Minimum value: <b>0 days</b><br>Maximum value: <b>10 days</b>","options"));
+
 	connect(b,SIGNAL(toggled(bool)),u,SLOT(setEnabled(bool)));
 
- 	b = addBoolSelector(0,3,4,3,__tr2qs_ctx("Keep away list updated","options"),KviOption_boolEnableAwayListUpdates);
-	mergeTip(b,
-		__tr2qs_ctx("KVIrc sends out a channel /WHO message every now and then to keep " \
-			"the channel away list in sync. Use this option to disable this feature (and to save " \
-			"your IRC bandwidth). If the server supports IRCv3.1's away-notify extension, it will be used instead of WHO requests.","options"));
+	b = addBoolSelector(0,3,4,3,__tr2qs_ctx("Keep away list updated","options"),KviOption_boolEnableAwayListUpdates);
+	mergeTip(b,__tr2qs_ctx("KVIrc sends out a channel /WHO message every now and then to keep the channel away list in sync. " \
+				"Use this option to disable this feature (and to save your IRC bandwidth).<br>" \
+				"If the server supports IRCv3.1's away-notify extension, it will be used instead of WHO requests.","options"));
 
 	addRowSpacer(0,5,4,5);
 }

--- a/src/modules/options/OptionsWidget_channel.h
+++ b/src/modules/options/OptionsWidget_channel.h
@@ -47,7 +47,6 @@ public:
 	~OptionsWidget_channel();
 };
 
-
 #define KVI_OPTIONS_WIDGET_ICON_OptionsWidget_channelGeneral KviIconManager::Channel
 #define KVI_OPTIONS_WIDGET_NAME_OptionsWidget_channelGeneral __tr2qs_no_lookup("General")
 #define KVI_OPTIONS_WIDGET_PARENT_OptionsWidget_channelGeneral OptionsWidget_channel

--- a/src/modules/options/OptionsWidget_dcc.cpp
+++ b/src/modules/options/OptionsWidget_dcc.cpp
@@ -173,7 +173,12 @@ OptionsWidget_dccSendGeneral::OptionsWidget_dccSendGeneral(QWidget * parent)
 
 	KviTalGroupBox * g = addGroupBox(0,0,0,0,Qt::Horizontal,__tr2qs_ctx("On Incoming File","options"));
 	KviBoolSelector * b2 = addBoolSelector(g,__tr2qs_ctx("Automatically accept","options"),KviOption_boolAutoAcceptDccSend);
-	KviBoolSelector * b3 = addBoolSelector(g,__tr2qs_ctx("Open transfer window as minimized when auto-accepted","options"),KviOption_boolCreateMinimizedDccSendWhenAutoAccepted,!KVI_OPTION_BOOL(KviOption_boolCreateMinimizedDccSend));
+	KviBoolSelector * b3 = addBoolSelector(g, __tr2qs_ctx("Open auto-accepted transfer window without focus","options"),KviOption_boolCreateMinimizedDccSendWhenAutoAccepted,!KVI_OPTION_BOOL(KviOption_boolCreateMinimizedDccSend));
+	mergeTip(b3, __tr2qs_ctx("This option prevents the transfer window " \
+			"from opening and diverting application focus.<br>" \
+			"Enable this if you don't like the transfer window " \
+			"popping up while you're typing something in a channel.","options"));
+
 	KviBoolSelector * b4 = addBoolSelector(g,__tr2qs_ctx("Automatically resume when auto-accepted","options"),KviOption_boolAutoResumeDccSendWhenAutoAccepted,KVI_OPTION_BOOL(KviOption_boolAutoAcceptDccSend));
 
 	g = addGroupBox(0,1,0,1,Qt::Horizontal,__tr2qs_ctx("Save Location","options"));
@@ -191,7 +196,11 @@ OptionsWidget_dccSendGeneral::OptionsWidget_dccSendGeneral(QWidget * parent)
 				"to be automatically removed from the transfer window.","options"));
 
 
-	KviBoolSelector * b1 = addBoolSelector(0,3,0,3,__tr2qs_ctx("Always open transfer window as minimized","options"),KviOption_boolCreateMinimizedDccSend);
+	KviBoolSelector * b1 = addBoolSelector(0,3,0,3, __tr2qs_ctx("Open transfer window without focus","options"), KviOption_boolCreateMinimizedDccSend);
+	mergeTip(b1, __tr2qs_ctx("This option prevents the transfer window " \
+			"from opening and diverting application focus.<br>" \
+			"Enable this if you don't like the transfer window " \
+			"popping up while you're typing something in a channel.","options"));
 
 	connect(b1,SIGNAL(toggled(bool)),b3,SLOT(setNotEnabled(bool)));
 	connect(b2,SIGNAL(toggled(bool)),b4,SLOT(setEnabled(bool)));
@@ -318,9 +327,17 @@ OptionsWidget_dccChat::OptionsWidget_dccChat(QWidget * parent)
 	KviTalGroupBox * g = addGroupBox(0,0,0,0,Qt::Horizontal,__tr2qs_ctx("On Chat Request","options"));
 	addBoolSelector(g,__tr2qs_ctx("Automatically accept","options"),KviOption_boolAutoAcceptDccChat);
 
-	KviBoolSelector * b1 = addBoolSelector(g,__tr2qs_ctx("Open minimized when auto-accepted","options"),KviOption_boolCreateMinimizedDccChatWhenAutoAccepted,!KVI_OPTION_BOOL(KviOption_boolCreateMinimizedDccChat));
+	KviBoolSelector * b1 = addBoolSelector(g, __tr2qs_ctx("Open auto-accepted DCC chat windows without focus","options"),KviOption_boolCreateMinimizedDccChatWhenAutoAccepted,!KVI_OPTION_BOOL(KviOption_boolCreateMinimizedDccChat));
+	mergeTip(b1, __tr2qs_ctx("This option prevents incoming " \
+				"auto-accepted DCC chat windows from diverting application focus.<br>" \
+				"Enable this if you don't like DCC chat windows " \
+				"popping up while you're typing something in a channel.","options"));
 
-	KviBoolSelector * b2 = addBoolSelector(0,1,0,1,__tr2qs_ctx("Always open as minimized","options"),KviOption_boolCreateMinimizedDccChat);
+	KviBoolSelector * b2 = addBoolSelector(0,1,0,1, __tr2qs_ctx("Open DCC chat windows without focus","options"),KviOption_boolCreateMinimizedDccChat);
+	mergeTip(b2, __tr2qs_ctx("This option prevents incoming " \
+				"DCC chat windows from diverting application focus.<br>" \
+				"Enable this if you don't like DCC chat windows " \
+				"popping up while you're typing something in a channel.","options"));
 
 	connect(b2,SIGNAL(toggled(bool)),b1,SLOT(setNotEnabled(bool)));
 
@@ -349,11 +366,21 @@ OptionsWidget_dccVoice::OptionsWidget_dccVoice(QWidget *p):KviOptionsWidget(p)
 {
 	createLayout();
 
-	KviBoolSelector * b1 = addBoolSelector(0,0,0,0,__tr2qs_ctx("Open all minimized","options"),KviOption_boolCreateMinimizedDccVoice);
+	KviBoolSelector * b1 = addBoolSelector(0,0,0,0, __tr2qs_ctx("Open all DCC voice windows without focus","options"),KviOption_boolCreateMinimizedDccVoice);
+	mergeTip(b1, __tr2qs_ctx("This option prevents all incoming " \
+				"DCC voice windows from diverting application focus.<br>" \
+				"Enable this if you don't like DCC voice windows " \
+				"popping up while you're typing something in a channel.","options"));
+
 	KviTalGroupBox * g = addGroupBox(0,1,0,1,Qt::Horizontal,__tr2qs_ctx("On Voice Request","options"));
 	KviBoolSelector * b = addBoolSelector(g,__tr2qs_ctx("Automatically accept","options"),KviOption_boolAutoAcceptDccVoice);
 
-	b = addBoolSelector(g,__tr2qs_ctx("Open minimized when auto-accepted","options"),KviOption_boolCreateMinimizedDccVoiceWhenAutoAccepted,!KVI_OPTION_BOOL(KviOption_boolCreateMinimizedDccVoice));
+	b = addBoolSelector(g, __tr2qs_ctx("Open auto-accepted DCC voice windows without focus","options"),KviOption_boolCreateMinimizedDccVoiceWhenAutoAccepted,!KVI_OPTION_BOOL(KviOption_boolCreateMinimizedDccVoice));
+	mergeTip(b, __tr2qs_ctx("This option prevents incoming " \
+				"auto-accepted DCC voice windows from diverting application focus.<br>" \
+				"Enable this if you don't like DCC voice windows " \
+				"popping up while you're typing something in a channel.","options"));
+
 	connect(b1,SIGNAL(toggled(bool)),b,SLOT(setNotEnabled(bool)));
 
 	addBoolSelector(0,2,0,2,__tr2qs_ctx("Force half-duplex mode on sound device","options"), KviOption_boolDccVoiceForceHalfDuplex);

--- a/src/modules/options/OptionsWidget_dcc.cpp
+++ b/src/modules/options/OptionsWidget_dcc.cpp
@@ -39,8 +39,6 @@ OptionsWidget_dcc::~OptionsWidget_dcc()
 {
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 
 OptionsWidget_dccGeneral::OptionsWidget_dccGeneral(QWidget * parent)
 : KviOptionsWidget(parent)
@@ -49,10 +47,9 @@ OptionsWidget_dccGeneral::OptionsWidget_dccGeneral(QWidget * parent)
 	createLayout();
 
 	KviBoolSelector * b = addBoolSelector(0,0,0,0,__tr2qs_ctx("Use workaround for firewall","options"),KviOption_boolCantAcceptIncomingDccConnections);
-
 	mergeTip(b,__tr2qs_ctx("Enable this option if you can't accept incoming connections.<br>" \
-			"KVIrc will try to use different methods to send and receive files.<br>" \
-			"Please note that these methods may NOT work when communicating with a non-KVIrc client.","options"));
+				"KVIrc will try to use different methods to send and receive files.<br>" \
+				"Please note that these methods may NOT work when communicating with a non-KVIrc client.","options"));
 
 	addRowSpacer(0,1,0,1);
 }
@@ -61,7 +58,6 @@ OptionsWidget_dccGeneral::~OptionsWidget_dccGeneral()
 {
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 OptionsWidget_dccAdvanced::OptionsWidget_dccAdvanced(QWidget * parent)
 : KviOptionsWidget(parent)
@@ -69,25 +65,24 @@ OptionsWidget_dccAdvanced::OptionsWidget_dccAdvanced(QWidget * parent)
 	setObjectName("dccgeneral_options_widget");
 	createLayout();
 
+	KviBoolSelector * b;
+	KviBoolSelector * b2;
+
 	KviTalGroupBox * g = addGroupBox(0,0,0,0,Qt::Horizontal,__tr2qs_ctx("Network Properties","options"));
 
-	KviBoolSelector * b = addBoolSelector(g,__tr2qs_ctx("Use user-defined address or network interface","options"),KviOption_boolDccListenOnSpecifiedInterfaceByDefault);
-
-
+	b = addBoolSelector(g,__tr2qs_ctx("Use user-defined address or network interface","options"),KviOption_boolDccListenOnSpecifiedInterfaceByDefault);
 	mergeTip(b,__tr2qs_ctx("Enable this option if you are on a multihost machine and want " \
-		"to force one of the available IP addresses to be used for outgoing DCCs.<br>This is especially useful " \
-		"when you use IPv6 and IPv4 addresses.<br>You can force KVIrc to always choose the IPv4 interface.","options"));
+				"to force one of the available IP addresses to be used for outgoing DCCs.<br>This is especially useful " \
+				"when you use IPv6 and IPv4 addresses.<br>You can force KVIrc to always choose the IPv4 interface.","options"));
 
 	KviStringSelector * s = addStringSelector(g,__tr2qs_ctx("Listen on address/interface:","options"),KviOption_stringDccListenDefaultInterface,KVI_OPTION_BOOL(KviOption_boolDccListenOnSpecifiedInterfaceByDefault));
-
 	mergeTip(s,__tr2qs_ctx("This is the IP address or name of the interface to use by default for outgoing DCC transfers.<br>" \
-		"On UNIX systems that support it, you can also specify IPv4 interface names (such as <b>ppp0</b>).<br>" \
-		"If you set it to <b>0.0.0.0</b>, KVIrc will try to use the first available IPv4 interface","options"));
+				"On UNIX systems that support it, you can also specify IPv4 interface names (such as <b>ppp0</b>).<br>" \
+				"If you set it to <b>0.0.0.0</b>, KVIrc will try to use the first available IPv4 interface","options"));
 
 	connect(b,SIGNAL(toggled(bool)),s,SLOT(setEnabled(bool)));
 
  	b = addBoolSelector(g,__tr2qs_ctx("Use user-defined port range","options"),KviOption_boolUserDefinedPortRange);
-
 	mergeTip(b,__tr2qs_ctx("Enable this option if you want specify a local port range for DCC.","options"));
 
 	KviTalHBox * hb = new KviTalHBox(g);
@@ -99,23 +94,21 @@ OptionsWidget_dccAdvanced::OptionsWidget_dccAdvanced(QWidget * parent)
 	connect(b,SIGNAL(toggled(bool)),u,SLOT(setEnabled(bool)));
 
 	b = addBoolSelector(g,__tr2qs_ctx("Send a fixed address in requests","options"),KviOption_boolDccSendFakeAddressByDefault);
-
 	mergeTip(b,__tr2qs_ctx("Enable this option if you want to always send a fake IP address in your DCC requests.<br>" \
-		"This might be useful if you're behind a router with a static address that does network address translation (NAT) and forwards all or a range of ports.","options"));
+				"This might be useful if you're behind a router with a static address that does network address translation (NAT) and forwards all or a range of ports.","options"));
 
 	s = addStringSelector(g,__tr2qs_ctx("Send address/interface:","options"),KviOption_stringDefaultDccFakeAddress,KVI_OPTION_BOOL(KviOption_boolDccSendFakeAddressByDefault));
 	connect(b,SIGNAL(toggled(bool)),s,SLOT(setEnabled(bool)));
-
 	mergeTip(s,__tr2qs_ctx("This is the fixed address that will be sent with all DCC requests if you enable the option above.","options"));
 
-	KviBoolSelector * b2;
 	b2 = addBoolSelector(g,__tr2qs_ctx("Guess address from IRC server if unroutable","options"),KviOption_boolDccGuessIpFromServerWhenLocalIsUnroutable,!KVI_OPTION_BOOL(KviOption_boolDccSendFakeAddressByDefault));
+
 	connect(b,SIGNAL(toggled(bool)),b2,SLOT(setNotEnabled(bool)));
 
 	mergeTip(b2,__tr2qs_ctx("You can enable this option if you are behind a router that forwards all or a range of ports.<br>" \
-			"KVIrc will try to guess the IP address to use for DCC by looking up the local hostname as seen " \
-			"by the IRC server you're connected to.<br>This method is an exclusive alternative to the \"fixed address\" above.<br>" \
-			"It might guess the correct address automatically if certain conditions are met (e.g. the IRC server doesn't mask hostnames).","options"));
+				"KVIrc will try to guess the IP address to use for DCC by looking up the local hostname as seen " \
+				"by the IRC server you're connected to.<br>This method is an exclusive alternative to the \"fixed address\" above.<br>" \
+				"It might guess the correct address automatically if certain conditions are met (e.g. the IRC server doesn't mask hostnames).","options"));
 
 	b = addBoolSelector(g,__tr2qs_ctx("Use \"broken bouncer hack\" to detect address","options"),KviOption_boolDccBrokenBouncerHack,KVI_OPTION_BOOL(KviOption_boolDccGuessIpFromServerWhenLocalIsUnroutable));
 	mergeTip(b,__tr2qs_ctx("When you're behind a dialup router and also tunneling through a psyBNC bouncer, " \
@@ -126,20 +119,20 @@ OptionsWidget_dccAdvanced::OptionsWidget_dccAdvanced(QWidget * parent)
 
 	b = addBoolSelector(0,1,1,1,__tr2qs_ctx("Notify failed DCC handshakes to the remote end","options"),KviOption_boolNotifyFailedDccHandshakes);
 	mergeTip(b,__tr2qs_ctx("If you enable this option, when a DCC request from a remote " \
-					"user can't be satisfied KVIrc will notify him by a CTCP ERRMSG. This is " \
-					"a nice feature so it is a good idea to leave it on unless for some reason " \
-					"you have deactivated the anti-flood system: in this case turning off this option " \
-					"might help if you often get attacked by CTCP floods.","options"));
+				"user can't be satisfied KVIrc will notify him by a CTCP ERRMSG. This is " \
+				"a nice feature so it is a good idea to leave it on unless for some reason " \
+				"you have deactivated the anti-flood system: in this case turning off this option " \
+				"might help if you often get attacked by CTCP floods.","options"));
 
 	u = addUIntSelector(0,2,1,2,__tr2qs_ctx("Maximum number of DCC sessions:","options"),KviOption_uintMaxDccSlots,0,1000,64);
 	mergeTip(u,__tr2qs_ctx("This is the maximum number of concurrent DCC sessions " \
-					"and it includes all the DCC types (send, chat, recv...). " \
-					"KVIrc will refuse the requests when this limit is reached.","options"));
+				"and it includes all the DCC types (send, chat, recv...). " \
+				"KVIrc will refuse the requests when this limit is reached.","options"));
 
 	u = addUIntSelector(0,3,1,3,__tr2qs_ctx("DCC socket timeout:","options"),KviOption_uintDccSocketTimeout,10,65536,180);
 	u->setSuffix(__tr2qs_ctx(" sec","options"));
 	mergeTip(u,__tr2qs_ctx("This is the amount of time that KVIrc will wait for a response before assuming that a DCC has failed " \
-		"because the remote client was unable to connect to our listening socket.","options"));
+				"because the remote client was unable to connect to our listening socket.","options"));
 
 	addRowSpacer(0,4,1,4);
 }
@@ -147,9 +140,6 @@ OptionsWidget_dccAdvanced::OptionsWidget_dccAdvanced(QWidget * parent)
 OptionsWidget_dccAdvanced::~OptionsWidget_dccAdvanced()
 {
 }
-
-
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 
 OptionsWidget_dccSend::OptionsWidget_dccSend(QWidget * parent)
@@ -170,37 +160,40 @@ OptionsWidget_dccSendGeneral::OptionsWidget_dccSendGeneral(QWidget * parent)
 	createLayout();
 
 	KviBoolSelector * b;
+	KviBoolSelector * b2;
+	KviBoolSelector * b3;
+	KviBoolSelector * b4;
+	KviBoolSelector * b1;
 
 	KviTalGroupBox * g = addGroupBox(0,0,0,0,Qt::Horizontal,__tr2qs_ctx("On Incoming File","options"));
-	KviBoolSelector * b2 = addBoolSelector(g,__tr2qs_ctx("Automatically accept","options"),KviOption_boolAutoAcceptDccSend);
-	KviBoolSelector * b3 = addBoolSelector(g, __tr2qs_ctx("Open auto-accepted transfer window without focus","options"),KviOption_boolCreateMinimizedDccSendWhenAutoAccepted,!KVI_OPTION_BOOL(KviOption_boolCreateMinimizedDccSend));
-	mergeTip(b3, __tr2qs_ctx("This option prevents the transfer window " \
-			"from opening and diverting application focus.<br>" \
-			"Enable this if you don't like the transfer window " \
-			"popping up while you're typing something in a channel.","options"));
+	b2 = addBoolSelector(g,__tr2qs_ctx("Automatically accept","options"),KviOption_boolAutoAcceptDccSend);
+	b3 = addBoolSelector(g, __tr2qs_ctx("Open auto-accepted transfer window without focus","options"),KviOption_boolCreateMinimizedDccSendWhenAutoAccepted,!KVI_OPTION_BOOL(KviOption_boolCreateMinimizedDccSend));
+	mergeTip(b3,__tr2qs_ctx("This option prevents the transfer window " \
+				"from opening and diverting application focus.<br>" \
+				"Enable this if you don't like the transfer window " \
+				"popping up while you're typing something in a channel.","options"));
 
-	KviBoolSelector * b4 = addBoolSelector(g,__tr2qs_ctx("Automatically resume when auto-accepted","options"),KviOption_boolAutoResumeDccSendWhenAutoAccepted,KVI_OPTION_BOOL(KviOption_boolAutoAcceptDccSend));
+	b4 = addBoolSelector(g,__tr2qs_ctx("Automatically resume when auto-accepted","options"),KviOption_boolAutoResumeDccSendWhenAutoAccepted,KVI_OPTION_BOOL(KviOption_boolAutoAcceptDccSend));
 
 	g = addGroupBox(0,1,0,1,Qt::Horizontal,__tr2qs_ctx("Save Location","options"));
+
 	addDirectorySelector(g,__tr2qs_ctx("Download folder:","options"),KviOption_stringIncomingPath);
 	addBoolSelector(g,__tr2qs_ctx("Sort saved files by nicknames (create subfolders)","options"),KviOption_boolSortReceivedByDccFilesByNicks);
 	addBoolSelector(g,__tr2qs_ctx("Guess save path from media type","options"),KviOption_boolUseIncomingDccMediaTypeSavePath);
 
-
 	g = addGroupBox(0,2,0,2,Qt::Horizontal,__tr2qs_ctx("On Download Completion","options"));
+
 	addBoolSelector(g,__tr2qs_ctx("Notify completion in console","options"),KviOption_boolNotifyDccSendSuccessInConsole);
 	addBoolSelector(g,__tr2qs_ctx("Notify completion in notifier","options"),KviOption_boolNotifyDccSendSuccessInNotifier);
 	b = addBoolSelector(g,__tr2qs_ctx("Automatically clear transfer","options"),KviOption_boolAutoCloseDccSendOnSuccess);
-	mergeTip(b,
-		__tr2qs_ctx("This option will cause successfully terminated transfers " \
+	mergeTip(b,__tr2qs_ctx("This option will cause successfully terminated transfers " \
 				"to be automatically removed from the transfer window.","options"));
 
-
-	KviBoolSelector * b1 = addBoolSelector(0,3,0,3, __tr2qs_ctx("Open transfer window without focus","options"), KviOption_boolCreateMinimizedDccSend);
-	mergeTip(b1, __tr2qs_ctx("This option prevents the transfer window " \
-			"from opening and diverting application focus.<br>" \
-			"Enable this if you don't like the transfer window " \
-			"popping up while you're typing something in a channel.","options"));
+	b1 = addBoolSelector(0,3,0,3, __tr2qs_ctx("Open transfer window without focus","options"), KviOption_boolCreateMinimizedDccSend);
+	mergeTip(b1,__tr2qs_ctx("This option prevents the transfer window " \
+				"from opening and diverting application focus.<br>" \
+				"Enable this if you don't like the transfer window " \
+				"popping up while you're typing something in a channel.","options"));
 
 	connect(b1,SIGNAL(toggled(bool)),b3,SLOT(setNotEnabled(bool)));
 	connect(b2,SIGNAL(toggled(bool)),b4,SLOT(setEnabled(bool)));
@@ -219,35 +212,32 @@ OptionsWidget_dccSendAdvanced::OptionsWidget_dccSendAdvanced(QWidget * parent)
 	setObjectName("dccsend_advanced_options_widget");
 	createLayout();
 
+	KviBoolSelector * b;
+	
 	KviTalGroupBox * g = addGroupBox(0,0,0,0,Qt::Horizontal,__tr2qs_ctx("Bug Compatibility","options"));
-	KviBoolSelector * b = addBoolSelector(g,__tr2qs_ctx("Send ACK for byte 0","options"),KviOption_boolSendZeroAckInDccRecv);
-	mergeTip(b,
-		__tr2qs_ctx("This option causes KVIrc to send a zero-byte acknowledge to kick-start " \
+
+	b = addBoolSelector(g,__tr2qs_ctx("Send ACK for byte 0","options"),KviOption_boolSendZeroAckInDccRecv);
+	mergeTip(b,__tr2qs_ctx("This option causes KVIrc to send a zero-byte acknowledge to kick-start " \
 				"the DCC transfer with some buggy IRC clients.<br>" \
 				"Use it only if your DCC transfers stall just after establishing a connection without sending any data.","options"));
 
 	b = addBoolSelector(g,__tr2qs_ctx("Accept RESUME requests with broken filename (mIRC file.ext)","options"),KviOption_boolAcceptBrokenFileNameDccResumeRequests);
-	mergeTip(b,
-		__tr2qs_ctx("This option causes KVIrc to accept RESUME requests with invalid filenames.<br>" \
+	mergeTip(b,__tr2qs_ctx("This option causes KVIrc to accept RESUME requests with invalid filenames.<br>" \
 				"Use it if KVIrc fails to accept RESUME requests from other clients (e.g. some versions of mIRC).","options"));
 
-
 	b = addBoolSelector(g,__tr2qs_ctx("Accept RESUME requests with mismatched ports","options"),KviOption_boolAcceptMismatchedPortDccResumeRequests);
-	mergeTip(b,
-		__tr2qs_ctx("This option causes KVIrc to accept RESUME requests with mismatched ports.<br>" \
+	mergeTip(b,__tr2qs_ctx("This option causes KVIrc to accept RESUME requests with mismatched ports.<br>" \
 				"Use it if some router on the path between you and the receiver remaps the ports in DCC SEND " \
 				"but not in DCC RESUME requests.<br>Please note that this option may misbehave in certain usage " \
 				"patterns since KVIrc must differentiate between transfers only by looking at the filename. Be careful.","options"));
 
 	b = addBoolSelector(g,__tr2qs_ctx("Replace spaces with underscores in outgoing filenames","options"),KviOption_boolDCCFileTransferReplaceOutgoingSpacesWithUnderscores);
-	mergeTip(b,
-		__tr2qs_ctx("This option causes KVIrc to replace spaces with underscores in filenames " \
+	mergeTip(b,__tr2qs_ctx("This option causes KVIrc to replace spaces with underscores in filenames " \
 				"for all the outgoing file transfers. This will fix filename handling with some buggy clients (e.g. some versions of mIRC).","options"));
 
-       b = addBoolSelector(g,__tr2qs_ctx("Send 64-bit ACKs for files larger than 4GiB","options"),KviOption_boolSend64BitAckInDccRecv);
-       mergeTip(b,
-               __tr2qs_ctx("This option causes KVIrc to send ACKs as 64-bit integers instead of 32-bit integers<br>" \
-                               "Use this to fix DCC RECEIVE transfers where the other client is using the mIRC ACK standard.","options"));
+	b = addBoolSelector(g,__tr2qs_ctx("Send 64-bit ACKs for files larger than 4GiB","options"),KviOption_boolSend64BitAckInDccRecv);
+	mergeTip(b,__tr2qs_ctx("This option causes KVIrc to send ACKs as 64-bit integers instead of 32-bit integers<br>" \
+				"Use this to fix DCC RECEIVE transfers where the other client is using the mIRC ACK standard.","options"));
 
 	g = addGroupBox(0,1,0,1,Qt::Horizontal,__tr2qs_ctx("Limits","options"));
 
@@ -255,32 +245,31 @@ OptionsWidget_dccSendAdvanced::OptionsWidget_dccSendAdvanced(QWidget * parent)
 	b = addBoolSelector(hb,__tr2qs_ctx("Limit upload bandwidth to:","options"),KviOption_boolLimitDccSendSpeed);
 	KviUIntSelector * u = addUIntSelector(hb,"",KviOption_uintMaxDccSendSpeed,0,0xffffff1,1024,KVI_OPTION_BOOL(KviOption_boolLimitDccSendSpeed));
 	u->setSuffix(" " + __tr2qs_ctx("bytes/sec","options"));
+
 	connect(b,SIGNAL(toggled(bool)),u,SLOT(setEnabled(bool)));
 
 	hb = new KviTalHBox(g);
 	b = addBoolSelector(hb,__tr2qs_ctx("Limit download bandwidth to:","options"),KviOption_boolLimitDccRecvSpeed);
 	u = addUIntSelector(hb,"",KviOption_uintMaxDccRecvSpeed,0,0xffffff1,1024,KVI_OPTION_BOOL(KviOption_boolLimitDccRecvSpeed));
 	u->setSuffix(" " + __tr2qs_ctx("bytes/sec","options"));
-	connect(b,SIGNAL(toggled(bool)),u,SLOT(setEnabled(bool)));
 
+	connect(b,SIGNAL(toggled(bool)),u,SLOT(setEnabled(bool)));
 
 	u = addUIntSelector(g,__tr2qs_ctx("Maximum number of DCC transfers:","options"),KviOption_uintMaxDccSendTransfers,0,1000,10);
 	mergeTip(u,__tr2qs_ctx("This is the maximum number of concurrent DCC transfers. " \
-					"KVIrc will refuse the requests when this limit is reached.","options"));
+				"KVIrc will refuse the requests when this limit is reached.","options"));
 
 	g = addGroupBox(0,2,0,2,Qt::Horizontal,__tr2qs_ctx("Tweaks","options"));
 
 	b = addBoolSelector(g,__tr2qs_ctx("Use fast send (send ahead)","options"),KviOption_boolUseFastDccSend);
-	mergeTip(b,
-		__tr2qs_ctx("The \"send ahead\" DCC method allows data to be sent faster by breaking " \
+	mergeTip(b,__tr2qs_ctx("The \"send ahead\" DCC method allows data to be sent faster by breaking " \
 				"some of the rules of the original DCC SEND protocol specification.<br>" \
 				"Most clients can handle this kind of optimisation so disable it only if you have problems.","options"));
 
 	hb = new KviTalHBox(g);
 
 	b = addBoolSelector(hb,__tr2qs_ctx("Force idle step:","options"),KviOption_boolDccSendForceIdleStep);
-	mergeTip(b,
-		__tr2qs_ctx("Enable this option when the DCC file transfers " \
+	mergeTip(b,__tr2qs_ctx("Enable this option when the DCC file transfers " \
 				"tend to block your computer by consuming too much CPU time. " \
 				"When this option is enabled the idle interval below will be " \
 				"forcibly inserted between each sent/received data packet.","options"));
@@ -289,16 +278,14 @@ OptionsWidget_dccSendAdvanced::OptionsWidget_dccSendAdvanced(QWidget * parent)
 	connect(b,SIGNAL(toggled(bool)),u,SLOT(setEnabled(bool)));
 	u->setSuffix(__tr2qs_ctx(" msec","options"));
 
-	mergeTip(u,
-		__tr2qs_ctx("This parameter controls the average delay between two packets sent or received.<br>" \
+	mergeTip(u,__tr2qs_ctx("This parameter controls the average delay between two packets sent or received.<br>" \
 				"A smaller interval will cause you to send data faster but will also " \
 				"add load to your CPU, disk and network interface.<br>" \
 				"Reasonable values are from 5 to 50 milliseconds.","options"));
 
 	u = addUIntSelector(g,__tr2qs_ctx("Packet size:","options"),KviOption_uintDccSendPacketSize,16,65536,1024);
 	u->setSuffix(__tr2qs_ctx(" bytes","options"));
-	mergeTip(u,
-		__tr2qs_ctx("This parameter controls the packet size used for DCC SEND.<br>" \
+	mergeTip(u,__tr2qs_ctx("This parameter controls the packet size used for DCC SEND.<br>" \
 				"With bigger packets you will be probably send data faster, but " \
 				"you will also saturate your bandwidth and in some cases " \
 				"cause more disk activity.<br>" \
@@ -312,29 +299,26 @@ OptionsWidget_dccSendAdvanced::~OptionsWidget_dccSendAdvanced()
 }
 
 
-//OptionsWidget_dccSend::enableStuff(bool)
-//{
-//	m_pOpenMinimizedAutoAccept->setEnabled(m_pAutoAccept->isChecked() && !m_pOpenMinimized->isChecked());
-//}
-
-
 OptionsWidget_dccChat::OptionsWidget_dccChat(QWidget * parent)
 : KviOptionsWidget(parent)
 {
 	setObjectName("dccchat_options_widget");
 	createLayout();
 
+	KviBoolSelector * b1;
+	KviBoolSelector * b2;
+
 	KviTalGroupBox * g = addGroupBox(0,0,0,0,Qt::Horizontal,__tr2qs_ctx("On Chat Request","options"));
 	addBoolSelector(g,__tr2qs_ctx("Automatically accept","options"),KviOption_boolAutoAcceptDccChat);
 
-	KviBoolSelector * b1 = addBoolSelector(g, __tr2qs_ctx("Open auto-accepted DCC chat windows without focus","options"),KviOption_boolCreateMinimizedDccChatWhenAutoAccepted,!KVI_OPTION_BOOL(KviOption_boolCreateMinimizedDccChat));
-	mergeTip(b1, __tr2qs_ctx("This option prevents incoming " \
+	b1 = addBoolSelector(g, __tr2qs_ctx("Open auto-accepted DCC chat windows without focus","options"),KviOption_boolCreateMinimizedDccChatWhenAutoAccepted,!KVI_OPTION_BOOL(KviOption_boolCreateMinimizedDccChat));
+	mergeTip(b1,__tr2qs_ctx("This option prevents incoming " \
 				"auto-accepted DCC chat windows from diverting application focus.<br>" \
 				"Enable this if you don't like DCC chat windows " \
 				"popping up while you're typing something in a channel.","options"));
 
-	KviBoolSelector * b2 = addBoolSelector(0,1,0,1, __tr2qs_ctx("Open DCC chat windows without focus","options"),KviOption_boolCreateMinimizedDccChat);
-	mergeTip(b2, __tr2qs_ctx("This option prevents incoming " \
+	b2 = addBoolSelector(0,1,0,1, __tr2qs_ctx("Open DCC chat windows without focus","options"),KviOption_boolCreateMinimizedDccChat);
+	mergeTip(b2,__tr2qs_ctx("This option prevents incoming " \
 				"DCC chat windows from diverting application focus.<br>" \
 				"Enable this if you don't like DCC chat windows " \
 				"popping up while you're typing something in a channel.","options"));
@@ -343,16 +327,13 @@ OptionsWidget_dccChat::OptionsWidget_dccChat(QWidget * parent)
 
 #if (defined(COMPILE_ON_WINDOWS) || defined(COMPILE_KDE_SUPPORT) || defined(COMPILE_ON_MINGW))
 	b2 = addBoolSelector(0,2,0,2,__tr2qs_ctx("Flash system taskbar on new DCC chat message","options"),KviOption_boolFlashDccChatWindowOnNewMessages);
-		mergeTip(b2,
-			__tr2qs_ctx("This option causes the system taskbar entry for KVIrc to flash when a new DCC chat message " \
+	mergeTip(b2,__tr2qs_ctx("This option causes the system taskbar entry for KVIrc to flash when a new DCC chat message " \
 				"is received and the KVIrc window is not the active.","options"));
 #endif
-
 	b2 = addBoolSelector(0,3,0,3, __tr2qs_ctx("Popup notifier on new DCC chat message","options"),KviOption_boolPopupNotifierOnNewDccChatMessages);
-	mergeTip(b2,
-		__tr2qs_ctx("This option causes a small notifier window to pop up " \
-			"in the low right corner of the screen when a new message is received " \
-			"and the KVIrc window is not active.","options"));
+	mergeTip(b2,__tr2qs_ctx("This option causes a small notifier window to pop up " \
+				"in the low right corner of the screen when a new message is received " \
+				"and the KVIrc window is not active.","options"));
 
 	addRowSpacer(0,4,0,4);
 }
@@ -365,18 +346,21 @@ OptionsWidget_dccChat::~OptionsWidget_dccChat()
 OptionsWidget_dccVoice::OptionsWidget_dccVoice(QWidget *p):KviOptionsWidget(p)
 {
 	createLayout();
+	
+	KviBoolSelector * b1;
+	KviBoolSelector * b;
 
-	KviBoolSelector * b1 = addBoolSelector(0,0,0,0, __tr2qs_ctx("Open all DCC voice windows without focus","options"),KviOption_boolCreateMinimizedDccVoice);
-	mergeTip(b1, __tr2qs_ctx("This option prevents all incoming " \
+	b1 = addBoolSelector(0,0,0,0, __tr2qs_ctx("Open all DCC voice windows without focus","options"),KviOption_boolCreateMinimizedDccVoice);
+	mergeTip(b1,__tr2qs_ctx("This option prevents all incoming " \
 				"DCC voice windows from diverting application focus.<br>" \
 				"Enable this if you don't like DCC voice windows " \
 				"popping up while you're typing something in a channel.","options"));
 
 	KviTalGroupBox * g = addGroupBox(0,1,0,1,Qt::Horizontal,__tr2qs_ctx("On Voice Request","options"));
-	KviBoolSelector * b = addBoolSelector(g,__tr2qs_ctx("Automatically accept","options"),KviOption_boolAutoAcceptDccVoice);
+	b = addBoolSelector(g,__tr2qs_ctx("Automatically accept","options"),KviOption_boolAutoAcceptDccVoice);
 
 	b = addBoolSelector(g, __tr2qs_ctx("Open auto-accepted DCC voice windows without focus","options"),KviOption_boolCreateMinimizedDccVoiceWhenAutoAccepted,!KVI_OPTION_BOOL(KviOption_boolCreateMinimizedDccVoice));
-	mergeTip(b, __tr2qs_ctx("This option prevents incoming " \
+	mergeTip(b,__tr2qs_ctx("This option prevents incoming " \
 				"auto-accepted DCC voice windows from diverting application focus.<br>" \
 				"Enable this if you don't like DCC voice windows " \
 				"popping up while you're typing something in a channel.","options"));

--- a/src/modules/options/OptionsWidget_dcc.h
+++ b/src/modules/options/OptionsWidget_dcc.h
@@ -40,8 +40,6 @@ public:
 	~OptionsWidget_dcc();
 };
 
-
-
 #define KVI_OPTIONS_WIDGET_ICON_OptionsWidget_dccGeneral KviIconManager::Dcc
 #define KVI_OPTIONS_WIDGET_NAME_OptionsWidget_dccGeneral __tr2qs_no_lookup("General")
 #define KVI_OPTIONS_WIDGET_PRIORITY_OptionsWidget_dccGeneral 70000
@@ -68,14 +66,10 @@ public:
 	~OptionsWidget_dccAdvanced();
 };
 
-
-
-
 #define KVI_OPTIONS_WIDGET_ICON_OptionsWidget_dccSend KviIconManager::FileTransfer
 #define KVI_OPTIONS_WIDGET_NAME_OptionsWidget_dccSend __tr2qs_no_lookup("File Transfer")
 #define KVI_OPTIONS_WIDGET_PARENT_OptionsWidget_dccSend OptionsWidget_dcc
 #define KVI_OPTIONS_WIDGET_CONTAINER_OptionsWidget_dccSend true
-
 
 class OptionsWidget_dccSend : public KviOptionsWidget
 {
@@ -89,7 +83,6 @@ public:
 #define KVI_OPTIONS_WIDGET_NAME_OptionsWidget_dccSendGeneral __tr2qs_no_lookup("General")
 #define KVI_OPTIONS_WIDGET_PARENT_OptionsWidget_dccSendGeneral OptionsWidget_dccSend
 
-
 class OptionsWidget_dccSendGeneral : public KviOptionsWidget
 {
 	Q_OBJECT
@@ -97,7 +90,6 @@ public:
 	OptionsWidget_dccSendGeneral(QWidget * parent);
 	~OptionsWidget_dccSendGeneral();
 };
-
 
 #define KVI_OPTIONS_WIDGET_ICON_OptionsWidget_dccSendAdvanced KviIconManager::Gui
 #define KVI_OPTIONS_WIDGET_NAME_OptionsWidget_dccSendAdvanced __tr2qs_no_lookup("Advanced")
@@ -110,7 +102,6 @@ public:
 	OptionsWidget_dccSendAdvanced(QWidget * parent);
 	~OptionsWidget_dccSendAdvanced();
 };
-
 
 #define KVI_OPTIONS_WIDGET_ICON_OptionsWidget_dccChat KviIconManager::Dcc
 #define KVI_OPTIONS_WIDGET_NAME_OptionsWidget_dccChat __tr2qs_no_lookup("Chat")
@@ -137,6 +128,5 @@ public:
 	OptionsWidget_dccVoice(QWidget *);
 	~OptionsWidget_dccVoice();
 };
-
 
 #endif //_OPTW_DCC_H_

--- a/src/modules/options/OptionsWidget_interfaceFeatures.cpp
+++ b/src/modules/options/OptionsWidget_interfaceFeatures.cpp
@@ -52,17 +52,16 @@ OptionsWidget_interfaceFeatures::OptionsWidget_interfaceFeatures(QWidget * paren
 #else
 	addBoolSelector(0,5,0,5,__tr2qs_ctx("Require Ctrl to be held down to copy text","options"),KviOption_boolRequireControlToCopy);
 #endif
-
 	KviTalGroupBox * g = addGroupBox(0,6,0,6,Qt::Horizontal,__tr2qs_ctx("Open Dialog Window for","options"));
 	addBoolSelector(g,__tr2qs_ctx("Preferences","options"),KviOption_boolShowGeneralOptionsDialogAsToplevel);
 	addBoolSelector(g,__tr2qs_ctx("Registered users","options"),KviOption_boolShowRegisteredUsersDialogAsToplevel);
 	addBoolSelector(g,__tr2qs_ctx("Identity","options"),KviOption_boolShowIdentityDialogAsToplevel);
 	addBoolSelector(g,__tr2qs_ctx("Servers","options"),KviOption_boolShowServersConnectDialogAsToplevel);
 	addBoolSelector(g,__tr2qs_ctx("Join channels","options"),KviOption_boolShowChannelsJoinDialogAsToplevel);
+
 	addRowSpacer(0,7,0,7);
 }
 
 OptionsWidget_interfaceFeatures::~OptionsWidget_interfaceFeatures()
 {
 }
-

--- a/src/modules/options/OptionsWidget_interfaceFeatures.cpp
+++ b/src/modules/options/OptionsWidget_interfaceFeatures.cpp
@@ -41,7 +41,7 @@ OptionsWidget_interfaceFeatures::OptionsWidget_interfaceFeatures(QWidget * paren
 	setObjectName("interfacefeatures_options_widget");
 	createLayout();
 
-	addBoolSelector(0,0,0,0,__tr2qs_ctx("Minimize on startup","options"),KviOption_boolStartupMinimized);
+	addBoolSelector(0,0,0,0,__tr2qs_ctx("Minimize application on startup","options"),KviOption_boolStartupMinimized);
 	addBoolSelector(0,1,0,1,__tr2qs_ctx("Confirm quit with active connections","options"),KviOption_boolConfirmCloseWhenThereAreConnections);
 	addBoolSelector(0,2,0,2,__tr2qs_ctx("Remember window properties","options"),KviOption_boolWindowsRememberProperties);
 

--- a/src/modules/options/OptionsWidget_query.cpp
+++ b/src/modules/options/OptionsWidget_query.cpp
@@ -36,61 +36,53 @@ OptionsWidget_query::OptionsWidget_query(QWidget * parent)
 : KviOptionsWidget(parent)
 {
 	setObjectName("query_options_widget");
-
 	createLayout();
 
+	KviBoolSelector * b;
+
 	KviTalGroupBox * g = addGroupBox(0,0,1,0,Qt::Horizontal,__tr2qs_ctx("Open Query for","options"));
-	KviBoolSelector * b  = addBoolSelector(g, __tr2qs_ctx("Private messages","options"),KviOption_boolCreateQueryOnPrivmsg);
-	mergeTip(b,
-		__tr2qs_ctx("This option enables query window creation " \
-			"when a private message (PRIVMSG) is received.<br>" \
-			"If you disable this, private messages will " \
-			"be shown in the active window or a common channel.","options"));
+	b  = addBoolSelector(g, __tr2qs_ctx("Private messages","options"),KviOption_boolCreateQueryOnPrivmsg);
+	mergeTip(b,__tr2qs_ctx("This option enables query window creation " \
+				"when a private message (PRIVMSG) is received.<br>" \
+				"If you disable this, private messages will " \
+				"be shown in the active window or a common channel.","options"));
 
-	b = addBoolSelector(g, __tr2qs_ctx("Private notices","options"),KviOption_boolCreateQueryOnNotice);
-	mergeTip(b,
-		__tr2qs_ctx("This option enables query window creation " \
-			"when a private notice (NOTICE) is received.<br>" \
-			"If you disable this, private notices will " \
-			"be shown in the active window or a common channel.","options"));
-
+	b = addBoolSelector(g,__tr2qs_ctx("Private notices","options"),KviOption_boolCreateQueryOnNotice);
+	mergeTip(b,__tr2qs_ctx("This option enables query window creation " \
+				"when a private notice (NOTICE) is received.<br>" \
+				"If you disable this, private notices will " \
+				"be shown in the active window or a common channel.","options"));
 
 	b = addBoolSelector(0,1,1,1,__tr2qs_ctx("Open incoming query windows without focus","options"),KviOption_boolCreateIncomingQueriesAsMinimized);
-	mergeTip(b, __tr2qs_ctx("This option prevents incoming " \
-			"query windows from diverting application focus.<br>" \
-			"Enable this if you don't like queries " \
-			"popping up while you're typing something in a channel.","options"));
-
+	mergeTip(b,__tr2qs_ctx("This option prevents incoming " \
+				"query windows from diverting application focus.<br>" \
+				"Enable this if you don't like queries " \
+				"popping up while you're typing something in a channel.","options"));
 
 	b = addBoolSelector(0,2,1,2, __tr2qs_ctx("Enable target user tracking","options"),KviOption_boolEnableQueryTracing);
-	mergeTip(b,
-		__tr2qs_ctx("This option will enable target user tracking.<br>" \
-			"Some actions of the target user (e.g. joins and parts) " \
-			"will be displayed in the window.","options"));
+	mergeTip(b,__tr2qs_ctx("This option will enable target user tracking.<br>" \
+				"Some actions of the target user (e.g. joins and parts) " \
+				"will be displayed in the window.","options"));
 
 #if (defined(COMPILE_ON_WINDOWS) || defined(COMPILE_KDE_SUPPORT) || defined(COMPILE_ON_MINGW))
 	b = addBoolSelector(0,3,1,3,__tr2qs_ctx("Flash system taskbar on new query message","options"),KviOption_boolFlashQueryWindowOnNewMessages);
-		mergeTip(b,
-			__tr2qs_ctx("This option causes the system taskbar entry for KVIrc to flash when a new query message " \
+	mergeTip(b,__tr2qs_ctx("This option causes the system taskbar entry for KVIrc to flash when a new query message " \
 				"is received and the KVIrc window is not the active.","options"));
 #endif
-
 	b = addBoolSelector(0,4,1,4, __tr2qs_ctx("Popup notifier on new query message","options"),KviOption_boolPopupNotifierOnNewQueryMessages);
-	mergeTip(b,
-		__tr2qs_ctx("This option causes a small notifier window to pop up " \
-			"in the lower right corner of the screen when a new message is received " \
-			"and the KVIrc window is not active.","options"));
+	mergeTip(b,__tr2qs_ctx("This option causes a small notifier window to pop up " \
+				"in the lower right corner of the screen when a new message is received " \
+				"and the KVIrc window is not active.","options"));
+
 	b = addBoolSelector(0,5,1,5, __tr2qs_ctx("Popup notifier on new notice","options"),KviOption_boolPopupNotifierOnNewNotices);
-	mergeTip(b,
-		__tr2qs_ctx("This option causes a small notifier window to pop up " \
-			"in the lower right corner of the screen when a new notice is received " \
-			"and the KVIrc window is not active.","options"));
+	mergeTip(b,__tr2qs_ctx("This option causes a small notifier window to pop up " \
+				"in the lower right corner of the screen when a new notice is received " \
+				"and the KVIrc window is not active.","options"));
+
 	b = addBoolSelector(0,6,1,6, __tr2qs_ctx("Show information about query target at the top of the query","options"),KviOption_boolShowExtendedInfoInQueryLabel);
-	mergeTip(b,
-		__tr2qs_ctx("This option enables query window information " \
-			"label. It can show you known information about query target at the top of the window.<br>" \
-			"Uncheck if you think,that it wastes your query space" \
-			"","options"));
+	mergeTip(b,__tr2qs_ctx("This option enables query window information " \
+				"label. It can show you known information about query target at the top of the window.<br>" \
+				"Uncheck if you think,that it wastes your query space","options"));
 
 	b = addBoolSelector(0,7,1,7,__tr2qs_ctx("Paste last query log","options"),KviOption_boolPasteLastLogOnQueryJoin);
 
@@ -100,10 +92,13 @@ OptionsWidget_query::OptionsWidget_query(QWidget * parent)
 	KviUIntSelector * u = addUIntSelector(box,__tr2qs_ctx("Paste up to:","options"),KviOption_uintLinesToPasteOnQueryJoin,0,50,10,KVI_OPTION_BOOL(KviOption_boolPasteLastLogOnQueryJoin));
 	u->setSuffix(__tr2qs_ctx(" lines","options"));
 	mergeTip(u,__tr2qs_ctx("Minimum value: <b>0 lines</b><br>Maximum value: <b>50 lines</b>","options"));
+
 	connect(b,SIGNAL(toggled(bool)),u,SLOT(setEnabled(bool)));
+
 	u = addUIntSelector(box,__tr2qs_ctx("Interval:","options"),KviOption_uintDaysIntervalToPasteOnQueryJoin,1,10,10,KVI_OPTION_BOOL(KviOption_boolPasteLastLogOnQueryJoin));
 	u->setSuffix(__tr2qs_ctx(" days","options"));
 	mergeTip(u,__tr2qs_ctx("Minimum value: <b>0 days</b><br>Maximum value: <b>10 days</b>","options"));
+
 	connect(b,SIGNAL(toggled(bool)),u,SLOT(setEnabled(bool)));
 
 	addRowSpacer(0,9,1,9);

--- a/src/modules/options/OptionsWidget_query.cpp
+++ b/src/modules/options/OptionsWidget_query.cpp
@@ -55,13 +55,11 @@ OptionsWidget_query::OptionsWidget_query(QWidget * parent)
 			"be shown in the active window or a common channel.","options"));
 
 
-	b = addBoolSelector(0,1,1,1,__tr2qs_ctx("Open incoming queries as minimized","options"),KviOption_boolCreateIncomingQueriesAsMinimized);
-
-	mergeTip(b,
-		__tr2qs_ctx("This option causes newly created " \
-			"query windows to be immediately minimized.<br>" \
+	b = addBoolSelector(0,1,1,1,__tr2qs_ctx("Open incoming query windows without focus","options"),KviOption_boolCreateIncomingQueriesAsMinimized);
+	mergeTip(b, __tr2qs_ctx("This option prevents incoming " \
+			"query windows from diverting application focus.<br>" \
 			"Enable this if you don't like queries " \
-			"popping up while you're typing something in a channel. :D","options"));
+			"popping up while you're typing something in a channel.","options"));
 
 
 	b = addBoolSelector(0,2,1,2, __tr2qs_ctx("Enable target user tracking","options"),KviOption_boolEnableQueryTracing);

--- a/src/modules/options/OptionsWidget_uparser.cpp
+++ b/src/modules/options/OptionsWidget_uparser.cpp
@@ -37,6 +37,7 @@ OptionsWidget_uparser::OptionsWidget_uparser(QWidget * parent)
 	createLayout();
 
 	KviBoolSelector * b;
+	KviBoolSelector * b1;
 
 	addBoolSelector(0,0,0,0,__tr2qs_ctx("Disable parser warnings","options"),KviOption_boolAvoidParserWarnings);
 	addBoolSelector(0,1,0,1,__tr2qs_ctx("Disable broken event handlers","options"),KviOption_boolDisableBrokenEventHandlers);
@@ -51,14 +52,17 @@ OptionsWidget_uparser::OptionsWidget_uparser(QWidget * parent)
 	addSeparator(0,7,0,7);
 
 	b = addBoolSelector(0,8,0,8,__tr2qs_ctx("Relay errors and warnings to debug window","options"),KviOption_boolScriptErrorsToDebugWindow);
-	mergeTip(b,
-		__tr2qs_ctx("This option will show the script errors and warnings " \
+	mergeTip(b, __tr2qs_ctx("This option will show the script errors and warnings " \
 			"also in the special debug window. This makes tracking of scripts that might " \
 			"be running in several windows far easier. The messages in the debug window " \
 			"also contain a deeper call stack which will help you identifying the " \
-			"scripting problems.","options")
-		);
-	addBoolSelector(0,9,0,9,__tr2qs_ctx("Create minimized debug window","options"),KviOption_boolShowMinimizedDebugWindow);
+			"scripting problems.","options"));
+	
+	b1 = addBoolSelector(0,9,0,9, __tr2qs_ctx("Create debug window without focus","options"),KviOption_boolShowMinimizedDebugWindow);
+	mergeTip(b1, __tr2qs_ctx("This option prevents the debug window " \
+			"from opening and diverting application focus.<br>" \
+			"Enable this if you don't like the debug window " \
+			"popping up while you're typing something in a channel.","options"));
 
 	addRowSpacer(0,10,0,10);
 }

--- a/src/modules/options/OptionsWidget_uparser.cpp
+++ b/src/modules/options/OptionsWidget_uparser.cpp
@@ -53,16 +53,16 @@ OptionsWidget_uparser::OptionsWidget_uparser(QWidget * parent)
 
 	b = addBoolSelector(0,8,0,8,__tr2qs_ctx("Relay errors and warnings to debug window","options"),KviOption_boolScriptErrorsToDebugWindow);
 	mergeTip(b, __tr2qs_ctx("This option will show the script errors and warnings " \
-			"also in the special debug window. This makes tracking of scripts that might " \
-			"be running in several windows far easier. The messages in the debug window " \
-			"also contain a deeper call stack which will help you identifying the " \
-			"scripting problems.","options"));
+				"also in the special debug window. This makes tracking of scripts that might " \
+				"be running in several windows far easier. The messages in the debug window " \
+				"also contain a deeper call stack which will help you identifying the " \
+				"scripting problems.","options"));
 	
-	b1 = addBoolSelector(0,9,0,9, __tr2qs_ctx("Create debug window without focus","options"),KviOption_boolShowMinimizedDebugWindow);
+	b1 = addBoolSelector(0,9,0,9,__tr2qs_ctx("Create debug window without focus","options"),KviOption_boolShowMinimizedDebugWindow);
 	mergeTip(b1, __tr2qs_ctx("This option prevents the debug window " \
-			"from opening and diverting application focus.<br>" \
-			"Enable this if you don't like the debug window " \
-			"popping up while you're typing something in a channel.","options"));
+				"from opening and diverting application focus.<br>" \
+				"Enable this if you don't like the debug window " \
+				"popping up while you're typing something in a channel.","options"));
 
 	addRowSpacer(0,10,0,10);
 }


### PR DESCRIPTION
Since removal of MDI opening something minimized behaviour has either been lost or behaviour changed, in this case its somewhat changed but these options naming has been slightly misleading were it not for some tooltips.

If you have better suggestion to preferably shorter label names while keeping in mind actual functionality and minimizing translating confusion by being too vague on string please, ideas very welcome.
#### Changes proposed
- Rename labels _something_ minimized to _something_ with no focus 
- Add tooltips where none existed and reword existing ones to reflect and clarify what these actually do.
#### TODO when this part is done
- ~~Cleanup files they are 100% a mess will add PR cleaning up after this is done to save me any rebasing/conflicts.~~
- ~~Theres more options that I havent renamed or tested to see if they are to be removed or improved instead.~~
