### PR TITLE
OptionsWidget_notify: refactor and make in seconds a spinbox suffix 

### DIFF
--- a/src/modules/options/OptionsWidget_notify.cpp
+++ b/src/modules/options/OptionsWidget_notify.cpp
@@ -38,33 +38,45 @@ OptionsWidget_notify::OptionsWidget_notify(QWidget * parent)
 
 	KviBoolSelector * b;
 	KviTalGroupBox * g;
+	KviUIntSelector * u;
 
 	b = addBoolSelector(0,0,0,0,__tr2qs_ctx("Use online notify list","options"),KviOption_boolUseNotifyList);
 
 	g = addGroupBox(0,1,0,1,Qt::Horizontal,__tr2qs_ctx("Configuration","options"));
 	connect(b,SIGNAL(toggled(bool)),g,SLOT(setEnabled(bool)));
-	connect(b,SIGNAL(toggled(bool)),addBoolSelector(g,__tr2qs_ctx("Show notifications in active window","options"),KviOption_boolNotifyListChangesToActiveWindow,
-		KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),SLOT(setEnabled(bool)));
-	connect(b,SIGNAL(toggled(bool)),addBoolSelector(g,__tr2qs_ctx("Flash window when users are going online","options"),KviOption_boolFlashWindowOnNotifyOnLine,
-		KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),SLOT(setEnabled(bool)));
-	connect(b,SIGNAL(toggled(bool)),addBoolSelector(g,__tr2qs_ctx("Popup notifier when users are going online","options"),KviOption_boolPopupNotifierOnNotifyOnLine,
-		KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),SLOT(setEnabled(bool)));
+
+	b = addBoolSelector(g,__tr2qs_ctx("Show notifications in active window","options"),KviOption_boolNotifyListChangesToActiveWindow,KVI_OPTION_BOOL(KviOption_boolUseNotifyList));
+	connect(g,SIGNAL(toggled(bool)),b,SLOT(setEnabled(bool)));
+
+	b = addBoolSelector(g,__tr2qs_ctx("Flash window when users are going online","options"),KviOption_boolFlashWindowOnNotifyOnLine,KVI_OPTION_BOOL(KviOption_boolUseNotifyList));
+	connect(g,SIGNAL(toggled(bool)),b,SLOT(setEnabled(bool)));
+
+	b = addBoolSelector(g,__tr2qs_ctx("Popup notifier when users are going online","options"),KviOption_boolPopupNotifierOnNotifyOnLine,KVI_OPTION_BOOL(KviOption_boolUseNotifyList));
+	connect(g,SIGNAL(toggled(bool)),b,SLOT(setEnabled(bool)));
 
 	g = addGroupBox(0,2,0,2,Qt::Horizontal,__tr2qs_ctx("Advanced Configuration","options"));
 	connect(b,SIGNAL(toggled(bool)),g,SLOT(setEnabled(bool)));
 
-	connect(b,SIGNAL(toggled(bool)),addBoolSelector(g,__tr2qs_ctx("Check USERHOST for online users","options"),KviOption_boolNotifyListSendUserhostForOnlineUsers,
-		KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),SLOT(setEnabled(bool)));
-	connect(b,SIGNAL(toggled(bool)),addBoolSelector(g,__tr2qs_ctx("Use \"smart\" notify list manager","options"),KviOption_boolUseIntelligentNotifyListManager,
-		KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),SLOT(setEnabled(bool)));
-	connect(b,SIGNAL(toggled(bool)),addBoolSelector(g,__tr2qs_ctx("Use the WATCH method if available","options"),KviOption_boolUseWatchListIfAvailable,
-		KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),SLOT(setEnabled(bool)));
-	connect(b,SIGNAL(toggled(bool)),addUIntSelector(g,__tr2qs_ctx("Check interval (in seconds):","options"),KviOption_uintNotifyListCheckTimeInSecs,5,3600,180,
-		KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),SLOT(setEnabled(bool)));
-	connect(b,SIGNAL(toggled(bool)),addUIntSelector(g,__tr2qs_ctx("ISON delay (in seconds):","options"),KviOption_uintNotifyListIsOnDelayTimeInSecs,5,180,6,
-		KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),SLOT(setEnabled(bool)));
-	connect(b,SIGNAL(toggled(bool)),addUIntSelector(g,__tr2qs_ctx("USERHOST delay (in seconds):","options"),KviOption_uintNotifyListUserhostDelayTimeInSecs,5,180,6,
-		KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),SLOT(setEnabled(bool)));
+	b = addBoolSelector(g,__tr2qs_ctx("Check USERHOST for online users","options"),KviOption_boolNotifyListSendUserhostForOnlineUsers,KVI_OPTION_BOOL(KviOption_boolUseNotifyList));
+	connect(g,SIGNAL(toggled(bool)),b,SLOT(setEnabled(bool)));
+
+	b = addBoolSelector(g,__tr2qs_ctx("Use \"smart\" notify list manager","options"),KviOption_boolUseIntelligentNotifyListManager,KVI_OPTION_BOOL(KviOption_boolUseNotifyList));
+	connect(g,SIGNAL(toggled(bool)),b,SLOT(setEnabled(bool)));
+
+	b = addBoolSelector(g,__tr2qs_ctx("Use the WATCH method if available","options"),KviOption_boolUseWatchListIfAvailable,KVI_OPTION_BOOL(KviOption_boolUseNotifyList));
+	connect(g,SIGNAL(toggled(bool)),b,SLOT(setEnabled(bool)));
+
+	u = addUIntSelector(g,__tr2qs_ctx("Check interval:","options"),KviOption_uintNotifyListCheckTimeInSecs,5,3600,180,KVI_OPTION_BOOL(KviOption_boolUseNotifyList));
+	u->setSuffix(__tr2qs_ctx(" sec","options"));
+	connect(g,SIGNAL(toggled(bool)),u,SLOT(setEnabled(bool)));
+
+	u = addUIntSelector(g,__tr2qs_ctx("ISON delay:","options"),KviOption_uintNotifyListIsOnDelayTimeInSecs,5,180,6,KVI_OPTION_BOOL(KviOption_boolUseNotifyList));
+	u->setSuffix(__tr2qs_ctx(" sec","options"));
+	connect(g,SIGNAL(toggled(bool)),u,SLOT(setEnabled(bool)));
+
+	u = addUIntSelector(g,__tr2qs_ctx("USERHOST delay:","options"),KviOption_uintNotifyListUserhostDelayTimeInSecs,5,180,6,KVI_OPTION_BOOL(KviOption_boolUseNotifyList));
+	u->setSuffix(__tr2qs_ctx(" sec","options"));
+	connect(g,SIGNAL(toggled(bool)),u,SLOT(setEnabled(bool)));
 
 	addLabel(0,3,0,3,__tr2qs_ctx("<p><b>Note:</b><br>The notify list is managed using the \"Registered Users\" settings.</p>","options"));
 

--- a/src/modules/options/OptionsWidget_notify.cpp
+++ b/src/modules/options/OptionsWidget_notify.cpp
@@ -40,43 +40,44 @@ OptionsWidget_notify::OptionsWidget_notify(QWidget * parent)
 	KviTalGroupBox * g;
 	KviUIntSelector * u;
 
-	b = addBoolSelector(0,0,0,0,__tr2qs_ctx("Use online notify list","options"),KviOption_boolUseNotifyList);
+	KviBoolSelector* notifyEnableBox = addBoolSelector(0,0,0,0,__tr2qs_ctx("Use online notify list","options"),KviOption_boolUseNotifyList);
+	b = notifyEnableBox;
 
 	g = addGroupBox(0,1,0,1,Qt::Horizontal,__tr2qs_ctx("Configuration","options"));
 	connect(b,SIGNAL(toggled(bool)),g,SLOT(setEnabled(bool)));
 
 	b = addBoolSelector(g,__tr2qs_ctx("Show notifications in active window","options"),KviOption_boolNotifyListChangesToActiveWindow,KVI_OPTION_BOOL(KviOption_boolUseNotifyList));
-	connect(g,SIGNAL(toggled(bool)),b,SLOT(setEnabled(bool)));
+	connect(notifyEnableBox,SIGNAL(toggled(bool)),b,SLOT(setEnabled(bool)));
 
 	b = addBoolSelector(g,__tr2qs_ctx("Flash window when users are going online","options"),KviOption_boolFlashWindowOnNotifyOnLine,KVI_OPTION_BOOL(KviOption_boolUseNotifyList));
-	connect(g,SIGNAL(toggled(bool)),b,SLOT(setEnabled(bool)));
+	connect(notifyEnableBox,SIGNAL(toggled(bool)),b,SLOT(setEnabled(bool)));
 
 	b = addBoolSelector(g,__tr2qs_ctx("Popup notifier when users are going online","options"),KviOption_boolPopupNotifierOnNotifyOnLine,KVI_OPTION_BOOL(KviOption_boolUseNotifyList));
-	connect(g,SIGNAL(toggled(bool)),b,SLOT(setEnabled(bool)));
+	connect(notifyEnableBox,SIGNAL(toggled(bool)),b,SLOT(setEnabled(bool)));
 
 	g = addGroupBox(0,2,0,2,Qt::Horizontal,__tr2qs_ctx("Advanced Configuration","options"));
-	connect(b,SIGNAL(toggled(bool)),g,SLOT(setEnabled(bool)));
+	connect(notifyEnableBox,SIGNAL(toggled(bool)),g,SLOT(setEnabled(bool)));
 
 	b = addBoolSelector(g,__tr2qs_ctx("Check USERHOST for online users","options"),KviOption_boolNotifyListSendUserhostForOnlineUsers,KVI_OPTION_BOOL(KviOption_boolUseNotifyList));
-	connect(g,SIGNAL(toggled(bool)),b,SLOT(setEnabled(bool)));
+	connect(notifyEnableBox,SIGNAL(toggled(bool)),b,SLOT(setEnabled(bool)));
 
 	b = addBoolSelector(g,__tr2qs_ctx("Use \"smart\" notify list manager","options"),KviOption_boolUseIntelligentNotifyListManager,KVI_OPTION_BOOL(KviOption_boolUseNotifyList));
-	connect(g,SIGNAL(toggled(bool)),b,SLOT(setEnabled(bool)));
+	connect(notifyEnableBox,SIGNAL(toggled(bool)),b,SLOT(setEnabled(bool)));
 
 	b = addBoolSelector(g,__tr2qs_ctx("Use the WATCH method if available","options"),KviOption_boolUseWatchListIfAvailable,KVI_OPTION_BOOL(KviOption_boolUseNotifyList));
-	connect(g,SIGNAL(toggled(bool)),b,SLOT(setEnabled(bool)));
+	connect(notifyEnableBox,SIGNAL(toggled(bool)),b,SLOT(setEnabled(bool)));
 
 	u = addUIntSelector(g,__tr2qs_ctx("Check interval:","options"),KviOption_uintNotifyListCheckTimeInSecs,5,3600,180,KVI_OPTION_BOOL(KviOption_boolUseNotifyList));
 	u->setSuffix(__tr2qs_ctx(" sec","options"));
-	connect(g,SIGNAL(toggled(bool)),u,SLOT(setEnabled(bool)));
+	connect(notifyEnableBox,SIGNAL(toggled(bool)),u,SLOT(setEnabled(bool)));
 
 	u = addUIntSelector(g,__tr2qs_ctx("ISON delay:","options"),KviOption_uintNotifyListIsOnDelayTimeInSecs,5,180,6,KVI_OPTION_BOOL(KviOption_boolUseNotifyList));
 	u->setSuffix(__tr2qs_ctx(" sec","options"));
-	connect(g,SIGNAL(toggled(bool)),u,SLOT(setEnabled(bool)));
+	connect(notifyEnableBox,SIGNAL(toggled(bool)),u,SLOT(setEnabled(bool)));
 
 	u = addUIntSelector(g,__tr2qs_ctx("USERHOST delay:","options"),KviOption_uintNotifyListUserhostDelayTimeInSecs,5,180,6,KVI_OPTION_BOOL(KviOption_boolUseNotifyList));
 	u->setSuffix(__tr2qs_ctx(" sec","options"));
-	connect(g,SIGNAL(toggled(bool)),u,SLOT(setEnabled(bool)));
+	connect(notifyEnableBox,SIGNAL(toggled(bool)),u,SLOT(setEnabled(bool)));
 
 	addLabel(0,3,0,3,__tr2qs_ctx("<p><b>Note:</b><br>The notify list is managed using the \"Registered Users\" settings.</p>","options"));
 

--- a/src/modules/options/OptionsWidget_notify.cpp
+++ b/src/modules/options/OptionsWidget_notify.cpp
@@ -34,67 +34,40 @@ OptionsWidget_notify::OptionsWidget_notify(QWidget * parent)
 : KviOptionsWidget(parent)
 {
 	setObjectName("notify_options_widget");
-
 	createLayout();
 
-	KviBoolSelector * b = addBoolSelector(0,0,0,0,__tr2qs_ctx("Use online notify list","options"),KviOption_boolUseNotifyList);
-	KviTalGroupBox *g = addGroupBox(0,1,0,1,Qt::Horizontal,__tr2qs_ctx("Configuration","options"));
-	connect(b,SIGNAL(toggled(bool)),g,SLOT(setEnabled(bool)));
+	KviBoolSelector * b;
+	KviTalGroupBox * g;
 
-	connect(b,
-		SIGNAL(toggled(bool)),
-		addBoolSelector(g,__tr2qs_ctx("Show notifications in active window","options"),
-				KviOption_boolNotifyListChangesToActiveWindow,KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),
-		SLOT(setEnabled(bool)));
-	connect(b,
-		SIGNAL(toggled(bool)),
-		addBoolSelector(g,__tr2qs_ctx("Flash window when users are going online","options"),
-				KviOption_boolFlashWindowOnNotifyOnLine,KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),
-		SLOT(setEnabled(bool)));
-	connect(b,
-		SIGNAL(toggled(bool)),
-		addBoolSelector(g,__tr2qs_ctx("Popup notifier when users are going online","options"),
-				KviOption_boolPopupNotifierOnNotifyOnLine,KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),
-		SLOT(setEnabled(bool)));
+	b = addBoolSelector(0,0,0,0,__tr2qs_ctx("Use online notify list","options"),KviOption_boolUseNotifyList);
+
+	g = addGroupBox(0,1,0,1,Qt::Horizontal,__tr2qs_ctx("Configuration","options"));
+	connect(b,SIGNAL(toggled(bool)),g,SLOT(setEnabled(bool)));
+	connect(b,SIGNAL(toggled(bool)),addBoolSelector(g,__tr2qs_ctx("Show notifications in active window","options"),KviOption_boolNotifyListChangesToActiveWindow,
+		KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),SLOT(setEnabled(bool)));
+	connect(b,SIGNAL(toggled(bool)),addBoolSelector(g,__tr2qs_ctx("Flash window when users are going online","options"),KviOption_boolFlashWindowOnNotifyOnLine,
+		KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),SLOT(setEnabled(bool)));
+	connect(b,SIGNAL(toggled(bool)),addBoolSelector(g,__tr2qs_ctx("Popup notifier when users are going online","options"),KviOption_boolPopupNotifierOnNotifyOnLine,
+		KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),SLOT(setEnabled(bool)));
 
 	g = addGroupBox(0,2,0,2,Qt::Horizontal,__tr2qs_ctx("Advanced Configuration","options"));
 	connect(b,SIGNAL(toggled(bool)),g,SLOT(setEnabled(bool)));
 
-	connect(b,
-		SIGNAL(toggled(bool)),
-		addBoolSelector(g,__tr2qs_ctx("Check USERHOST for online users","options"),
-				KviOption_boolNotifyListSendUserhostForOnlineUsers,KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),
-		SLOT(setEnabled(bool)));
-	connect(b,
-		SIGNAL(toggled(bool)),
-		addBoolSelector(g,__tr2qs_ctx("Use \"smart\" notify list manager","options"),
-				KviOption_boolUseIntelligentNotifyListManager,KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),
-		SLOT(setEnabled(bool)));
-	connect(b,
-		SIGNAL(toggled(bool)),
-		addBoolSelector(g,__tr2qs_ctx("Use the WATCH method if available","options"),
-				KviOption_boolUseWatchListIfAvailable,KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),
-		SLOT(setEnabled(bool)));
-	connect(b,
-		SIGNAL(toggled(bool)),
-		addUIntSelector(g,__tr2qs_ctx("Check interval (in seconds):","options"),
-				KviOption_uintNotifyListCheckTimeInSecs,
-				5,3600,180,KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),
-		SLOT(setEnabled(bool)));
-	connect(b,
-		SIGNAL(toggled(bool)),
-		addUIntSelector(g,__tr2qs_ctx("ISON delay (in seconds):","options"),
-				KviOption_uintNotifyListIsOnDelayTimeInSecs,
-				5,180,6,KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),
-		SLOT(setEnabled(bool)));
-	connect(b,
-		SIGNAL(toggled(bool)),
-		addUIntSelector(g,__tr2qs_ctx("USERHOST delay (in seconds):","options"),
-				KviOption_uintNotifyListUserhostDelayTimeInSecs,
-				5,180,6,KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),
-		SLOT(setEnabled(bool)));
+	connect(b,SIGNAL(toggled(bool)),addBoolSelector(g,__tr2qs_ctx("Check USERHOST for online users","options"),KviOption_boolNotifyListSendUserhostForOnlineUsers,
+		KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),SLOT(setEnabled(bool)));
+	connect(b,SIGNAL(toggled(bool)),addBoolSelector(g,__tr2qs_ctx("Use \"smart\" notify list manager","options"),KviOption_boolUseIntelligentNotifyListManager,
+		KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),SLOT(setEnabled(bool)));
+	connect(b,SIGNAL(toggled(bool)),addBoolSelector(g,__tr2qs_ctx("Use the WATCH method if available","options"),KviOption_boolUseWatchListIfAvailable,
+		KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),SLOT(setEnabled(bool)));
+	connect(b,SIGNAL(toggled(bool)),addUIntSelector(g,__tr2qs_ctx("Check interval (in seconds):","options"),KviOption_uintNotifyListCheckTimeInSecs,5,3600,180,
+		KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),SLOT(setEnabled(bool)));
+	connect(b,SIGNAL(toggled(bool)),addUIntSelector(g,__tr2qs_ctx("ISON delay (in seconds):","options"),KviOption_uintNotifyListIsOnDelayTimeInSecs,5,180,6,
+		KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),SLOT(setEnabled(bool)));
+	connect(b,SIGNAL(toggled(bool)),addUIntSelector(g,__tr2qs_ctx("USERHOST delay (in seconds):","options"),KviOption_uintNotifyListUserhostDelayTimeInSecs,5,180,6,
+		KVI_OPTION_BOOL(KviOption_boolUseNotifyList)),SLOT(setEnabled(bool)));
 
 	addLabel(0,3,0,3,__tr2qs_ctx("<p><b>Note:</b><br>The notify list is managed using the \"Registered Users\" settings.</p>","options"));
+
 	addRowSpacer(0,4,0,4);
 }
 


### PR DESCRIPTION
### Intro

This solves a long standing pet peeve (in part) where the **sec** (for seconds) on every setting within KVIrc are inside spinboxes, except here.
In order to make this work I have to refactor the option to also make formatting fit what other dialogs do. **And its works** in part.
#### Changes proposed
- Make **(in seconds)** from label _USERHOST delay / Check interval  and  ISON delay_ into a suffix inside respective spinboxes to make this consistent with other similar types of options/spin boxes.
- Cleanup formatting / indenting / spacing and refactor options **W.I.P.**

~~#### Whats doesnt work!~~
~~With this patch You enable top checkbox and nothing happens unless~~
1) ~~you check the top box box,~~
2) ~~press APPLY (option come alive then,~~ 

~~Ive tried multiple variation on the connect signal Im must be missing something obvious but alas cant figure what the heck that is.~~
## Assistance appreciated. :).

Thx to @AndrioCelos for kind assist, who saw the forest through the trees
