### PR TITLE
fix #1965: clang format caused MUTABLE_PTR warning in ppport.h

### DIFF
--- a/src/modules/perlcore/ppport.h
+++ b/src/modules/perlcore/ppport.h
@@ -47,7 +47,7 @@ __DATA__*/
 #ifndef DPPP_NAMESPACE
 #define DPPP_NAMESPACE DPPP_
 #endif
-#define DPPP_CAT2(x, y) CAT2(x, y)
+#define DPPP_CAT2(x,y) CAT2(x,y)
 #define DPPP_(name) DPPP_CAT2(DPPP_NAMESPACE, name)
 #ifndef PERL_REVISION
 #if !defined(__PATCHLEVEL_H_INCLUDED__) && !(defined(PATCHLEVEL) && defined(SUBVERSION))
@@ -63,8 +63,8 @@ __DATA__*/
 #define PERL_SUBVERSION SUBVERSION
 #endif
 #endif
-#define _dpppDEC2BCD(dec) ((((dec) / 100) << 8) | ((((dec) % 100) / 10) << 4) | ((dec) % 10))
-#define PERL_BCDVERSION ((_dpppDEC2BCD(PERL_REVISION) << 24) | (_dpppDEC2BCD(PERL_VERSION) << 12) | _dpppDEC2BCD(PERL_SUBVERSION))
+#define _dpppDEC2BCD(dec) ((((dec)/100)<<8)|((((dec)%100)/10)<<4)|((dec)%10))
+#define PERL_BCDVERSION ((_dpppDEC2BCD(PERL_REVISION)<<24)|(_dpppDEC2BCD(PERL_VERSION)<<12)|_dpppDEC2BCD(PERL_SUBVERSION))
 #if PERL_REVISION != 5
 #error ppport.h only works with Perl version 5
 #endif
@@ -89,7 +89,7 @@ __DATA__*/
 #ifndef aTHX_
 #define aTHX_
 #endif
-#if(PERL_BCDVERSION < 0x5006000)
+#if (PERL_BCDVERSION < 0x5006000)
 #ifdef USE_THREADS
 #define aTHXR thr
 #define aTHXR_ thr,
@@ -151,7 +151,7 @@ __DATA__*/
 #ifdef SHRT_MAX
 #define PERL_SHORT_MAX ((short)SHRT_MAX)
 #else
-#define PERL_SHORT_MAX ((short)(PERL_USHORT_MAX >> 1))
+#define PERL_SHORT_MAX ((short) (PERL_USHORT_MAX >> 1))
 #endif
 #endif
 #endif
@@ -228,7 +228,7 @@ __DATA__*/
 #ifdef MAXLONG
 #define PERL_LONG_MAX ((long)MAXLONG)
 #else
-#define PERL_LONG_MAX ((long)(PERL_ULONG_MAX >> 1))
+#define PERL_LONG_MAX ((long) (PERL_ULONG_MAX >> 1))
 #endif
 #endif
 #endif
@@ -265,7 +265,7 @@ __DATA__*/
 #ifdef MAXLONGLONG
 #define PERL_QUAD_MAX ((long long)MAXLONGLONG)
 #else
-#define PERL_QUAD_MAX ((long long)(PERL_UQUAD_MAX >> 1))
+#define PERL_QUAD_MAX ((long long) (PERL_UQUAD_MAX >> 1))
 #endif
 #endif
 #endif
@@ -400,22 +400,20 @@ __DATA__*/
 #define UVSIZE IVSIZE
 #endif
 #ifndef sv_setuv
-#define sv_setuv(sv, uv)                  \
-	STMT_START                            \
-	{                                     \
-		UV TeMpUv = uv;                   \
-		if(TeMpUv <= IV_MAX)              \
-			sv_setiv(sv, TeMpUv);         \
-		else                              \
-			sv_setnv(sv, (double)TeMpUv); \
-	}                                     \
-	STMT_END
+#define sv_setuv(sv, uv) \
+STMT_START { \
+UV TeMpUv = uv; \
+if (TeMpUv <= IV_MAX) \
+sv_setiv(sv, TeMpUv); \
+else \
+sv_setnv(sv, (double)TeMpUv); \
+} STMT_END
 #endif
 #ifndef newSVuv
 #define newSVuv(uv) ((uv) <= IV_MAX ? newSViv((IV)uv) : newSVnv((NV)uv))
 #endif
 #ifndef sv_2uv
-#define sv_2uv(sv) ((PL_Sv = (sv)), (UV)(SvNOK(PL_Sv) ? SvNV(PL_Sv) : sv_2nv(PL_Sv)))
+#define sv_2uv(sv) ((PL_Sv = (sv)), (UV) (SvNOK(PL_Sv) ? SvNV(PL_Sv) : sv_2nv(PL_Sv)))
 #endif
 #ifndef SvUVX
 #define SvUVX(sv) ((UV)SvIVX(sv))
@@ -436,96 +434,78 @@ __DATA__*/
 #define SvUOK(sv) SvIOK_UV(sv)
 #endif
 #ifndef XST_mUV
-#define XST_mUV(i, v) (ST(i) = sv_2mortal(newSVuv(v)))
+#define XST_mUV(i,v) (ST(i) = sv_2mortal(newSVuv(v)) )
 #endif
 #ifndef XSRETURN_UV
-#define XSRETURN_UV(v) \
-	STMT_START         \
-	{                  \
-		XST_mUV(0, v); \
-		XSRETURN(1);   \
-	}                  \
-	STMT_END
+#define XSRETURN_UV(v) STMT_START { XST_mUV(0,v); XSRETURN(1); } STMT_END
 #endif
 #ifndef PUSHu
-#define PUSHu(u)                 \
-	STMT_START                   \
-	{                            \
-		sv_setuv(TARG, (UV)(u)); \
-		PUSHTARG;                \
-	}                            \
-	STMT_END
+#define PUSHu(u) STMT_START { sv_setuv(TARG, (UV)(u)); PUSHTARG; } STMT_END
 #endif
 #ifndef XPUSHu
-#define XPUSHu(u)                \
-	STMT_START                   \
-	{                            \
-		sv_setuv(TARG, (UV)(u)); \
-		XPUSHTARG;               \
-	}                            \
-	STMT_END
+#define XPUSHu(u) STMT_START { sv_setuv(TARG, (UV)(u)); XPUSHTARG; } STMT_END
 #endif
 #ifdef HAS_MEMCMP
 #ifndef memNE
-#define memNE(s1, s2, l) (memcmp(s1, s2, l))
+#define memNE(s1,s2,l) (memcmp(s1,s2,l))
 #endif
 #ifndef memEQ
-#define memEQ(s1, s2, l) (!memcmp(s1, s2, l))
+#define memEQ(s1,s2,l) (!memcmp(s1,s2,l))
 #endif
 #else
 #ifndef memNE
-#define memNE(s1, s2, l) (bcmp(s1, s2, l))
+#define memNE(s1,s2,l) (bcmp(s1,s2,l))
 #endif
 #ifndef memEQ
-#define memEQ(s1, s2, l) (!bcmp(s1, s2, l))
+#define memEQ(s1,s2,l) (!bcmp(s1,s2,l))
 #endif
 #endif
 #ifndef memEQs
 #define memEQs(s1, l, s2) \
-	(sizeof(s2) - 1 == l && memEQ(s1, (s2 ""), (sizeof(s2) - 1)))
+(sizeof(s2)-1 == l && memEQ(s1, (s2 ""), (sizeof(s2)-1)))
 #endif
 #ifndef memNEs
 #define memNEs(s1, l, s2) !memEQs(s1, l, s2)
 #endif
 #ifndef MoveD
-#define MoveD(s, d, n, t) memmove((char *)(d), (char *)(s), (n) * sizeof(t))
+#define MoveD(s,d,n,t) memmove((char*)(d),(char*)(s), (n) * sizeof(t))
 #endif
 #ifndef CopyD
-#define CopyD(s, d, n, t) memcpy((char *)(d), (char *)(s), (n) * sizeof(t))
+#define CopyD(s,d,n,t) memcpy((char*)(d),(char*)(s), (n) * sizeof(t))
 #endif
 #ifdef HAS_MEMSET
 #ifndef ZeroD
-#define ZeroD(d, n, t) memzero((char *)(d), (n) * sizeof(t))
+#define ZeroD(d,n,t) memzero((char*)(d), (n) * sizeof(t))
 #endif
 #else
 #ifndef ZeroD
-#define ZeroD(d, n, t) ((void)memzero((char *)(d), (n) * sizeof(t)), d)
+#define ZeroD(d,n,t) ((void)memzero((char*)(d), (n) * sizeof(t)), d)
 #endif
 #endif
 #ifndef PoisonWith
-#define PoisonWith(d, n, t, b) (void)memset((char *)(d), (U8)(b), (n) * sizeof(t))
+#define PoisonWith(d,n,t,b) (void)memset((char*)(d), (U8)(b), (n) * sizeof(t))
 #endif
 #ifndef PoisonNew
-#define PoisonNew(d, n, t) PoisonWith(d, n, t, 0xAB)
+#define PoisonNew(d,n,t) PoisonWith(d,n,t,0xAB)
 #endif
 #ifndef PoisonFree
-#define PoisonFree(d, n, t) PoisonWith(d, n, t, 0xEF)
+#define PoisonFree(d,n,t) PoisonWith(d,n,t,0xEF)
 #endif
 #ifndef Poison
-#define Poison(d, n, t) PoisonFree(d, n, t)
+#define Poison(d,n,t) PoisonFree(d,n,t)
 #endif
 #ifndef Newx
-#define Newx(v, n, t) New(0, v, n, t)
+#define Newx(v,n,t) New(0,v,n,t)
 #endif
 #ifndef Newxc
-#define Newxc(v, n, t, c) Newc(0, v, n, t, c)
+#define Newxc(v,n,t,c) Newc(0,v,n,t,c)
 #endif
 #ifndef Newxz
-#define Newxz(v, n, t) Newz(0, v, n, t)
+#define Newxz(v,n,t) Newz(0,v,n,t)
 #endif
 #ifndef PERL_UNUSED_DECL
 #ifdef HASATTRIBUTE
-#if(defined(__GNUC__) && defined(__cplusplus)) || defined(__INTEL_COMPILER)
+#if (defined(__GNUC__) && defined(__cplusplus)) || defined(__INTEL_COMPILER)
 #define PERL_UNUSED_DECL
 #else
 #define PERL_UNUSED_DECL __attribute__((unused))
@@ -556,7 +536,7 @@ __DATA__*/
 #define NOOP (void)0
 #endif
 #ifndef dNOOP
-#define dNOOP extern int Perl___notused PERL_UNUSED_DECL
+#define dNOOP extern int  Perl___notused PERL_UNUSED_DECL
 #endif
 #ifndef NVTYPE
 #if defined(USE_LONG_DOUBLE) && defined(HAS_LONG_DOUBLE)
@@ -567,39 +547,39 @@ __DATA__*/
 typedef NVTYPE NV;
 #endif
 #ifndef INT2PTR
-#if(IVSIZE == PTRSIZE) && (UVSIZE == PTRSIZE)
+#if (IVSIZE == PTRSIZE) && (UVSIZE == PTRSIZE)
 #define PTRV UV
-#define INT2PTR(any, d) (any)(d)
+#define INT2PTR(any,d) (any)(d)
 #else
 #if PTRSIZE == LONGSIZE
 #define PTRV unsigned long
 #else
 #define PTRV unsigned
 #endif
-#define INT2PTR(any, d) (any)(PTRV)(d)
+#define INT2PTR(any,d) (any)(PTRV)(d)
 #endif
 #endif
 #ifndef PTR2ul
 #if PTRSIZE == LONGSIZE
 #define PTR2ul(p) (unsigned long)(p)
 #else
-#define PTR2ul(p) INT2PTR(unsigned long, p)
+#define PTR2ul(p) INT2PTR(unsigned long,p)
 #endif
 #endif
 #ifndef PTR2nat
 #define PTR2nat(p) (PTRV)(p)
 #endif
 #ifndef NUM2PTR
-#define NUM2PTR(any, d) (any) PTR2nat(d)
+#define NUM2PTR(any,d) (any)PTR2nat(d)
 #endif
 #ifndef PTR2IV
-#define PTR2IV(p) INT2PTR(IV, p)
+#define PTR2IV(p) INT2PTR(IV,p)
 #endif
 #ifndef PTR2UV
-#define PTR2UV(p) INT2PTR(UV, p)
+#define PTR2UV(p) INT2PTR(UV,p)
 #endif
 #ifndef PTR2NV
-#define PTR2NV(p) NUM2PTR(NV, p)
+#define PTR2NV(p) NUM2PTR(NV,p)
 #endif
 #undef START_EXTERN_C
 #undef END_EXTERN_C
@@ -630,11 +610,11 @@ typedef NVTYPE NV;
 #define STMT_END )
 #else
 #if defined(VOIDFLAGS) && (VOIDFLAGS) && (defined(sun) || defined(__sun__)) && !defined(__GNUC__)
-#define STMT_START if(1)
-#define STMT_END else(void) 0
+#define STMT_START if (1)
+#define STMT_END else (void)0
 #else
 #define STMT_START do
-#define STMT_END while(0)
+#define STMT_END while (0)
 #endif
 #endif
 #ifndef boolSV
@@ -653,10 +633,10 @@ typedef NVTYPE NV;
 #define AvFILLp AvFILL
 #endif
 #ifndef ERRSV
-#define ERRSV get_sv("@", FALSE)
+#define ERRSV get_sv("@",FALSE)
 #endif
 #ifndef gv_stashpvn
-#define gv_stashpvn(str, len, create) gv_stashpv(str, create)
+#define gv_stashpvn(str,len,create) gv_stashpv(str,create)
 #endif
 #ifndef get_cv
 #define get_cv perl_get_cv
@@ -686,28 +666,25 @@ typedef NVTYPE NV;
 #define dXSTARG SV * targ = sv_newmortal()
 #endif
 #ifndef dAXMARK
-#define dAXMARK       \
-	I32 ax = POPMARK; \
-	register SV ** const mark = PL_stack_base + ax++
+#define dAXMARK I32 ax = POPMARK; \
+register SV ** const mark = PL_stack_base + ax++
 #endif
 #ifndef XSprePUSH
 #define XSprePUSH (sp = PL_stack_base + ax - 1)
 #endif
-#if(PERL_BCDVERSION < 0x5005000)
+#if (PERL_BCDVERSION < 0x5005000)
 #undef XSRETURN
-#define XSRETURN(off)                                 \
-	STMT_START                                        \
-	{                                                 \
-		PL_stack_sp = PL_stack_base + ax + ((off)-1); \
-		return;                                       \
-	}                                                 \
-	STMT_END
+#define XSRETURN(off) \
+STMT_START { \
+PL_stack_sp = PL_stack_base + ax + ((off) - 1); \
+return; \
+} STMT_END
 #endif
 #ifndef XSPROTO
-#define XSPROTO(name) void name(pTHX_ CV * cv)
+#define XSPROTO(name) void name(pTHX_ CV* cv)
 #endif
 #ifndef SVfARG
-#define SVfARG(p) ((void *)(p))
+#define SVfARG(p) ((void*)(p))
 #endif
 #ifndef PERL_ABS
 #define PERL_ABS(x) ((x) < 0 ? -(x) : (x))
@@ -725,34 +702,32 @@ typedef NVTYPE NV;
 #define CPERLscope(x) x
 #endif
 #ifndef PERL_HASH
-#define PERL_HASH(hash, str, len)                               \
-	STMT_START                                                  \
-	{                                                           \
-		const char * s_PeRlHaSh = str;                          \
-		I32 i_PeRlHaSh = len;                                   \
-		U32 hash_PeRlHaSh = 0;                                  \
-		while(i_PeRlHaSh--)                                     \
-			hash_PeRlHaSh = hash_PeRlHaSh * 33 + *s_PeRlHaSh++; \
-		(hash) = hash_PeRlHaSh;                                 \
-	}                                                           \
-	STMT_END
+#define PERL_HASH(hash,str,len) \
+STMT_START { \
+const char *s_PeRlHaSh = str; \
+I32 i_PeRlHaSh = len; \
+U32 hash_PeRlHaSh = 0; \
+while (i_PeRlHaSh--) \
+hash_PeRlHaSh = hash_PeRlHaSh * 33 + *s_PeRlHaSh++; \
+(hash) = hash_PeRlHaSh; \
+} STMT_END
 #endif
 #ifndef PERLIO_FUNCS_DECL
 #ifdef PERLIO_FUNCS_CONST
 #define PERLIO_FUNCS_DECL(funcs) const PerlIO_funcs funcs
-#define PERLIO_FUNCS_CAST(funcs) (PerlIO_funcs *)(funcs)
+#define PERLIO_FUNCS_CAST(funcs) (PerlIO_funcs*)(funcs)
 #else
 #define PERLIO_FUNCS_DECL(funcs) PerlIO_funcs funcs
 #define PERLIO_FUNCS_CAST(funcs) (funcs)
 #endif
 #endif
-#if(PERL_BCDVERSION < 0x5009003)
+#if (PERL_BCDVERSION < 0x5009003)
 #ifdef ARGSproto
-typedef OP *(CPERLscope(*Perl_ppaddr_t))(ARGSproto);
+typedef OP* (CPERLscope(*Perl_ppaddr_t))(ARGSproto);
 #else
-typedef OP *(CPERLscope(*Perl_ppaddr_t))(pTHX);
+typedef OP* (CPERLscope(*Perl_ppaddr_t))(pTHX);
 #endif
-typedef OP *(CPERLscope(*Perl_check_t))(pTHX_ OP *);
+typedef OP* (CPERLscope(*Perl_check_t)) (pTHX_ OP*);
 #endif
 #ifndef isPSXSPC
 #define isPSXSPC(c) (isSPACE(c) || (c) == '\v')
@@ -783,7 +758,7 @@ typedef OP *(CPERLscope(*Perl_check_t))(pTHX_ OP *);
 #define isXDIGIT(c) isxdigit(c)
 #endif
 #else
-#if(PERL_BCDVERSION < 0x5010000)
+#if (PERL_BCDVERSION < 0x5010000)
 #undef isPRINT
 #endif
 #ifdef HAS_QUAD
@@ -799,10 +774,10 @@ typedef OP *(CPERLscope(*Perl_check_t))(pTHX_ OP *);
 #define isALNUMC(c) (isALPHA(c) || isDIGIT(c))
 #endif
 #ifndef isASCII
-#define isASCII(c) ((WIDEST_UTYPE)(c) <= 127)
+#define isASCII(c) ((WIDEST_UTYPE) (c) <= 127)
 #endif
 #ifndef isCNTRL
-#define isCNTRL(c) ((WIDEST_UTYPE)(c) < ' ' || (c) == 127)
+#define isCNTRL(c) ((WIDEST_UTYPE) (c) < ' ' || (c) == 127)
 #endif
 #ifndef isGRAPH
 #define isGRAPH(c) (isALNUM(c) || isPUNCT(c))
@@ -817,14 +792,16 @@ typedef OP *(CPERLscope(*Perl_check_t))(pTHX_ OP *);
 #define isXDIGIT(c) (isDIGIT(c) || ((c) >= 'a' && (c) <= 'f') || ((c) >= 'A' && (c) <= 'F'))
 #endif
 #endif
-#if(PERL_BCDVERSION >= 0x5008000)
+#if (PERL_BCDVERSION >= 0x5008000)
 #ifndef HeUTF8
-#define HeUTF8(he) ((HeKLEN(he) == HEf_SVKEY) ? SvUTF8(HeKEY_sv(he)) : (U32)HeKUTF8(he))
+#define HeUTF8(he) ((HeKLEN(he) == HEf_SVKEY) ? \
+SvUTF8(HeKEY_sv(he)) : \
+(U32)HeKUTF8(he))
 #endif
 #endif
 #ifndef PERL_SIGNALS_UNSAFE_FLAG
 #define PERL_SIGNALS_UNSAFE_FLAG 0x0001
-#if(PERL_BCDVERSION < 0x5008000)
+#if (PERL_BCDVERSION < 0x5008000)
 #define D_PPP_PERL_SIGNALS_INIT PERL_SIGNALS_UNSAFE_FLAG
 #else
 #define D_PPP_PERL_SIGNALS_INIT 0
@@ -838,11 +815,11 @@ extern U32 DPPP_(my_PL_signals);
 #endif
 #define PL_signals DPPP_(my_PL_signals)
 #endif
-#if(PERL_BCDVERSION <= 0x5005005)
+#if (PERL_BCDVERSION <= 0x5005005)
 #define PL_ppaddr ppaddr
 #define PL_no_modify no_modify
 #endif
-#if(PERL_BCDVERSION <= 0x5004005)
+#if (PERL_BCDVERSION <= 0x5004005)
 #define PL_DBsignal DBsignal
 #define PL_DBsingle DBsingle
 #define PL_DBsub DBsub
@@ -886,20 +863,20 @@ extern U32 DPPP_(my_PL_signals);
 #define PL_tainting tainting
 #define PL_tokenbuf tokenbuf
 #endif
-#if(PERL_BCDVERSION >= 0x5009005)
+#if (PERL_BCDVERSION >= 0x5009005)
 #ifdef DPPP_PL_parser_NO_DUMMY
-#define D_PPP_my_PL_parser_var(var) ((PL_parser ? PL_parser : (croak("panic: PL_parser == NULL in %s:%d", \
-                                                                   __FILE__, __LINE__),                   \
-                                                                  (yy_parser *)NULL))                     \
-                                         ->var)
+#define D_PPP_my_PL_parser_var(var) ((PL_parser ? PL_parser : \
+(croak("panic: PL_parser == NULL in %s:%d", \
+__FILE__, __LINE__), (yy_parser *) NULL))->var)
 #else
 #ifdef DPPP_PL_parser_NO_DUMMY_WARNING
 #define D_PPP_parser_dummy_warning(var)
 #else
 #define D_PPP_parser_dummy_warning(var) \
-	warn("warning: dummy PL_" #var " used in %s:%d", __FILE__, __LINE__),
+warn("warning: dummy PL_" #var " used in %s:%d", __FILE__, __LINE__),
 #endif
-#define D_PPP_my_PL_parser_var(var) ((PL_parser ? PL_parser : (D_PPP_parser_dummy_warning(var) & DPPP_(dummy_PL_parser)))->var)
+#define D_PPP_my_PL_parser_var(var) ((PL_parser ? PL_parser : \
+(D_PPP_parser_dummy_warning(var) &DPPP_(dummy_PL_parser)))->var)
 #if defined(NEED_PL_parser)
 static yy_parser DPPP_(dummy_PL_parser);
 #elif defined(NEED_PL_parser_GLOBAL)
@@ -922,7 +899,7 @@ extern yy_parser DPPP_(dummy_PL_parser);
 #define PL_in_my_stash D_PPP_my_PL_parser_var(in_my_stash)
 #define PL_error_count D_PPP_my_PL_parser_var(error_count)
 #else
-#define PL_parser ((void *)1)
+#define PL_parser ((void *) 1)
 #endif
 #ifndef mPUSHs
 #define mPUSHs(s) PUSHs(sv_2mortal(s))
@@ -931,7 +908,7 @@ extern yy_parser DPPP_(dummy_PL_parser);
 #define PUSHmortal PUSHs(sv_newmortal())
 #endif
 #ifndef mPUSHp
-#define mPUSHp(p, l) sv_setpvn(PUSHmortal, (p), (l))
+#define mPUSHp(p,l) sv_setpvn(PUSHmortal, (p), (l))
 #endif
 #ifndef mPUSHn
 #define mPUSHn(n) sv_setnv(PUSHmortal, (NV)(n))
@@ -949,40 +926,16 @@ extern yy_parser DPPP_(dummy_PL_parser);
 #define XPUSHmortal XPUSHs(sv_newmortal())
 #endif
 #ifndef mXPUSHp
-#define mXPUSHp(p, l)                    \
-	STMT_START                           \
-	{                                    \
-		EXTEND(sp, 1);                   \
-		sv_setpvn(PUSHmortal, (p), (l)); \
-	}                                    \
-	STMT_END
+#define mXPUSHp(p,l) STMT_START { EXTEND(sp,1); sv_setpvn(PUSHmortal, (p), (l)); } STMT_END
 #endif
 #ifndef mXPUSHn
-#define mXPUSHn(n)                     \
-	STMT_START                         \
-	{                                  \
-		EXTEND(sp, 1);                 \
-		sv_setnv(PUSHmortal, (NV)(n)); \
-	}                                  \
-	STMT_END
+#define mXPUSHn(n) STMT_START { EXTEND(sp,1); sv_setnv(PUSHmortal, (NV)(n)); } STMT_END
 #endif
 #ifndef mXPUSHi
-#define mXPUSHi(i)                     \
-	STMT_START                         \
-	{                                  \
-		EXTEND(sp, 1);                 \
-		sv_setiv(PUSHmortal, (IV)(i)); \
-	}                                  \
-	STMT_END
+#define mXPUSHi(i) STMT_START { EXTEND(sp,1); sv_setiv(PUSHmortal, (IV)(i)); } STMT_END
 #endif
 #ifndef mXPUSHu
-#define mXPUSHu(u)                     \
-	STMT_START                         \
-	{                                  \
-		EXTEND(sp, 1);                 \
-		sv_setuv(PUSHmortal, (UV)(u)); \
-	}                                  \
-	STMT_END
+#define mXPUSHu(u) STMT_START { EXTEND(sp,1); sv_setuv(PUSHmortal, (UV)(u)); } STMT_END
 #endif
 #ifndef call_sv
 #define call_sv perl_call_sv
@@ -1013,124 +966,113 @@ extern yy_parser DPPP_(dummy_PL_parser);
 #ifdef call_sv
 #undef call_sv
 #endif
-#if(PERL_BCDVERSION < 0x5006000)
-#define call_sv(sv, flags) ((flags)&G_METHOD ? perl_call_method((char *)SvPV_nolen_const(sv), \
-                                                   (flags) & ~G_METHOD)                       \
-                                             : perl_call_sv(sv, flags))
+#if (PERL_BCDVERSION < 0x5006000)
+#define call_sv(sv, flags) ((flags) & G_METHOD ? perl_call_method((char *) SvPV_nolen_const(sv), \
+(flags) & ~G_METHOD) : perl_call_sv(sv, flags))
 #else
-#define call_sv(sv, flags) ((flags)&G_METHOD ? Perl_call_method(aTHX_(char *) SvPV_nolen_const(sv), \
-                                                   (flags) & ~G_METHOD)                             \
-                                             : Perl_call_sv(aTHX_ sv, flags))
+#define call_sv(sv, flags) ((flags) & G_METHOD ? Perl_call_method(aTHX_ (char *) SvPV_nolen_const(sv), \
+(flags) & ~G_METHOD) : Perl_call_sv(aTHX_ sv, flags))
 #endif
 #endif
 #ifndef eval_pv
 #if defined(NEED_eval_pv)
-static SV * DPPP_(my_eval_pv)(char * p, I32 croak_on_error);
+static SV* DPPP_(my_eval_pv)(char *p, I32 croak_on_error);
 static
 #else
-extern SV * DPPP_(my_eval_pv)(char * p, I32 croak_on_error);
+extern SV* DPPP_(my_eval_pv)(char *p, I32 croak_on_error);
 #endif
 #ifdef eval_pv
 #undef eval_pv
 #endif
-#define eval_pv(a, b) \
-	DPPP_(my_eval_pv) \
-	(aTHX_ a, b)
+#define eval_pv(a,b) DPPP_(my_eval_pv)(aTHX_ a,b)
 #define Perl_eval_pv DPPP_(my_eval_pv)
 #if defined(NEED_eval_pv) || defined(NEED_eval_pv_GLOBAL)
-    SV *
-        DPPP_(my_eval_pv)(char * p, I32 croak_on_error)
+SV*
+DPPP_(my_eval_pv)(char *p, I32 croak_on_error)
 {
-	dSP;
-	SV * sv = newSVpv(p, 0);
-	PUSHMARK(sp);
-	eval_sv(sv, G_SCALAR);
-	SvREFCNT_dec(sv);
-	SPAGAIN;
-	sv = POPs;
-	PUTBACK;
-	if(croak_on_error && SvTRUE(GvSV(errgv)))
-		croak(SvPVx(GvSV(errgv), na));
-	return sv;
+dSP;
+SV* sv = newSVpv(p, 0);
+PUSHMARK(sp);
+eval_sv(sv, G_SCALAR);
+SvREFCNT_dec(sv);
+SPAGAIN;
+sv = POPs;
+PUTBACK;
+if (croak_on_error && SvTRUE(GvSV(errgv)))
+croak(SvPVx(GvSV(errgv), na));
+return sv;
 }
 #endif
 #endif
 #ifndef vload_module
 #if defined(NEED_vload_module)
-static void DPPP_(my_vload_module)(U32 flags, SV * name, SV * ver, va_list * args);
+static void DPPP_(my_vload_module)(U32 flags, SV *name, SV *ver, va_list *args);
 static
 #else
-extern void DPPP_(my_vload_module)(U32 flags, SV * name, SV * ver, va_list * args);
+extern void DPPP_(my_vload_module)(U32 flags, SV *name, SV *ver, va_list *args);
 #endif
 #ifdef vload_module
 #undef vload_module
 #endif
-#define vload_module(a, b, c, d) \
-	DPPP_(my_vload_module)       \
-	(aTHX_ a, b, c, d)
+#define vload_module(a,b,c,d) DPPP_(my_vload_module)(aTHX_ a,b,c,d)
 #define Perl_vload_module DPPP_(my_vload_module)
 #if defined(NEED_vload_module) || defined(NEED_vload_module_GLOBAL)
-    void
-        DPPP_(my_vload_module)(U32 flags, SV * name, SV * ver, va_list * args)
+void
+DPPP_(my_vload_module)(U32 flags, SV *name, SV *ver, va_list *args)
 {
-	dTHR;
-	dVAR;
-	OP *veop, *imop;
-	OP * const modname = newSVOP(OP_CONST, 0, name);
-	SvREADONLY_off(((SVOP *)modname)->op_sv);
-	modname->op_private |= OPpCONST_BARE;
-	if(ver)
-	{
-		veop = newSVOP(OP_CONST, 0, ver);
-	}
-	else
-		veop = NULL;
-	if(flags & PERL_LOADMOD_NOIMPORT)
-	{
-		imop = sawparens(newNULLLIST());
-	}
-	else if(flags & PERL_LOADMOD_IMPORT_OPS)
-	{
-		imop = va_arg(*args, OP *);
-	}
-	else
-	{
-		SV * sv;
-		imop = NULL;
-		sv = va_arg(*args, SV *);
-		while(sv)
-		{
-			imop = append_elem(OP_LIST, imop, newSVOP(OP_CONST, 0, sv));
-			sv = va_arg(*args, SV *);
-		}
-	}
-	{
-		const line_t ocopline = PL_copline;
-		COP * const ocurcop = PL_curcop;
-		const int oexpect = PL_expect;
-#if(PERL_BCDVERSION >= 0x5004000)
-		utilize(!(flags & PERL_LOADMOD_DENY), start_subparse(FALSE, 0),
-		    veop, modname, imop);
-#elif(PERL_BCDVERSION > 0x5003000)
-		utilize(!(flags & PERL_LOADMOD_DENY), start_subparse(),
-		    veop, modname, imop);
+dTHR;
+dVAR;
+OP *veop, *imop;
+OP * const modname = newSVOP(OP_CONST, 0, name);
+SvREADONLY_off(((SVOP*)modname)->op_sv);
+modname->op_private |= OPpCONST_BARE;
+if (ver) {
+veop = newSVOP(OP_CONST, 0, ver);
+}
+else
+veop = NULL;
+if (flags & PERL_LOADMOD_NOIMPORT) {
+imop = sawparens(newNULLLIST());
+}
+else if (flags & PERL_LOADMOD_IMPORT_OPS) {
+imop = va_arg(*args, OP*);
+}
+else {
+SV *sv;
+imop = NULL;
+sv = va_arg(*args, SV*);
+while (sv) {
+imop = append_elem(OP_LIST, imop, newSVOP(OP_CONST, 0, sv));
+sv = va_arg(*args, SV*);
+}
+}
+{
+const line_t ocopline = PL_copline;
+COP * const ocurcop = PL_curcop;
+const int oexpect = PL_expect;
+#if (PERL_BCDVERSION >= 0x5004000)
+utilize(!(flags & PERL_LOADMOD_DENY), start_subparse(FALSE, 0),
+veop, modname, imop);
+#elif (PERL_BCDVERSION > 0x5003000)
+utilize(!(flags & PERL_LOADMOD_DENY), start_subparse(),
+veop, modname, imop);
 #else
-		utilize(!(flags & PERL_LOADMOD_DENY), start_subparse(),
-		    modname, imop);
+utilize(!(flags & PERL_LOADMOD_DENY), start_subparse(),
+modname, imop);
 #endif
-		PL_expect = oexpect;
-		PL_copline = ocopline;
-		PL_curcop = ocurcop;
-	}
+PL_expect = oexpect;
+PL_copline = ocopline;
+PL_curcop = ocurcop;
+}
 }
 #endif
 #endif
 #ifndef load_module
 #if defined(NEED_load_module)
-static void DPPP_(my_load_module)(U32 flags, SV * name, SV * ver, ...);
+static void DPPP_(my_load_module)(U32 flags, SV *name, SV *ver, ...);
 static
 #else
-extern void DPPP_(my_load_module)(U32 flags, SV * name, SV * ver, ...);
+extern void DPPP_(my_load_module)(U32 flags, SV *name, SV *ver, ...);
 #endif
 #ifdef load_module
 #undef load_module
@@ -1138,13 +1080,13 @@ extern void DPPP_(my_load_module)(U32 flags, SV * name, SV * ver, ...);
 #define load_module DPPP_(my_load_module)
 #define Perl_load_module DPPP_(my_load_module)
 #if defined(NEED_load_module) || defined(NEED_load_module_GLOBAL)
-    void
-        DPPP_(my_load_module)(U32 flags, SV * name, SV * ver, ...)
+void
+DPPP_(my_load_module)(U32 flags, SV *name, SV *ver, ...)
 {
-	va_list args;
-	va_start(args, ver);
-	vload_module(flags, name, ver, &args);
-	va_end(args);
+va_list args;
+va_start(args, ver);
+vload_module(flags, name, ver, &args);
+va_end(args);
 }
 #endif
 #endif
@@ -1153,107 +1095,105 @@ extern void DPPP_(my_load_module)(U32 flags, SV * name, SV * ver, ...);
 #endif
 #ifndef newRV_noinc
 #if defined(NEED_newRV_noinc)
-static SV * DPPP_(my_newRV_noinc)(SV * sv);
+static SV * DPPP_(my_newRV_noinc)(SV *sv);
 static
 #else
-extern SV * DPPP_(my_newRV_noinc)(SV * sv);
+extern SV * DPPP_(my_newRV_noinc)(SV *sv);
 #endif
 #ifdef newRV_noinc
 #undef newRV_noinc
 #endif
-#define newRV_noinc(a)    \
-	DPPP_(my_newRV_noinc) \
-	(aTHX_ a)
+#define newRV_noinc(a) DPPP_(my_newRV_noinc)(aTHX_ a)
 #define Perl_newRV_noinc DPPP_(my_newRV_noinc)
 #if defined(NEED_newRV_noinc) || defined(NEED_newRV_noinc_GLOBAL)
-    SV *
-        DPPP_(my_newRV_noinc)(SV * sv)
+SV *
+DPPP_(my_newRV_noinc)(SV *sv)
 {
-	SV * rv = (SV *)newRV(sv);
-	SvREFCNT_dec(sv);
-	return rv;
+SV *rv = (SV *)newRV(sv);
+SvREFCNT_dec(sv);
+return rv;
 }
 #endif
 #endif
-#if(PERL_BCDVERSION < 0x5004063) && (PERL_BCDVERSION != 0x5004005)
+#if (PERL_BCDVERSION < 0x5004063) && (PERL_BCDVERSION != 0x5004005)
 #if defined(NEED_newCONSTSUB)
-static void DPPP_(my_newCONSTSUB)(HV * stash, const char * name, SV * sv);
+static void DPPP_(my_newCONSTSUB)(HV *stash, const char *name, SV *sv);
 static
 #else
-extern void DPPP_(my_newCONSTSUB)(HV * stash, const char * name, SV * sv);
+extern void DPPP_(my_newCONSTSUB)(HV *stash, const char *name, SV *sv);
 #endif
 #ifdef newCONSTSUB
 #undef newCONSTSUB
 #endif
-#define newCONSTSUB(a, b, c) \
-	DPPP_(my_newCONSTSUB)    \
-	(aTHX_ a, b, c)
+#define newCONSTSUB(a,b,c) DPPP_(my_newCONSTSUB)(aTHX_ a,b,c)
 #define Perl_newCONSTSUB DPPP_(my_newCONSTSUB)
 #if defined(NEED_newCONSTSUB) || defined(NEED_newCONSTSUB_GLOBAL)
 #define D_PPP_PL_copline PL_copline
-    void
-        DPPP_(my_newCONSTSUB)(HV * stash, const char * name, SV * sv)
+void
+DPPP_(my_newCONSTSUB)(HV *stash, const char *name, SV *sv)
 {
-	U32 oldhints = PL_hints;
-	HV * old_cop_stash = PL_curcop->cop_stash;
-	HV * old_curstash = PL_curstash;
-	line_t oldline = PL_curcop->cop_line;
-	PL_curcop->cop_line = D_PPP_PL_copline;
-	PL_hints &= ~HINT_BLOCK_SCOPE;
-	if(stash)
-		PL_curstash = PL_curcop->cop_stash = stash;
-	newSUB(
-#if(PERL_BCDVERSION < 0x5003022)
-	    start_subparse(),
-#elif(PERL_BCDVERSION == 0x5003022)
-	    start_subparse(0),
+U32 oldhints = PL_hints;
+HV *old_cop_stash = PL_curcop->cop_stash;
+HV *old_curstash = PL_curstash;
+line_t oldline = PL_curcop->cop_line;
+PL_curcop->cop_line = D_PPP_PL_copline;
+PL_hints &= ~HINT_BLOCK_SCOPE;
+if (stash)
+PL_curstash = PL_curcop->cop_stash = stash;
+newSUB(
+#if (PERL_BCDVERSION < 0x5003022)
+start_subparse(),
+#elif (PERL_BCDVERSION == 0x5003022)
+start_subparse(0),
 #else
-	    start_subparse(FALSE, 0),
+start_subparse(FALSE, 0),
 #endif
-	    newSVOP(OP_CONST, 0, newSVpv((char *)name, 0)),
-	    newSVOP(OP_CONST, 0, &PL_sv_no),
-	    newSTATEOP(0, Nullch, newSVOP(OP_CONST, 0, sv)));
-	PL_hints = oldhints;
-	PL_curcop->cop_stash = old_cop_stash;
-	PL_curstash = old_curstash;
-	PL_curcop->cop_line = oldline;
+newSVOP(OP_CONST, 0, newSVpv((char *) name, 0)),
+newSVOP(OP_CONST, 0, &PL_sv_no),
+newSTATEOP(0, Nullch, newSVOP(OP_CONST, 0, sv))
+);
+PL_hints = oldhints;
+PL_curcop->cop_stash = old_cop_stash;
+PL_curstash = old_curstash;
+PL_curcop->cop_line = oldline;
 }
 #endif
 #endif
-#if defined(MULTIPLICITY) || defined(PERL_OBJECT) || defined(PERL_CAPI) || defined(PERL_IMPLICIT_CONTEXT)
+#if defined(MULTIPLICITY) || defined(PERL_OBJECT) || \
+defined(PERL_CAPI) || defined(PERL_IMPLICIT_CONTEXT)
 #ifndef START_MY_CXT
 #define START_MY_CXT
-#if(PERL_BCDVERSION < 0x5004068)
+#if (PERL_BCDVERSION < 0x5004068)
 #define dMY_CXT_SV \
-	SV * my_cxt_sv = get_sv(MY_CXT_KEY, FALSE)
+SV *my_cxt_sv = get_sv(MY_CXT_KEY, FALSE)
 #else
-#define dMY_CXT_SV                                       \
-	SV * my_cxt_sv = *hv_fetch(PL_modglobal, MY_CXT_KEY, \
-	    sizeof(MY_CXT_KEY) - 1, TRUE)
+#define dMY_CXT_SV \
+SV *my_cxt_sv = *hv_fetch(PL_modglobal, MY_CXT_KEY, \
+sizeof(MY_CXT_KEY)-1, TRUE)
 #endif
 #define dMY_CXT \
-	dMY_CXT_SV; \
-	my_cxt_t * my_cxtp = INT2PTR(my_cxt_t *, SvUV(my_cxt_sv))
-#define MY_CXT_INIT                                                      \
-	dMY_CXT_SV;                                                          \
-                                                                         \
-	my_cxt_t * my_cxtp = (my_cxt_t *)SvPVX(newSV(sizeof(my_cxt_t) - 1)); \
-	Zero(my_cxtp, 1, my_cxt_t);                                          \
-	sv_setuv(my_cxt_sv, PTR2UV(my_cxtp))
+dMY_CXT_SV; \
+my_cxt_t *my_cxtp = INT2PTR(my_cxt_t*,SvUV(my_cxt_sv))
+#define MY_CXT_INIT \
+dMY_CXT_SV; \
+\
+my_cxt_t *my_cxtp = (my_cxt_t*)SvPVX(newSV(sizeof(my_cxt_t)-1));\
+Zero(my_cxtp, 1, my_cxt_t); \
+sv_setuv(my_cxt_sv, PTR2UV(my_cxtp))
 #define MY_CXT (*my_cxtp)
-#define pMY_CXT my_cxt_t * my_cxtp
+#define pMY_CXT my_cxt_t *my_cxtp
 #define pMY_CXT_ pMY_CXT,
-#define _pMY_CXT , pMY_CXT
+#define _pMY_CXT ,pMY_CXT
 #define aMY_CXT my_cxtp
 #define aMY_CXT_ aMY_CXT,
-#define _aMY_CXT , aMY_CXT
+#define _aMY_CXT ,aMY_CXT
 #endif
 #ifndef MY_CXT_CLONE
-#define MY_CXT_CLONE                                                     \
-	dMY_CXT_SV;                                                          \
-	my_cxt_t * my_cxtp = (my_cxt_t *)SvPVX(newSV(sizeof(my_cxt_t) - 1)); \
-	Copy(INT2PTR(my_cxt_t *, SvUV(my_cxt_sv)), my_cxtp, 1, my_cxt_t);    \
-	sv_setuv(my_cxt_sv, PTR2UV(my_cxtp))
+#define MY_CXT_CLONE \
+dMY_CXT_SV; \
+my_cxt_t *my_cxtp = (my_cxt_t*)SvPVX(newSV(sizeof(my_cxt_t)-1));\
+Copy(INT2PTR(my_cxt_t*, SvUV(my_cxt_sv)), my_cxtp, 1, my_cxt_t);\
+sv_setuv(my_cxt_sv, PTR2UV(my_cxtp))
 #endif
 #else
 #ifndef START_MY_CXT
@@ -1291,7 +1231,8 @@ extern void DPPP_(my_newCONSTSUB)(HV * stash, const char * name, SV * sv);
 #endif
 #endif
 #ifndef NVef
-#if defined(USE_LONG_DOUBLE) && defined(HAS_LONG_DOUBLE) && defined(PERL_PRIfldbl) && (PERL_BCDVERSION != 0x5006000)
+#if defined(USE_LONG_DOUBLE) && defined(HAS_LONG_DOUBLE) && \
+defined(PERL_PRIfldbl) && (PERL_BCDVERSION != 0x5006000)
 #define NVef PERL_PRIeldbl
 #define NVff PERL_PRIfldbl
 #define NVgf PERL_PRIgldbl
@@ -1303,112 +1244,100 @@ extern void DPPP_(my_newCONSTSUB)(HV * stash, const char * name, SV * sv);
 #endif
 #ifndef SvREFCNT_inc
 #ifdef PERL_USE_GCC_BRACE_GROUPS
-#define SvREFCNT_inc(sv)                 \
-	(                                    \
-	    {                                \
-		    SV * const _sv = (SV *)(sv); \
-		    if(_sv)                      \
-			    (SvREFCNT(_sv))++;       \
-		    _sv;                         \
-		})
+#define SvREFCNT_inc(sv) \
+({ \
+SV * const _sv = (SV*)(sv); \
+if (_sv) \
+(SvREFCNT(_sv))++; \
+_sv; \
+})
 #else
 #define SvREFCNT_inc(sv) \
-	((PL_Sv = (SV *)(sv)) ? (++(SvREFCNT(PL_Sv)), PL_Sv) : NULL)
+((PL_Sv=(SV*)(sv)) ? (++(SvREFCNT(PL_Sv)),PL_Sv) : NULL)
 #endif
 #endif
 #ifndef SvREFCNT_inc_simple
 #ifdef PERL_USE_GCC_BRACE_GROUPS
-#define SvREFCNT_inc_simple(sv)   \
-	(                             \
-	    {                         \
-		    if(sv)                \
-			    (SvREFCNT(sv))++; \
-		    (SV *)(sv);           \
-		})
+#define SvREFCNT_inc_simple(sv) \
+({ \
+if (sv) \
+(SvREFCNT(sv))++; \
+(SV *)(sv); \
+})
 #else
 #define SvREFCNT_inc_simple(sv) \
-	((sv) ? (SvREFCNT(sv)++, (SV *)(sv)) : NULL)
+((sv) ? (SvREFCNT(sv)++,(SV*)(sv)) : NULL)
 #endif
 #endif
 #ifndef SvREFCNT_inc_NN
 #ifdef PERL_USE_GCC_BRACE_GROUPS
-#define SvREFCNT_inc_NN(sv)              \
-	(                                    \
-	    {                                \
-		    SV * const _sv = (SV *)(sv); \
-		    SvREFCNT(_sv)++;             \
-		    _sv;                         \
-		})
+#define SvREFCNT_inc_NN(sv) \
+({ \
+SV * const _sv = (SV*)(sv); \
+SvREFCNT(_sv)++; \
+_sv; \
+})
 #else
 #define SvREFCNT_inc_NN(sv) \
-	(PL_Sv = (SV *)(sv), ++(SvREFCNT(PL_Sv)), PL_Sv)
+(PL_Sv=(SV*)(sv),++(SvREFCNT(PL_Sv)),PL_Sv)
 #endif
 #endif
 #ifndef SvREFCNT_inc_void
 #ifdef PERL_USE_GCC_BRACE_GROUPS
-#define SvREFCNT_inc_void(sv)            \
-	(                                    \
-	    {                                \
-		    SV * const _sv = (SV *)(sv); \
-		    if(_sv)                      \
-			    (void)(SvREFCNT(_sv)++); \
-		})
+#define SvREFCNT_inc_void(sv) \
+({ \
+SV * const _sv = (SV*)(sv); \
+if (_sv) \
+(void)(SvREFCNT(_sv)++); \
+})
 #else
 #define SvREFCNT_inc_void(sv) \
-	(void)((PL_Sv = (SV *)(sv)) ? ++(SvREFCNT(PL_Sv)) : 0)
+(void)((PL_Sv=(SV*)(sv)) ? ++(SvREFCNT(PL_Sv)) : 0)
 #endif
 #endif
 #ifndef SvREFCNT_inc_simple_void
-#define SvREFCNT_inc_simple_void(sv) \
-	STMT_START                       \
-	{                                \
-		if(sv)                       \
-			SvREFCNT(sv)++;          \
-	}                                \
-	STMT_END
+#define SvREFCNT_inc_simple_void(sv) STMT_START { if (sv) SvREFCNT(sv)++; } STMT_END
 #endif
 #ifndef SvREFCNT_inc_simple_NN
-#define SvREFCNT_inc_simple_NN(sv) (++SvREFCNT(sv), (SV *)(sv))
+#define SvREFCNT_inc_simple_NN(sv) (++SvREFCNT(sv), (SV*)(sv))
 #endif
 #ifndef SvREFCNT_inc_void_NN
-#define SvREFCNT_inc_void_NN(sv) (void)(++SvREFCNT((SV *)(sv)))
+#define SvREFCNT_inc_void_NN(sv) (void)(++SvREFCNT((SV*)(sv)))
 #endif
 #ifndef SvREFCNT_inc_simple_void_NN
-#define SvREFCNT_inc_simple_void_NN(sv) (void)(++SvREFCNT((SV *)(sv)))
+#define SvREFCNT_inc_simple_void_NN(sv) (void)(++SvREFCNT((SV*)(sv)))
 #endif
 #ifndef newSV_type
 #if defined(NEED_newSV_type)
-static SV * DPPP_(my_newSV_type)(pTHX_ svtype const t);
+static SV* DPPP_(my_newSV_type)(pTHX_ svtype const t);
 static
 #else
-extern SV * DPPP_(my_newSV_type)(pTHX_ svtype const t);
+extern SV* DPPP_(my_newSV_type)(pTHX_ svtype const t);
 #endif
 #ifdef newSV_type
 #undef newSV_type
 #endif
-#define newSV_type(a)    \
-	DPPP_(my_newSV_type) \
-	(aTHX_ a)
+#define newSV_type(a) DPPP_(my_newSV_type)(aTHX_ a)
 #define Perl_newSV_type DPPP_(my_newSV_type)
 #if defined(NEED_newSV_type) || defined(NEED_newSV_type_GLOBAL)
-    SV *
-        DPPP_(my_newSV_type)(pTHX_ svtype const t)
+SV*
+DPPP_(my_newSV_type)(pTHX_ svtype const t)
 {
-	SV * const sv = newSV(0);
-	sv_upgrade(sv, t);
-	return sv;
+SV* const sv = newSV(0);
+sv_upgrade(sv, t);
+return sv;
 }
 #endif
 #endif
-#if(PERL_BCDVERSION < 0x5006000)
-#define D_PPP_CONSTPV_ARG(x) ((char *)(x))
+#if (PERL_BCDVERSION < 0x5006000)
+#define D_PPP_CONSTPV_ARG(x) ((char *) (x))
 #else
 #define D_PPP_CONSTPV_ARG(x) (x)
 #endif
 #ifndef newSVpvn
-#define newSVpvn(data, len) ((data)                         \
-        ? ((len) ? newSVpv((data), (len)) : newSVpv("", 0)) \
-        : newSV(0))
+#define newSVpvn(data,len) ((data) \
+? ((len) ? newSVpv((data), (len)) : newSVpv("", 0)) \
+: newSV(0))
 #endif
 #ifndef newSVpvn_utf8
 #define newSVpvn_utf8(s, len, u) newSVpvn_flags((s), (len), (u) ? SVf_UTF8 : 0)
@@ -1418,25 +1347,23 @@ extern SV * DPPP_(my_newSV_type)(pTHX_ svtype const t);
 #endif
 #ifndef newSVpvn_flags
 #if defined(NEED_newSVpvn_flags)
-static SV * DPPP_(my_newSVpvn_flags)(pTHX_ const char * s, STRLEN len, U32 flags);
+static SV * DPPP_(my_newSVpvn_flags)(pTHX_ const char *s, STRLEN len, U32 flags);
 static
 #else
-extern SV * DPPP_(my_newSVpvn_flags)(pTHX_ const char * s, STRLEN len, U32 flags);
+extern SV * DPPP_(my_newSVpvn_flags)(pTHX_ const char *s, STRLEN len, U32 flags);
 #endif
 #ifdef newSVpvn_flags
 #undef newSVpvn_flags
 #endif
-#define newSVpvn_flags(a, b, c) \
-	DPPP_(my_newSVpvn_flags)    \
-	(aTHX_ a, b, c)
+#define newSVpvn_flags(a,b,c) DPPP_(my_newSVpvn_flags)(aTHX_ a,b,c)
 #define Perl_newSVpvn_flags DPPP_(my_newSVpvn_flags)
 #if defined(NEED_newSVpvn_flags) || defined(NEED_newSVpvn_flags_GLOBAL)
-    SV *
-        DPPP_(my_newSVpvn_flags)(pTHX_ const char * s, STRLEN len, U32 flags)
+SV *
+DPPP_(my_newSVpvn_flags)(pTHX_ const char *s, STRLEN len, U32 flags)
 {
-	SV * sv = newSVpvn(D_PPP_CONSTPV_ARG(s), len);
-	SvFLAGS(sv) |= (flags & SVf_UTF8);
-	return (flags & SVs_TEMP) ? sv_2mortal(sv) : sv;
+SV *sv = newSVpvn(D_PPP_CONSTPV_ARG(s), len);
+SvFLAGS(sv) |= (flags & SVf_UTF8);
+return (flags & SVs_TEMP) ? sv_2mortal(sv) : sv;
 }
 #endif
 #endif
@@ -1450,33 +1377,30 @@ extern SV * DPPP_(my_newSVpvn_flags)(pTHX_ const char * s, STRLEN len, U32 flags
 #define sv_2pv_nolen(sv) SvPV_nolen(sv)
 #endif
 #ifdef SvPVbyte
-#if(PERL_BCDVERSION < 0x5007000)
+#if (PERL_BCDVERSION < 0x5007000)
 #if defined(NEED_sv_2pvbyte)
-static char * DPPP_(my_sv_2pvbyte)(pTHX_ SV * sv, STRLEN * lp);
+static char * DPPP_(my_sv_2pvbyte)(pTHX_ SV *sv, STRLEN *lp);
 static
 #else
-extern char * DPPP_(my_sv_2pvbyte)(pTHX_ SV * sv, STRLEN * lp);
+extern char * DPPP_(my_sv_2pvbyte)(pTHX_ SV *sv, STRLEN *lp);
 #endif
 #ifdef sv_2pvbyte
 #undef sv_2pvbyte
 #endif
-#define sv_2pvbyte(a, b) \
-	DPPP_(my_sv_2pvbyte) \
-	(aTHX_ a, b)
+#define sv_2pvbyte(a,b) DPPP_(my_sv_2pvbyte)(aTHX_ a,b)
 #define Perl_sv_2pvbyte DPPP_(my_sv_2pvbyte)
 #if defined(NEED_sv_2pvbyte) || defined(NEED_sv_2pvbyte_GLOBAL)
-    char *
-        DPPP_(my_sv_2pvbyte)(pTHX_ SV * sv, STRLEN * lp)
+char *
+DPPP_(my_sv_2pvbyte)(pTHX_ SV *sv, STRLEN *lp)
 {
-	sv_utf8_downgrade(sv, 0);
-	return SvPV(sv, *lp);
+sv_utf8_downgrade(sv,0);
+return SvPV(sv,*lp);
 }
 #endif
 #undef SvPVbyte
-#define SvPVbyte(sv, lp)                               \
-	((SvFLAGS(sv) & (SVf_POK | SVf_UTF8)) == (SVf_POK) \
-	        ? ((lp = SvCUR(sv)), SvPVX(sv))            \
-	        : sv_2pvbyte(sv, &lp))
+#define SvPVbyte(sv, lp) \
+((SvFLAGS(sv) & (SVf_POK|SVf_UTF8)) == (SVf_POK) \
+? ((lp = SvCUR(sv)), SvPVX(sv)) : sv_2pvbyte(sv, &lp))
 #endif
 #else
 #define SvPVbyte SvPV
@@ -1515,51 +1439,47 @@ extern char * DPPP_(my_sv_2pvbyte)(pTHX_ SV * sv, STRLEN * lp);
 #ifndef SV_COW_SHARED_HASH_KEYS
 #define SV_COW_SHARED_HASH_KEYS 0
 #endif
-#if(PERL_BCDVERSION < 0x5007002)
+#if (PERL_BCDVERSION < 0x5007002)
 #if defined(NEED_sv_2pv_flags)
-static char * DPPP_(my_sv_2pv_flags)(pTHX_ SV * sv, STRLEN * lp, I32 flags);
+static char * DPPP_(my_sv_2pv_flags)(pTHX_ SV *sv, STRLEN *lp, I32 flags);
 static
 #else
-extern char * DPPP_(my_sv_2pv_flags)(pTHX_ SV * sv, STRLEN * lp, I32 flags);
+extern char * DPPP_(my_sv_2pv_flags)(pTHX_ SV *sv, STRLEN *lp, I32 flags);
 #endif
 #ifdef sv_2pv_flags
 #undef sv_2pv_flags
 #endif
-#define sv_2pv_flags(a, b, c) \
-	DPPP_(my_sv_2pv_flags)    \
-	(aTHX_ a, b, c)
+#define sv_2pv_flags(a,b,c) DPPP_(my_sv_2pv_flags)(aTHX_ a,b,c)
 #define Perl_sv_2pv_flags DPPP_(my_sv_2pv_flags)
 #if defined(NEED_sv_2pv_flags) || defined(NEED_sv_2pv_flags_GLOBAL)
-    char *
-        DPPP_(my_sv_2pv_flags)(pTHX_ SV * sv, STRLEN * lp, I32 flags)
+char *
+DPPP_(my_sv_2pv_flags)(pTHX_ SV *sv, STRLEN *lp, I32 flags)
 {
-	STRLEN n_a = (STRLEN)flags;
-	return sv_2pv(sv, lp ? lp : &n_a);
+STRLEN n_a = (STRLEN) flags;
+return sv_2pv(sv, lp ? lp : &n_a);
 }
 #endif
 #if defined(NEED_sv_pvn_force_flags)
-static char * DPPP_(my_sv_pvn_force_flags)(pTHX_ SV * sv, STRLEN * lp, I32 flags);
+static char * DPPP_(my_sv_pvn_force_flags)(pTHX_ SV *sv, STRLEN *lp, I32 flags);
 static
 #else
-extern char * DPPP_(my_sv_pvn_force_flags)(pTHX_ SV * sv, STRLEN * lp, I32 flags);
+extern char * DPPP_(my_sv_pvn_force_flags)(pTHX_ SV *sv, STRLEN *lp, I32 flags);
 #endif
 #ifdef sv_pvn_force_flags
 #undef sv_pvn_force_flags
 #endif
-#define sv_pvn_force_flags(a, b, c) \
-	DPPP_(my_sv_pvn_force_flags)    \
-	(aTHX_ a, b, c)
+#define sv_pvn_force_flags(a,b,c) DPPP_(my_sv_pvn_force_flags)(aTHX_ a,b,c)
 #define Perl_sv_pvn_force_flags DPPP_(my_sv_pvn_force_flags)
 #if defined(NEED_sv_pvn_force_flags) || defined(NEED_sv_pvn_force_flags_GLOBAL)
-    char *
-        DPPP_(my_sv_pvn_force_flags)(pTHX_ SV * sv, STRLEN * lp, I32 flags)
+char *
+DPPP_(my_sv_pvn_force_flags)(pTHX_ SV *sv, STRLEN *lp, I32 flags)
 {
-	STRLEN n_a = (STRLEN)flags;
-	return sv_pvn_force(sv, lp ? lp : &n_a);
+STRLEN n_a = (STRLEN) flags;
+return sv_pvn_force(sv, lp ? lp : &n_a);
 }
 #endif
 #endif
-#if(PERL_BCDVERSION < 0x5008008) || ((PERL_BCDVERSION >= 0x5009000) && (PERL_BCDVERSION < 0x5009003))
+#if (PERL_BCDVERSION < 0x5008008) || ( (PERL_BCDVERSION >= 0x5009000) && (PERL_BCDVERSION < 0x5009003) )
 #define DPPP_SVPV_NOLEN_LP_ARG &PL_na
 #else
 #define DPPP_SVPV_NOLEN_LP_ARG 0
@@ -1571,28 +1491,27 @@ extern char * DPPP_(my_sv_pvn_force_flags)(pTHX_ SV * sv, STRLEN * lp, I32 flags
 #define SvPV_mutable(sv, lp) SvPV_flags_mutable(sv, lp, SV_GMAGIC)
 #endif
 #ifndef SvPV_flags
-#define SvPV_flags(sv, lp, flags)           \
-	((SvFLAGS(sv) & (SVf_POK)) == SVf_POK   \
-	        ? ((lp = SvCUR(sv)), SvPVX(sv)) \
-	        : sv_2pv_flags(sv, &lp, flags))
+#define SvPV_flags(sv, lp, flags) \
+((SvFLAGS(sv) & (SVf_POK)) == SVf_POK \
+? ((lp = SvCUR(sv)), SvPVX(sv)) : sv_2pv_flags(sv, &lp, flags))
 #endif
 #ifndef SvPV_flags_const
-#define SvPV_flags_const(sv, lp, flags)           \
-	((SvFLAGS(sv) & (SVf_POK)) == SVf_POK         \
-	        ? ((lp = SvCUR(sv)), SvPVX_const(sv)) \
-	        : (const char *)sv_2pv_flags(sv, &lp, flags | SV_CONST_RETURN))
+#define SvPV_flags_const(sv, lp, flags) \
+((SvFLAGS(sv) & (SVf_POK)) == SVf_POK \
+? ((lp = SvCUR(sv)), SvPVX_const(sv)) : \
+(const char*) sv_2pv_flags(sv, &lp, flags|SV_CONST_RETURN))
 #endif
 #ifndef SvPV_flags_const_nolen
 #define SvPV_flags_const_nolen(sv, flags) \
-	((SvFLAGS(sv) & (SVf_POK)) == SVf_POK \
-	        ? SvPVX_const(sv)             \
-	        : (const char *)sv_2pv_flags(sv, DPPP_SVPV_NOLEN_LP_ARG, flags | SV_CONST_RETURN))
+((SvFLAGS(sv) & (SVf_POK)) == SVf_POK \
+? SvPVX_const(sv) : \
+(const char*) sv_2pv_flags(sv, DPPP_SVPV_NOLEN_LP_ARG, flags|SV_CONST_RETURN))
 #endif
 #ifndef SvPV_flags_mutable
-#define SvPV_flags_mutable(sv, lp, flags)           \
-	((SvFLAGS(sv) & (SVf_POK)) == SVf_POK           \
-	        ? ((lp = SvCUR(sv)), SvPVX_mutable(sv)) \
-	        : sv_2pv_flags(sv, &lp, flags | SV_MUTABLE_RETURN))
+#define SvPV_flags_mutable(sv, lp, flags) \
+((SvFLAGS(sv) & (SVf_POK)) == SVf_POK \
+? ((lp = SvCUR(sv)), SvPVX_mutable(sv)) : \
+sv_2pv_flags(sv, &lp, flags|SV_MUTABLE_RETURN))
 #endif
 #ifndef SvPV_force
 #define SvPV_force(sv, lp) SvPV_force_flags(sv, lp, SV_GMAGIC)
@@ -1610,34 +1529,30 @@ extern char * DPPP_(my_sv_pvn_force_flags)(pTHX_ SV * sv, STRLEN * lp, I32 flags
 #define SvPV_force_nomg_nolen(sv) SvPV_force_flags_nolen(sv, 0)
 #endif
 #ifndef SvPV_force_flags
-#define SvPV_force_flags(sv, lp, flags)                    \
-	((SvFLAGS(sv) & (SVf_POK | SVf_THINKFIRST)) == SVf_POK \
-	        ? ((lp = SvCUR(sv)), SvPVX(sv))                \
-	        : sv_pvn_force_flags(sv, &lp, flags))
+#define SvPV_force_flags(sv, lp, flags) \
+((SvFLAGS(sv) & (SVf_POK|SVf_THINKFIRST)) == SVf_POK \
+? ((lp = SvCUR(sv)), SvPVX(sv)) : sv_pvn_force_flags(sv, &lp, flags))
 #endif
 #ifndef SvPV_force_flags_nolen
-#define SvPV_force_flags_nolen(sv, flags)                  \
-	((SvFLAGS(sv) & (SVf_POK | SVf_THINKFIRST)) == SVf_POK \
-	        ? SvPVX(sv)                                    \
-	        : sv_pvn_force_flags(sv, DPPP_SVPV_NOLEN_LP_ARG, flags))
+#define SvPV_force_flags_nolen(sv, flags) \
+((SvFLAGS(sv) & (SVf_POK|SVf_THINKFIRST)) == SVf_POK \
+? SvPVX(sv) : sv_pvn_force_flags(sv, DPPP_SVPV_NOLEN_LP_ARG, flags))
 #endif
 #ifndef SvPV_force_flags_mutable
-#define SvPV_force_flags_mutable(sv, lp, flags)            \
-	((SvFLAGS(sv) & (SVf_POK | SVf_THINKFIRST)) == SVf_POK \
-	        ? ((lp = SvCUR(sv)), SvPVX_mutable(sv))        \
-	        : sv_pvn_force_flags(sv, &lp, flags | SV_MUTABLE_RETURN))
+#define SvPV_force_flags_mutable(sv, lp, flags) \
+((SvFLAGS(sv) & (SVf_POK|SVf_THINKFIRST)) == SVf_POK \
+? ((lp = SvCUR(sv)), SvPVX_mutable(sv)) \
+: sv_pvn_force_flags(sv, &lp, flags|SV_MUTABLE_RETURN))
 #endif
 #ifndef SvPV_nolen
-#define SvPV_nolen(sv)                    \
-	((SvFLAGS(sv) & (SVf_POK)) == SVf_POK \
-	        ? SvPVX(sv)                   \
-	        : sv_2pv_flags(sv, DPPP_SVPV_NOLEN_LP_ARG, SV_GMAGIC))
+#define SvPV_nolen(sv) \
+((SvFLAGS(sv) & (SVf_POK)) == SVf_POK \
+? SvPVX(sv) : sv_2pv_flags(sv, DPPP_SVPV_NOLEN_LP_ARG, SV_GMAGIC))
 #endif
 #ifndef SvPV_nolen_const
-#define SvPV_nolen_const(sv)              \
-	((SvFLAGS(sv) & (SVf_POK)) == SVf_POK \
-	        ? SvPVX_const(sv)             \
-	        : sv_2pv_flags(sv, DPPP_SVPV_NOLEN_LP_ARG, SV_GMAGIC | SV_CONST_RETURN))
+#define SvPV_nolen_const(sv) \
+((SvFLAGS(sv) & (SVf_POK)) == SVf_POK \
+? SvPVX_const(sv) : sv_2pv_flags(sv, DPPP_SVPV_NOLEN_LP_ARG, SV_GMAGIC|SV_CONST_RETURN))
 #endif
 #ifndef SvPV_nomg
 #define SvPV_nomg(sv, lp) SvPV_flags(sv, lp, 0)
@@ -1650,161 +1565,130 @@ extern char * DPPP_(my_sv_pvn_force_flags)(pTHX_ SV * sv, STRLEN * lp, I32 flags
 #endif
 #ifndef SvPV_nomg_nolen
 #define SvPV_nomg_nolen(sv) ((SvFLAGS(sv) & (SVf_POK)) == SVf_POK \
-        ? SvPVX(sv)                                               \
-        : sv_2pv_flags(sv, DPPP_SVPV_NOLEN_LP_ARG, 0))
+? SvPVX(sv) : sv_2pv_flags(sv, DPPP_SVPV_NOLEN_LP_ARG, 0))
 #endif
 #ifndef SvPV_renew
-#define SvPV_renew(sv, n)                                          \
-	STMT_START                                                     \
-	{                                                              \
-		SvLEN_set(sv, n);                                          \
-		SvPV_set((sv), (char *)saferealloc(                        \
-		                   (Malloc_t)SvPVX(sv), (MEM_SIZE)((n)))); \
-	}                                                              \
-	STMT_END
+#define SvPV_renew(sv,n) STMT_START { SvLEN_set(sv, n); \
+SvPV_set((sv), (char *) saferealloc( \
+(Malloc_t)SvPVX(sv), (MEM_SIZE)((n)))); \
+} STMT_END
 #endif
 #ifndef SvMAGIC_set
-#define SvMAGIC_set(sv, val)                       \
-	STMT_START                                     \
-	{                                              \
-		assert(SvTYPE(sv) >= SVt_PVMG);            \
-		(((XPVMG *)SvANY(sv))->xmg_magic = (val)); \
-	}                                              \
-	STMT_END
+#define SvMAGIC_set(sv, val) \
+STMT_START { assert(SvTYPE(sv) >= SVt_PVMG); \
+(((XPVMG*) SvANY(sv))->xmg_magic = (val)); } STMT_END
 #endif
-#if(PERL_BCDVERSION < 0x5009003)
+#if (PERL_BCDVERSION < 0x5009003)
 #ifndef SvPVX_const
-#define SvPVX_const(sv) ((const char *)(0 + SvPVX(sv)))
+#define SvPVX_const(sv) ((const char*) (0 + SvPVX(sv)))
 #endif
 #ifndef SvPVX_mutable
 #define SvPVX_mutable(sv) (0 + SvPVX(sv))
 #endif
 #ifndef SvRV_set
-#define SvRV_set(sv, val)                     \
-	STMT_START                                \
-	{                                         \
-		assert(SvTYPE(sv) >= SVt_RV);         \
-		(((XRV *)SvANY(sv))->xrv_rv = (val)); \
-	}                                         \
-	STMT_END
+#define SvRV_set(sv, val) \
+STMT_START { assert(SvTYPE(sv) >= SVt_RV); \
+(((XRV*) SvANY(sv))->xrv_rv = (val)); } STMT_END
 #endif
 #else
 #ifndef SvPVX_const
-#define SvPVX_const(sv) ((const char *)((sv)->sv_u.svu_pv))
+#define SvPVX_const(sv) ((const char*)((sv)->sv_u.svu_pv))
 #endif
 #ifndef SvPVX_mutable
 #define SvPVX_mutable(sv) ((sv)->sv_u.svu_pv)
 #endif
 #ifndef SvRV_set
-#define SvRV_set(sv, val)             \
-	STMT_START                        \
-	{                                 \
-		assert(SvTYPE(sv) >= SVt_RV); \
-		((sv)->sv_u.svu_rv = (val));  \
-	}                                 \
-	STMT_END
+#define SvRV_set(sv, val) \
+STMT_START { assert(SvTYPE(sv) >= SVt_RV); \
+((sv)->sv_u.svu_rv = (val)); } STMT_END
 #endif
 #endif
 #ifndef SvSTASH_set
-#define SvSTASH_set(sv, val)                       \
-	STMT_START                                     \
-	{                                              \
-		assert(SvTYPE(sv) >= SVt_PVMG);            \
-		(((XPVMG *)SvANY(sv))->xmg_stash = (val)); \
-	}                                              \
-	STMT_END
+#define SvSTASH_set(sv, val) \
+STMT_START { assert(SvTYPE(sv) >= SVt_PVMG); \
+(((XPVMG*) SvANY(sv))->xmg_stash = (val)); } STMT_END
 #endif
-#if(PERL_BCDVERSION < 0x5004000)
+#if (PERL_BCDVERSION < 0x5004000)
 #ifndef SvUV_set
-#define SvUV_set(sv, val)                                       \
-	STMT_START                                                  \
-	{                                                           \
-		assert(SvTYPE(sv) == SVt_IV || SvTYPE(sv) >= SVt_PVIV); \
-		(((XPVIV *)SvANY(sv))->xiv_iv = (IV)(val));             \
-	}                                                           \
-	STMT_END
+#define SvUV_set(sv, val) \
+STMT_START { assert(SvTYPE(sv) == SVt_IV || SvTYPE(sv) >= SVt_PVIV); \
+(((XPVIV*) SvANY(sv))->xiv_iv = (IV) (val)); } STMT_END
 #endif
 #else
 #ifndef SvUV_set
-#define SvUV_set(sv, val)                                       \
-	STMT_START                                                  \
-	{                                                           \
-		assert(SvTYPE(sv) == SVt_IV || SvTYPE(sv) >= SVt_PVIV); \
-		(((XPVUV *)SvANY(sv))->xuv_uv = (val));                 \
-	}                                                           \
-	STMT_END
+#define SvUV_set(sv, val) \
+STMT_START { assert(SvTYPE(sv) == SVt_IV || SvTYPE(sv) >= SVt_PVIV); \
+(((XPVUV*) SvANY(sv))->xuv_uv = (val)); } STMT_END
 #endif
 #endif
-#if(PERL_BCDVERSION >= 0x5004000) && !defined(vnewSVpvf)
+#if (PERL_BCDVERSION >= 0x5004000) && !defined(vnewSVpvf)
 #if defined(NEED_vnewSVpvf)
-static SV * DPPP_(my_vnewSVpvf)(pTHX_ const char * pat, va_list * args);
+static SV * DPPP_(my_vnewSVpvf)(pTHX_ const char *pat, va_list *args);
 static
 #else
-extern SV * DPPP_(my_vnewSVpvf)(pTHX_ const char * pat, va_list * args);
+extern SV * DPPP_(my_vnewSVpvf)(pTHX_ const char *pat, va_list *args);
 #endif
 #ifdef vnewSVpvf
 #undef vnewSVpvf
 #endif
-#define vnewSVpvf(a, b) \
-	DPPP_(my_vnewSVpvf) \
-	(aTHX_ a, b)
+#define vnewSVpvf(a,b) DPPP_(my_vnewSVpvf)(aTHX_ a,b)
 #define Perl_vnewSVpvf DPPP_(my_vnewSVpvf)
 #if defined(NEED_vnewSVpvf) || defined(NEED_vnewSVpvf_GLOBAL)
-    SV *
-        DPPP_(my_vnewSVpvf)(pTHX_ const char * pat, va_list * args)
+SV *
+DPPP_(my_vnewSVpvf)(pTHX_ const char *pat, va_list *args)
 {
-	register SV * sv = newSV(0);
-	sv_vsetpvfn(sv, pat, strlen(pat), args, Null(SV **), 0, Null(bool *));
-	return sv;
+register SV *sv = newSV(0);
+sv_vsetpvfn(sv, pat, strlen(pat), args, Null(SV**), 0, Null(bool*));
+return sv;
 }
 #endif
 #endif
-#if(PERL_BCDVERSION >= 0x5004000) && !defined(sv_vcatpvf)
-#define sv_vcatpvf(sv, pat, args) sv_vcatpvfn(sv, pat, strlen(pat), args, Null(SV **), 0, Null(bool *))
+#if (PERL_BCDVERSION >= 0x5004000) && !defined(sv_vcatpvf)
+#define sv_vcatpvf(sv, pat, args) sv_vcatpvfn(sv, pat, strlen(pat), args, Null(SV**), 0, Null(bool*))
 #endif
-#if(PERL_BCDVERSION >= 0x5004000) && !defined(sv_vsetpvf)
-#define sv_vsetpvf(sv, pat, args) sv_vsetpvfn(sv, pat, strlen(pat), args, Null(SV **), 0, Null(bool *))
+#if (PERL_BCDVERSION >= 0x5004000) && !defined(sv_vsetpvf)
+#define sv_vsetpvf(sv, pat, args) sv_vsetpvfn(sv, pat, strlen(pat), args, Null(SV**), 0, Null(bool*))
 #endif
-#if(PERL_BCDVERSION >= 0x5004000) && !defined(sv_catpvf_mg)
+#if (PERL_BCDVERSION >= 0x5004000) && !defined(sv_catpvf_mg)
 #if defined(NEED_sv_catpvf_mg)
-static void DPPP_(my_sv_catpvf_mg)(pTHX_ SV * sv, const char * pat, ...);
+static void DPPP_(my_sv_catpvf_mg)(pTHX_ SV *sv, const char *pat, ...);
 static
 #else
-extern void DPPP_(my_sv_catpvf_mg)(pTHX_ SV * sv, const char * pat, ...);
+extern void DPPP_(my_sv_catpvf_mg)(pTHX_ SV *sv, const char *pat, ...);
 #endif
 #define Perl_sv_catpvf_mg DPPP_(my_sv_catpvf_mg)
 #if defined(NEED_sv_catpvf_mg) || defined(NEED_sv_catpvf_mg_GLOBAL)
-    void
-        DPPP_(my_sv_catpvf_mg)(pTHX_ SV * sv, const char * pat, ...)
+void
+DPPP_(my_sv_catpvf_mg)(pTHX_ SV *sv, const char *pat, ...)
 {
-	va_list args;
-	va_start(args, pat);
-	sv_vcatpvfn(sv, pat, strlen(pat), &args, Null(SV **), 0, Null(bool *));
-	SvSETMAGIC(sv);
-	va_end(args);
+va_list args;
+va_start(args, pat);
+sv_vcatpvfn(sv, pat, strlen(pat), &args, Null(SV**), 0, Null(bool*));
+SvSETMAGIC(sv);
+va_end(args);
 }
 #endif
 #endif
 #ifdef PERL_IMPLICIT_CONTEXT
-#if(PERL_BCDVERSION >= 0x5004000) && !defined(sv_catpvf_mg_nocontext)
+#if (PERL_BCDVERSION >= 0x5004000) && !defined(sv_catpvf_mg_nocontext)
 #if defined(NEED_sv_catpvf_mg_nocontext)
-static void DPPP_(my_sv_catpvf_mg_nocontext)(SV * sv, const char * pat, ...);
+static void DPPP_(my_sv_catpvf_mg_nocontext)(SV *sv, const char *pat, ...);
 static
 #else
-extern void DPPP_(my_sv_catpvf_mg_nocontext)(SV * sv, const char * pat, ...);
+extern void DPPP_(my_sv_catpvf_mg_nocontext)(SV *sv, const char *pat, ...);
 #endif
 #define sv_catpvf_mg_nocontext DPPP_(my_sv_catpvf_mg_nocontext)
 #define Perl_sv_catpvf_mg_nocontext DPPP_(my_sv_catpvf_mg_nocontext)
 #if defined(NEED_sv_catpvf_mg_nocontext) || defined(NEED_sv_catpvf_mg_nocontext_GLOBAL)
-    void
-        DPPP_(my_sv_catpvf_mg_nocontext)(SV * sv, const char * pat, ...)
+void
+DPPP_(my_sv_catpvf_mg_nocontext)(SV *sv, const char *pat, ...)
 {
-	dTHX;
-	va_list args;
-	va_start(args, pat);
-	sv_vcatpvfn(sv, pat, strlen(pat), &args, Null(SV **), 0, Null(bool *));
-	SvSETMAGIC(sv);
-	va_end(args);
+dTHX;
+va_list args;
+va_start(args, pat);
+sv_vcatpvfn(sv, pat, strlen(pat), &args, Null(SV**), 0, Null(bool*));
+SvSETMAGIC(sv);
+va_end(args);
 }
 #endif
 #endif
@@ -1816,55 +1700,53 @@ extern void DPPP_(my_sv_catpvf_mg_nocontext)(SV * sv, const char * pat, ...);
 #define sv_catpvf_mg Perl_sv_catpvf_mg
 #endif
 #endif
-#if(PERL_BCDVERSION >= 0x5004000) && !defined(sv_vcatpvf_mg)
-#define sv_vcatpvf_mg(sv, pat, args)                                           \
-	STMT_START                                                                 \
-	{                                                                          \
-		sv_vcatpvfn(sv, pat, strlen(pat), args, Null(SV **), 0, Null(bool *)); \
-		SvSETMAGIC(sv);                                                        \
-	}                                                                          \
-	STMT_END
+#if (PERL_BCDVERSION >= 0x5004000) && !defined(sv_vcatpvf_mg)
+#define sv_vcatpvf_mg(sv, pat, args) \
+STMT_START { \
+sv_vcatpvfn(sv, pat, strlen(pat), args, Null(SV**), 0, Null(bool*)); \
+SvSETMAGIC(sv); \
+} STMT_END
 #endif
-#if(PERL_BCDVERSION >= 0x5004000) && !defined(sv_setpvf_mg)
+#if (PERL_BCDVERSION >= 0x5004000) && !defined(sv_setpvf_mg)
 #if defined(NEED_sv_setpvf_mg)
-static void DPPP_(my_sv_setpvf_mg)(pTHX_ SV * sv, const char * pat, ...);
+static void DPPP_(my_sv_setpvf_mg)(pTHX_ SV *sv, const char *pat, ...);
 static
 #else
-extern void DPPP_(my_sv_setpvf_mg)(pTHX_ SV * sv, const char * pat, ...);
+extern void DPPP_(my_sv_setpvf_mg)(pTHX_ SV *sv, const char *pat, ...);
 #endif
 #define Perl_sv_setpvf_mg DPPP_(my_sv_setpvf_mg)
 #if defined(NEED_sv_setpvf_mg) || defined(NEED_sv_setpvf_mg_GLOBAL)
-    void
-        DPPP_(my_sv_setpvf_mg)(pTHX_ SV * sv, const char * pat, ...)
+void
+DPPP_(my_sv_setpvf_mg)(pTHX_ SV *sv, const char *pat, ...)
 {
-	va_list args;
-	va_start(args, pat);
-	sv_vsetpvfn(sv, pat, strlen(pat), &args, Null(SV **), 0, Null(bool *));
-	SvSETMAGIC(sv);
-	va_end(args);
+va_list args;
+va_start(args, pat);
+sv_vsetpvfn(sv, pat, strlen(pat), &args, Null(SV**), 0, Null(bool*));
+SvSETMAGIC(sv);
+va_end(args);
 }
 #endif
 #endif
 #ifdef PERL_IMPLICIT_CONTEXT
-#if(PERL_BCDVERSION >= 0x5004000) && !defined(sv_setpvf_mg_nocontext)
+#if (PERL_BCDVERSION >= 0x5004000) && !defined(sv_setpvf_mg_nocontext)
 #if defined(NEED_sv_setpvf_mg_nocontext)
-static void DPPP_(my_sv_setpvf_mg_nocontext)(SV * sv, const char * pat, ...);
+static void DPPP_(my_sv_setpvf_mg_nocontext)(SV *sv, const char *pat, ...);
 static
 #else
-extern void DPPP_(my_sv_setpvf_mg_nocontext)(SV * sv, const char * pat, ...);
+extern void DPPP_(my_sv_setpvf_mg_nocontext)(SV *sv, const char *pat, ...);
 #endif
 #define sv_setpvf_mg_nocontext DPPP_(my_sv_setpvf_mg_nocontext)
 #define Perl_sv_setpvf_mg_nocontext DPPP_(my_sv_setpvf_mg_nocontext)
 #if defined(NEED_sv_setpvf_mg_nocontext) || defined(NEED_sv_setpvf_mg_nocontext_GLOBAL)
-    void
-        DPPP_(my_sv_setpvf_mg_nocontext)(SV * sv, const char * pat, ...)
+void
+DPPP_(my_sv_setpvf_mg_nocontext)(SV *sv, const char *pat, ...)
 {
-	dTHX;
-	va_list args;
-	va_start(args, pat);
-	sv_vsetpvfn(sv, pat, strlen(pat), &args, Null(SV **), 0, Null(bool *));
-	SvSETMAGIC(sv);
-	va_end(args);
+dTHX;
+va_list args;
+va_start(args, pat);
+sv_vsetpvfn(sv, pat, strlen(pat), &args, Null(SV**), 0, Null(bool*));
+SvSETMAGIC(sv);
+va_end(args);
 }
 #endif
 #endif
@@ -1876,44 +1758,40 @@ extern void DPPP_(my_sv_setpvf_mg_nocontext)(SV * sv, const char * pat, ...);
 #define sv_setpvf_mg Perl_sv_setpvf_mg
 #endif
 #endif
-#if(PERL_BCDVERSION >= 0x5004000) && !defined(sv_vsetpvf_mg)
-#define sv_vsetpvf_mg(sv, pat, args)                                           \
-	STMT_START                                                                 \
-	{                                                                          \
-		sv_vsetpvfn(sv, pat, strlen(pat), args, Null(SV **), 0, Null(bool *)); \
-		SvSETMAGIC(sv);                                                        \
-	}                                                                          \
-	STMT_END
+#if (PERL_BCDVERSION >= 0x5004000) && !defined(sv_vsetpvf_mg)
+#define sv_vsetpvf_mg(sv, pat, args) \
+STMT_START { \
+sv_vsetpvfn(sv, pat, strlen(pat), args, Null(SV**), 0, Null(bool*)); \
+SvSETMAGIC(sv); \
+} STMT_END
 #endif
 #ifndef newSVpvn_share
 #if defined(NEED_newSVpvn_share)
-static SV * DPPP_(my_newSVpvn_share)(pTHX_ const char * src, I32 len, U32 hash);
+static SV * DPPP_(my_newSVpvn_share)(pTHX_ const char *src, I32 len, U32 hash);
 static
 #else
-extern SV * DPPP_(my_newSVpvn_share)(pTHX_ const char * src, I32 len, U32 hash);
+extern SV * DPPP_(my_newSVpvn_share)(pTHX_ const char *src, I32 len, U32 hash);
 #endif
 #ifdef newSVpvn_share
 #undef newSVpvn_share
 #endif
-#define newSVpvn_share(a, b, c) \
-	DPPP_(my_newSVpvn_share)    \
-	(aTHX_ a, b, c)
+#define newSVpvn_share(a,b,c) DPPP_(my_newSVpvn_share)(aTHX_ a,b,c)
 #define Perl_newSVpvn_share DPPP_(my_newSVpvn_share)
 #if defined(NEED_newSVpvn_share) || defined(NEED_newSVpvn_share_GLOBAL)
-    SV *
-        DPPP_(my_newSVpvn_share)(pTHX_ const char * src, I32 len, U32 hash)
+SV *
+DPPP_(my_newSVpvn_share)(pTHX_ const char *src, I32 len, U32 hash)
 {
-	SV * sv;
-	if(len < 0)
-		len = -len;
-	if(!hash)
-		PERL_HASH(hash, (char *)src, len);
-	sv = newSVpvn((char *)src, len);
-	sv_upgrade(sv, SVt_PVIV);
-	SvIVX(sv) = hash;
-	SvREADONLY_on(sv);
-	SvPOK_on(sv);
-	return sv;
+SV *sv;
+if (len < 0)
+len = -len;
+if (!hash)
+PERL_HASH(hash, (char*) src, len);
+sv = newSVpvn((char *) src, len);
+sv_upgrade(sv, SVt_PVIV);
+SvIVX(sv) = hash;
+SvREADONLY_on(sv);
+SvPOK_on(sv);
+return sv;
 }
 #endif
 #endif
@@ -2092,33 +1970,33 @@ extern SV * DPPP_(my_newSVpvn_share)(pTHX_ const char * src, I32 len, U32 hash);
 #define ckWARN(a) PL_dowarn
 #endif
 #endif
-#if(PERL_BCDVERSION >= 0x5004000) && !defined(warner)
+#if (PERL_BCDVERSION >= 0x5004000) && !defined(warner)
 #if defined(NEED_warner)
-static void DPPP_(my_warner)(U32 err, const char * pat, ...);
+static void DPPP_(my_warner)(U32 err, const char *pat, ...);
 static
 #else
-extern void DPPP_(my_warner)(U32 err, const char * pat, ...);
+extern void DPPP_(my_warner)(U32 err, const char *pat, ...);
 #endif
 #define Perl_warner DPPP_(my_warner)
 #if defined(NEED_warner) || defined(NEED_warner_GLOBAL)
-    void
-        DPPP_(my_warner)(U32 err, const char * pat, ...)
+void
+DPPP_(my_warner)(U32 err, const char *pat, ...)
 {
-	SV * sv;
-	va_list args;
-	PERL_UNUSED_ARG(err);
-	va_start(args, pat);
-	sv = vnewSVpvf(pat, &args);
-	va_end(args);
-	sv_2mortal(sv);
-	warn("%s", SvPV_nolen(sv));
+SV *sv;
+va_list args;
+PERL_UNUSED_ARG(err);
+va_start(args, pat);
+sv = vnewSVpvf(pat, &args);
+va_end(args);
+sv_2mortal(sv);
+warn("%s", SvPV_nolen(sv));
 }
 #define warner Perl_warner
 #define Perl_warner_nocontext Perl_warner
 #endif
 #endif
 #ifndef STR_WITH_LEN
-#define STR_WITH_LEN(s) (s ""), (sizeof(s) - 1)
+#define STR_WITH_LEN(s) (s ""), (sizeof(s)-1)
 #endif
 #ifndef newSVpvs
 #define newSVpvs(str) newSVpvn(str "", sizeof(str) - 1)
@@ -2148,28 +2026,18 @@ extern void DPPP_(my_warner)(U32 err, const char * pat, ...);
 #define gv_stashpvs(name, flags) gv_stashpvn(name "", sizeof(name) - 1, flags)
 #endif
 #ifndef get_cvs
-#define get_cvs(name, flags) get_cvn_flags(name "", sizeof(name) - 1, flags)
+#define get_cvs(name, flags) get_cvn_flags(name "", sizeof(name)-1, flags)
 #endif
 #ifndef SvGETMAGIC
-#define SvGETMAGIC(x)     \
-	STMT_START            \
-	{                     \
-		if(SvGMAGICAL(x)) \
-			mg_get(x);    \
-	}                     \
-	STMT_END
+#define SvGETMAGIC(x) STMT_START { if (SvGMAGICAL(x)) mg_get(x); } STMT_END
 #endif
 #ifndef HEf_SVKEY
 #define HEf_SVKEY -2
 #endif
 #if defined(__GNUC__) && !defined(PERL_GCC_BRACE_GROUPS_FORBIDDEN)
-#define MUTABLE_PTR(p) ( \
-    {                    \
-		void * _p = (p); \
-		_p;              \
-	})
+#define MUTABLE_PTR(p) ({ void *_p = (p); _p; })
 #else
-#define MUTABLE_PTR(p) ((void *)(p))
+#define MUTABLE_PTR(p) ((void *) (p))
 #endif
 #define MUTABLE_SV(p) ((SV *)MUTABLE_PTR(p))
 #ifndef PERL_MAGIC_sv
@@ -2308,159 +2176,134 @@ extern void DPPP_(my_warner)(U32 err, const char * pat, ...);
 #define SvUV_nomg SvUV
 #endif
 #ifndef sv_catpv_mg
-#define sv_catpv_mg(sv, ptr)   \
-	STMT_START                 \
-	{                          \
-		SV * TeMpSv = sv;      \
-		sv_catpv(TeMpSv, ptr); \
-		SvSETMAGIC(TeMpSv);    \
-	}                          \
-	STMT_END
+#define sv_catpv_mg(sv, ptr) \
+STMT_START { \
+SV *TeMpSv = sv; \
+sv_catpv(TeMpSv,ptr); \
+SvSETMAGIC(TeMpSv); \
+} STMT_END
 #endif
 #ifndef sv_catpvn_mg
-#define sv_catpvn_mg(sv, ptr, len)   \
-	STMT_START                       \
-	{                                \
-		SV * TeMpSv = sv;            \
-		sv_catpvn(TeMpSv, ptr, len); \
-		SvSETMAGIC(TeMpSv);          \
-	}                                \
-	STMT_END
+#define sv_catpvn_mg(sv, ptr, len) \
+STMT_START { \
+SV *TeMpSv = sv; \
+sv_catpvn(TeMpSv,ptr,len); \
+SvSETMAGIC(TeMpSv); \
+} STMT_END
 #endif
 #ifndef sv_catsv_mg
-#define sv_catsv_mg(dsv, ssv)  \
-	STMT_START                 \
-	{                          \
-		SV * TeMpSv = dsv;     \
-		sv_catsv(TeMpSv, ssv); \
-		SvSETMAGIC(TeMpSv);    \
-	}                          \
-	STMT_END
+#define sv_catsv_mg(dsv, ssv) \
+STMT_START { \
+SV *TeMpSv = dsv; \
+sv_catsv(TeMpSv,ssv); \
+SvSETMAGIC(TeMpSv); \
+} STMT_END
 #endif
 #ifndef sv_setiv_mg
-#define sv_setiv_mg(sv, i)   \
-	STMT_START               \
-	{                        \
-		SV * TeMpSv = sv;    \
-		sv_setiv(TeMpSv, i); \
-		SvSETMAGIC(TeMpSv);  \
-	}                        \
-	STMT_END
+#define sv_setiv_mg(sv, i) \
+STMT_START { \
+SV *TeMpSv = sv; \
+sv_setiv(TeMpSv,i); \
+SvSETMAGIC(TeMpSv); \
+} STMT_END
 #endif
 #ifndef sv_setnv_mg
-#define sv_setnv_mg(sv, num)   \
-	STMT_START                 \
-	{                          \
-		SV * TeMpSv = sv;      \
-		sv_setnv(TeMpSv, num); \
-		SvSETMAGIC(TeMpSv);    \
-	}                          \
-	STMT_END
+#define sv_setnv_mg(sv, num) \
+STMT_START { \
+SV *TeMpSv = sv; \
+sv_setnv(TeMpSv,num); \
+SvSETMAGIC(TeMpSv); \
+} STMT_END
 #endif
 #ifndef sv_setpv_mg
-#define sv_setpv_mg(sv, ptr)   \
-	STMT_START                 \
-	{                          \
-		SV * TeMpSv = sv;      \
-		sv_setpv(TeMpSv, ptr); \
-		SvSETMAGIC(TeMpSv);    \
-	}                          \
-	STMT_END
+#define sv_setpv_mg(sv, ptr) \
+STMT_START { \
+SV *TeMpSv = sv; \
+sv_setpv(TeMpSv,ptr); \
+SvSETMAGIC(TeMpSv); \
+} STMT_END
 #endif
 #ifndef sv_setpvn_mg
-#define sv_setpvn_mg(sv, ptr, len)   \
-	STMT_START                       \
-	{                                \
-		SV * TeMpSv = sv;            \
-		sv_setpvn(TeMpSv, ptr, len); \
-		SvSETMAGIC(TeMpSv);          \
-	}                                \
-	STMT_END
+#define sv_setpvn_mg(sv, ptr, len) \
+STMT_START { \
+SV *TeMpSv = sv; \
+sv_setpvn(TeMpSv,ptr,len); \
+SvSETMAGIC(TeMpSv); \
+} STMT_END
 #endif
 #ifndef sv_setsv_mg
-#define sv_setsv_mg(dsv, ssv)  \
-	STMT_START                 \
-	{                          \
-		SV * TeMpSv = dsv;     \
-		sv_setsv(TeMpSv, ssv); \
-		SvSETMAGIC(TeMpSv);    \
-	}                          \
-	STMT_END
+#define sv_setsv_mg(dsv, ssv) \
+STMT_START { \
+SV *TeMpSv = dsv; \
+sv_setsv(TeMpSv,ssv); \
+SvSETMAGIC(TeMpSv); \
+} STMT_END
 #endif
 #ifndef sv_setuv_mg
-#define sv_setuv_mg(sv, i)   \
-	STMT_START               \
-	{                        \
-		SV * TeMpSv = sv;    \
-		sv_setuv(TeMpSv, i); \
-		SvSETMAGIC(TeMpSv);  \
-	}                        \
-	STMT_END
+#define sv_setuv_mg(sv, i) \
+STMT_START { \
+SV *TeMpSv = sv; \
+sv_setuv(TeMpSv,i); \
+SvSETMAGIC(TeMpSv); \
+} STMT_END
 #endif
 #ifndef sv_usepvn_mg
-#define sv_usepvn_mg(sv, ptr, len)   \
-	STMT_START                       \
-	{                                \
-		SV * TeMpSv = sv;            \
-		sv_usepvn(TeMpSv, ptr, len); \
-		SvSETMAGIC(TeMpSv);          \
-	}                                \
-	STMT_END
+#define sv_usepvn_mg(sv, ptr, len) \
+STMT_START { \
+SV *TeMpSv = sv; \
+sv_usepvn(TeMpSv,ptr,len); \
+SvSETMAGIC(TeMpSv); \
+} STMT_END
 #endif
 #ifndef SvVSTRING_mg
 #define SvVSTRING_mg(sv) (SvMAGICAL(sv) ? mg_find(sv, PERL_MAGIC_vstring) : NULL)
 #endif
-#if(PERL_BCDVERSION < 0x5004000)
-#elif(PERL_BCDVERSION < 0x5008000)
-#define sv_magic_portable(sv, obj, how, name, namlen)            \
-	STMT_START                                                   \
-	{                                                            \
-		SV * SvMp_sv = (sv);                                     \
-		char * SvMp_name = (char *)(name);                       \
-		I32 SvMp_namlen = (namlen);                              \
-		if(SvMp_name && SvMp_namlen == 0)                        \
-		{                                                        \
-			MAGIC * mg;                                          \
-			sv_magic(SvMp_sv, obj, how, 0, 0);                   \
-			mg = SvMAGIC(SvMp_sv);                               \
-			mg->mg_len = -42;                                    \
-			mg->mg_ptr = SvMp_name;                              \
-		}                                                        \
-		else                                                     \
-		{                                                        \
-			sv_magic(SvMp_sv, obj, how, SvMp_name, SvMp_namlen); \
-		}                                                        \
-	}                                                            \
-	STMT_END
+#if (PERL_BCDVERSION < 0x5004000)
+#elif (PERL_BCDVERSION < 0x5008000)
+#define sv_magic_portable(sv, obj, how, name, namlen) \
+STMT_START { \
+SV *SvMp_sv = (sv); \
+char *SvMp_name = (char *) (name); \
+I32 SvMp_namlen = (namlen); \
+if (SvMp_name && SvMp_namlen == 0) \
+{ \
+MAGIC *mg; \
+sv_magic(SvMp_sv, obj, how, 0, 0); \
+mg = SvMAGIC(SvMp_sv); \
+mg->mg_len = -42;  \
+mg->mg_ptr = SvMp_name; \
+} \
+else \
+{ \
+sv_magic(SvMp_sv, obj, how, SvMp_name, SvMp_namlen); \
+} \
+} STMT_END
 #else
 #define sv_magic_portable(a, b, c, d, e) sv_magic(a, b, c, d, e)
 #endif
 #if !defined(mg_findext)
 #if defined(NEED_mg_findext)
-static MAGIC * DPPP_(my_mg_findext)(SV * sv, int type, const MGVTBL * vtbl);
+static MAGIC * DPPP_(my_mg_findext)(SV * sv, int type, const MGVTBL *vtbl);
 static
 #else
-extern MAGIC * DPPP_(my_mg_findext)(SV * sv, int type, const MGVTBL * vtbl);
+extern MAGIC * DPPP_(my_mg_findext)(SV * sv, int type, const MGVTBL *vtbl);
 #endif
 #define mg_findext DPPP_(my_mg_findext)
 #define Perl_mg_findext DPPP_(my_mg_findext)
 #if defined(NEED_mg_findext) || defined(NEED_mg_findext_GLOBAL)
-    MAGIC *
-        DPPP_(my_mg_findext)(SV * sv, int type, const MGVTBL * vtbl)
-{
-	if(sv)
-	{
-		MAGIC * mg;
+MAGIC *
+DPPP_(my_mg_findext)(SV * sv, int type, const MGVTBL *vtbl) {
+if (sv) {
+MAGIC *mg;
 #ifdef AvPAD_NAMELIST
-		assert(!(SvTYPE(sv) == SVt_PVAV && AvPAD_NAMELIST(sv)));
+assert(!(SvTYPE(sv) == SVt_PVAV && AvPAD_NAMELIST(sv)));
 #endif
-		for(mg = SvMAGIC(sv); mg; mg = mg->mg_moremagic)
-		{
-			if(mg->mg_type == type && mg->mg_virtual == vtbl)
-				return mg;
-		}
-	}
-	return NULL;
+for (mg = SvMAGIC (sv); mg; mg = mg->mg_moremagic) {
+if (mg->mg_type == type && mg->mg_virtual == vtbl)
+return mg;
+}
+}
+return NULL;
 }
 #endif
 #endif
@@ -2474,54 +2317,47 @@ extern int DPPP_(my_sv_unmagicext)(pTHX_ SV * const sv, const int type, MGVTBL *
 #ifdef sv_unmagicext
 #undef sv_unmagicext
 #endif
-#define sv_unmagicext(a, b, c) \
-	DPPP_(my_sv_unmagicext)    \
-	(aTHX_ a, b, c)
+#define sv_unmagicext(a,b,c) DPPP_(my_sv_unmagicext)(aTHX_ a,b,c)
 #define Perl_sv_unmagicext DPPP_(my_sv_unmagicext)
 #if defined(NEED_sv_unmagicext) || defined(NEED_sv_unmagicext_GLOBAL)
-    int
-        DPPP_(my_sv_unmagicext)(pTHX_ SV * const sv, const int type, MGVTBL * vtbl)
+int
+DPPP_(my_sv_unmagicext)(pTHX_ SV *const sv, const int type, MGVTBL *vtbl)
 {
-	MAGIC * mg;
-	MAGIC ** mgp;
-	if(SvTYPE(sv) < SVt_PVMG || !SvMAGIC(sv))
-		return 0;
-	mgp = &(SvMAGIC(sv));
-	for(mg = *mgp; mg; mg = *mgp)
-	{
-		const MGVTBL * const virt = mg->mg_virtual;
-		if(mg->mg_type == type && virt == vtbl)
-		{
-			*mgp = mg->mg_moremagic;
-			if(virt && virt->svt_free)
-				virt->svt_free(aTHX_ sv, mg);
-			if(mg->mg_ptr && mg->mg_type != PERL_MAGIC_regex_global)
-			{
-				if(mg->mg_len > 0)
-					Safefree(mg->mg_ptr);
-				else if(mg->mg_len == HEf_SVKEY)
-					SvREFCNT_dec(MUTABLE_SV(mg->mg_ptr));
-				else if(mg->mg_type == PERL_MAGIC_utf8)
-					Safefree(mg->mg_ptr);
-			}
-			if(mg->mg_flags & MGf_REFCOUNTED)
-				SvREFCNT_dec(mg->mg_obj);
-			Safefree(mg);
-		}
-		else
-			mgp = &mg->mg_moremagic;
-	}
-	if(SvMAGIC(sv))
-	{
-		if(SvMAGICAL(sv))
-			mg_magical(sv);
-	}
-	else
-	{
-		SvMAGICAL_off(sv);
-		SvFLAGS(sv) |= (SvFLAGS(sv) & (SVp_IOK | SVp_NOK | SVp_POK)) >> PRIVSHIFT;
-	}
-	return 0;
+MAGIC* mg;
+MAGIC** mgp;
+if (SvTYPE(sv) < SVt_PVMG || !SvMAGIC(sv))
+return 0;
+mgp = &(SvMAGIC(sv));
+for (mg = *mgp; mg; mg = *mgp) {
+const MGVTBL* const virt = mg->mg_virtual;
+if (mg->mg_type == type && virt == vtbl) {
+*mgp = mg->mg_moremagic;
+if (virt && virt->svt_free)
+virt->svt_free(aTHX_ sv, mg);
+if (mg->mg_ptr && mg->mg_type != PERL_MAGIC_regex_global) {
+if (mg->mg_len > 0)
+Safefree(mg->mg_ptr);
+else if (mg->mg_len == HEf_SVKEY)
+SvREFCNT_dec(MUTABLE_SV(mg->mg_ptr));
+else if (mg->mg_type == PERL_MAGIC_utf8)
+Safefree(mg->mg_ptr);
+}
+if (mg->mg_flags & MGf_REFCOUNTED)
+SvREFCNT_dec(mg->mg_obj);
+Safefree(mg);
+}
+else
+mgp = &mg->mg_moremagic;
+}
+if (SvMAGIC(sv)) {
+if (SvMAGICAL(sv))
+mg_magical(sv);
+}
+else {
+SvMAGICAL_off(sv);
+SvFLAGS(sv) |= (SvFLAGS(sv) & (SVp_IOK|SVp_NOK|SVp_POK)) >> PRIVSHIFT;
+}
+return 0;
 }
 #endif
 #endif
@@ -2533,7 +2369,7 @@ extern int DPPP_(my_sv_unmagicext)(pTHX_ SV * const sv, const int type, MGVTBL *
 #define CopFILEGV(c) (CopFILE(c) ? gv_fetchfile(CopFILE(c)) : Nullgv)
 #endif
 #ifndef CopFILE_set
-#define CopFILE_set(c, pv) ((c)->cop_file = savepv(pv))
+#define CopFILE_set(c,pv) ((c)->cop_file = savepv(pv))
 #endif
 #ifndef CopFILESV
 #define CopFILESV(c) (CopFILE(c) ? GvSV(gv_fetchfile(CopFILE(c))) : Nullsv)
@@ -2545,28 +2381,28 @@ extern int DPPP_(my_sv_unmagicext)(pTHX_ SV * const sv, const int type, MGVTBL *
 #define CopSTASHPV(c) ((c)->cop_stashpv)
 #endif
 #ifndef CopSTASHPV_set
-#define CopSTASHPV_set(c, pv) ((c)->cop_stashpv = ((pv) ? savepv(pv) : Nullch))
+#define CopSTASHPV_set(c,pv) ((c)->cop_stashpv = ((pv) ? savepv(pv) : Nullch))
 #endif
 #ifndef CopSTASH
-#define CopSTASH(c) (CopSTASHPV(c) ? gv_stashpv(CopSTASHPV(c), GV_ADD) : Nullhv)
+#define CopSTASH(c) (CopSTASHPV(c) ? gv_stashpv(CopSTASHPV(c),GV_ADD) : Nullhv)
 #endif
 #ifndef CopSTASH_set
-#define CopSTASH_set(c, hv) CopSTASHPV_set(c, (hv) ? HvNAME(hv) : Nullch)
+#define CopSTASH_set(c,hv) CopSTASHPV_set(c, (hv) ? HvNAME(hv) : Nullch)
 #endif
 #ifndef CopSTASH_eq
-#define CopSTASH_eq(c, hv) ((hv) && (CopSTASHPV(c) == HvNAME(hv)        \
-                                        || (CopSTASHPV(c) && HvNAME(hv) \
-                                               && strEQ(CopSTASHPV(c), HvNAME(hv)))))
+#define CopSTASH_eq(c,hv) ((hv) && (CopSTASHPV(c) == HvNAME(hv) \
+|| (CopSTASHPV(c) && HvNAME(hv) \
+&& strEQ(CopSTASHPV(c), HvNAME(hv)))))
 #endif
 #else
 #ifndef CopFILEGV
 #define CopFILEGV(c) ((c)->cop_filegv)
 #endif
 #ifndef CopFILEGV_set
-#define CopFILEGV_set(c, gv) ((c)->cop_filegv = (GV *)SvREFCNT_inc(gv))
+#define CopFILEGV_set(c,gv) ((c)->cop_filegv = (GV*)SvREFCNT_inc(gv))
 #endif
 #ifndef CopFILE_set
-#define CopFILE_set(c, pv) CopFILEGV_set((c), gv_fetchfile(pv))
+#define CopFILE_set(c,pv) CopFILEGV_set((c), gv_fetchfile(pv))
 #endif
 #ifndef CopFILESV
 #define CopFILESV(c) (CopFILEGV(c) ? GvSV(CopFILEGV(c)) : Nullsv)
@@ -2581,88 +2417,81 @@ extern int DPPP_(my_sv_unmagicext)(pTHX_ SV * const sv, const int type, MGVTBL *
 #define CopSTASH(c) ((c)->cop_stash)
 #endif
 #ifndef CopSTASH_set
-#define CopSTASH_set(c, hv) ((c)->cop_stash = (hv))
+#define CopSTASH_set(c,hv) ((c)->cop_stash = (hv))
 #endif
 #ifndef CopSTASHPV
 #define CopSTASHPV(c) (CopSTASH(c) ? HvNAME(CopSTASH(c)) : Nullch)
 #endif
 #ifndef CopSTASHPV_set
-#define CopSTASHPV_set(c, pv) CopSTASH_set((c), gv_stashpv(pv, GV_ADD))
+#define CopSTASHPV_set(c,pv) CopSTASH_set((c), gv_stashpv(pv,GV_ADD))
 #endif
 #ifndef CopSTASH_eq
-#define CopSTASH_eq(c, hv) (CopSTASH(c) == (hv))
+#define CopSTASH_eq(c,hv) (CopSTASH(c) == (hv))
 #endif
 #endif
-#if(PERL_BCDVERSION >= 0x5006000)
+#if (PERL_BCDVERSION >= 0x5006000)
 #ifndef caller_cx
 #if defined(NEED_caller_cx) || defined(NEED_caller_cx_GLOBAL)
 static I32
-DPPP_dopoptosub_at(const PERL_CONTEXT * cxstk, I32 startingblock)
+DPPP_dopoptosub_at(const PERL_CONTEXT *cxstk, I32 startingblock)
 {
-	I32 i;
-	for(i = startingblock; i >= 0; i--)
-	{
-		register const PERL_CONTEXT * const cx = &cxstk[i];
-		switch(CxTYPE(cx))
-		{
-			default:
-				continue;
-			case CXt_EVAL:
-			case CXt_SUB:
-			case CXt_FORMAT:
-				return i;
-		}
-	}
-	return i;
+I32 i;
+for (i = startingblock; i >= 0; i--) {
+register const PERL_CONTEXT * const cx = &cxstk[i];
+switch (CxTYPE(cx)) {
+default:
+continue;
+case CXt_EVAL:
+case CXt_SUB:
+case CXt_FORMAT:
+return i;
+}
+}
+return i;
 }
 #endif
 #if defined(NEED_caller_cx)
-static const PERL_CONTEXT * DPPP_(my_caller_cx)(pTHX_ I32 count, const PERL_CONTEXT ** dbcxp);
+static const PERL_CONTEXT * DPPP_(my_caller_cx)(pTHX_ I32 count, const PERL_CONTEXT **dbcxp);
 static
 #else
-extern const PERL_CONTEXT * DPPP_(my_caller_cx)(pTHX_ I32 count, const PERL_CONTEXT ** dbcxp);
+extern const PERL_CONTEXT * DPPP_(my_caller_cx)(pTHX_ I32 count, const PERL_CONTEXT **dbcxp);
 #endif
 #ifdef caller_cx
 #undef caller_cx
 #endif
-#define caller_cx(a, b) \
-	DPPP_(my_caller_cx) \
-	(aTHX_ a, b)
+#define caller_cx(a,b) DPPP_(my_caller_cx)(aTHX_ a,b)
 #define Perl_caller_cx DPPP_(my_caller_cx)
 #if defined(NEED_caller_cx) || defined(NEED_caller_cx_GLOBAL)
-    const PERL_CONTEXT *
-        DPPP_(my_caller_cx)(pTHX_ I32 count, const PERL_CONTEXT ** dbcxp)
+const PERL_CONTEXT *
+DPPP_(my_caller_cx)(pTHX_ I32 count, const PERL_CONTEXT **dbcxp)
 {
-	register I32 cxix = DPPP_dopoptosub_at(cxstack, cxstack_ix);
-	register const PERL_CONTEXT * cx;
-	register const PERL_CONTEXT * ccstack = cxstack;
-	const PERL_SI * top_si = PL_curstackinfo;
-	for(;;)
-	{
-		while(cxix < 0 && top_si->si_type != PERLSI_MAIN)
-		{
-			top_si = top_si->si_prev;
-			ccstack = top_si->si_cxstack;
-			cxix = DPPP_dopoptosub_at(ccstack, top_si->si_cxix);
-		}
-		if(cxix < 0)
-			return NULL;
-		if(PL_DBsub && GvCV(PL_DBsub) && cxix >= 0 && ccstack[cxix].blk_sub.cv == GvCV(PL_DBsub))
-			count++;
-		if(!count--)
-			break;
-		cxix = DPPP_dopoptosub_at(ccstack, cxix - 1);
-	}
-	cx = &ccstack[cxix];
-	if(dbcxp)
-		*dbcxp = cx;
-	if(CxTYPE(cx) == CXt_SUB || CxTYPE(cx) == CXt_FORMAT)
-	{
-		const I32 dbcxix = DPPP_dopoptosub_at(ccstack, cxix - 1);
-		if(PL_DBsub && GvCV(PL_DBsub) && dbcxix >= 0 && ccstack[dbcxix].blk_sub.cv == GvCV(PL_DBsub))
-			cx = &ccstack[dbcxix];
-	}
-	return cx;
+register I32 cxix = DPPP_dopoptosub_at(cxstack, cxstack_ix);
+register const PERL_CONTEXT *cx;
+register const PERL_CONTEXT *ccstack = cxstack;
+const PERL_SI *top_si = PL_curstackinfo;
+for (;;) {
+while (cxix < 0 && top_si->si_type != PERLSI_MAIN) {
+top_si = top_si->si_prev;
+ccstack = top_si->si_cxstack;
+cxix = DPPP_dopoptosub_at(ccstack, top_si->si_cxix);
+}
+if (cxix < 0)
+return NULL;
+if (PL_DBsub && GvCV(PL_DBsub) && cxix >= 0 &&
+ccstack[cxix].blk_sub.cv == GvCV(PL_DBsub))
+count++;
+if (!count--)
+break;
+cxix = DPPP_dopoptosub_at(ccstack, cxix - 1);
+}
+cx = &ccstack[cxix];
+if (dbcxp) *dbcxp = cx;
+if (CxTYPE(cx) == CXt_SUB || CxTYPE(cx) == CXt_FORMAT) {
+const I32 dbcxix = DPPP_dopoptosub_at(ccstack, cxix - 1);
+if (PL_DBsub && GvCV(PL_DBsub) && dbcxix >= 0 && ccstack[dbcxix].blk_sub.cv == GvCV(PL_DBsub))
+cx = &ccstack[dbcxix];
+}
+return cx;
 }
 #endif
 #endif
@@ -2722,48 +2551,41 @@ extern bool DPPP_(my_grok_numeric_radix)(pTHX_ const char ** sp, const char * se
 #ifdef grok_numeric_radix
 #undef grok_numeric_radix
 #endif
-#define grok_numeric_radix(a, b) \
-	DPPP_(my_grok_numeric_radix) \
-	(aTHX_ a, b)
+#define grok_numeric_radix(a,b) DPPP_(my_grok_numeric_radix)(aTHX_ a,b)
 #define Perl_grok_numeric_radix DPPP_(my_grok_numeric_radix)
 #if defined(NEED_grok_numeric_radix) || defined(NEED_grok_numeric_radix_GLOBAL)
-    bool
-        DPPP_(my_grok_numeric_radix)(pTHX_ const char ** sp, const char * send)
+bool
+DPPP_(my_grok_numeric_radix)(pTHX_ const char **sp, const char *send)
 {
 #ifdef USE_LOCALE_NUMERIC
 #ifdef PL_numeric_radix_sv
-	if(PL_numeric_radix_sv && IN_LOCALE)
-	{
-		STRLEN len;
-		char * radix = SvPV(PL_numeric_radix_sv, len);
-		if(*sp + len <= send && memEQ(*sp, radix, len))
-		{
-			*sp += len;
-			return TRUE;
-		}
-	}
+if (PL_numeric_radix_sv && IN_LOCALE) {
+STRLEN len;
+char* radix = SvPV(PL_numeric_radix_sv, len);
+if (*sp + len <= send && memEQ(*sp, radix, len)) {
+*sp += len;
+return TRUE;
+}
+}
 #else
 #include <locale.h>
-	dTHR;
-	struct lconv * lc = localeconv();
-	char * radix = lc->decimal_point;
-	if(radix && IN_LOCALE)
-	{
-		STRLEN len = strlen(radix);
-		if(*sp + len <= send && memEQ(*sp, radix, len))
-		{
-			*sp += len;
-			return TRUE;
-		}
-	}
+dTHR;
+struct lconv *lc = localeconv();
+char *radix = lc->decimal_point;
+if (radix && IN_LOCALE) {
+STRLEN len = strlen(radix);
+if (*sp + len <= send && memEQ(*sp, radix, len)) {
+*sp += len;
+return TRUE;
+}
+}
 #endif
 #endif
-	if(*sp < send && **sp == '.')
-	{
-		++*sp;
-		return TRUE;
-	}
-	return FALSE;
+if (*sp < send && **sp == '.') {
+++*sp;
+return TRUE;
+}
+return FALSE;
 }
 #endif
 #endif
@@ -2777,237 +2599,175 @@ extern int DPPP_(my_grok_number)(pTHX_ const char * pv, STRLEN len, UV * valuep)
 #ifdef grok_number
 #undef grok_number
 #endif
-#define grok_number(a, b, c) \
-	DPPP_(my_grok_number)    \
-	(aTHX_ a, b, c)
+#define grok_number(a,b,c) DPPP_(my_grok_number)(aTHX_ a,b,c)
 #define Perl_grok_number DPPP_(my_grok_number)
 #if defined(NEED_grok_number) || defined(NEED_grok_number_GLOBAL)
-    int
-        DPPP_(my_grok_number)(pTHX_ const char * pv, STRLEN len, UV * valuep)
+int
+DPPP_(my_grok_number)(pTHX_ const char *pv, STRLEN len, UV *valuep)
 {
-	const char * s = pv;
-	const char * send = pv + len;
-	const UV max_div_10 = UV_MAX / 10;
-	const char max_mod_10 = UV_MAX % 10;
-	int numtype = 0;
-	int sawinf = 0;
-	int sawnan = 0;
-	while(s < send && isSPACE(*s))
-		s++;
-	if(s == send)
-	{
-		return 0;
-	}
-	else if(*s == '-')
-	{
-		s++;
-		numtype = IS_NUMBER_NEG;
-	}
-	else if(*s == '+')
-		s++;
-	if(s == send)
-		return 0;
-	if(isDIGIT(*s))
-	{
-		UV value = *s - '0';
-		if(++s < send)
-		{
-			int digit = *s - '0';
-			if(digit >= 0 && digit <= 9)
-			{
-				value = value * 10 + digit;
-				if(++s < send)
-				{
-					digit = *s - '0';
-					if(digit >= 0 && digit <= 9)
-					{
-						value = value * 10 + digit;
-						if(++s < send)
-						{
-							digit = *s - '0';
-							if(digit >= 0 && digit <= 9)
-							{
-								value = value * 10 + digit;
-								if(++s < send)
-								{
-									digit = *s - '0';
-									if(digit >= 0 && digit <= 9)
-									{
-										value = value * 10 + digit;
-										if(++s < send)
-										{
-											digit = *s - '0';
-											if(digit >= 0 && digit <= 9)
-											{
-												value = value * 10 + digit;
-												if(++s < send)
-												{
-													digit = *s - '0';
-													if(digit >= 0 && digit <= 9)
-													{
-														value = value * 10 + digit;
-														if(++s < send)
-														{
-															digit = *s - '0';
-															if(digit >= 0 && digit <= 9)
-															{
-																value = value * 10 + digit;
-																if(++s < send)
-																{
-																	digit = *s - '0';
-																	if(digit >= 0 && digit <= 9)
-																	{
-																		value = value * 10 + digit;
-																		if(++s < send)
-																		{
-																			digit = *s - '0';
-																			while(digit >= 0 && digit <= 9
-																			    && (value < max_div_10
-																			           || (value == max_div_10
-																			                  && digit <= max_mod_10)))
-																			{
-																				value = value * 10 + digit;
-																				if(++s < send)
-																					digit = *s - '0';
-																				else
-																					break;
-																			}
-																			if(digit >= 0 && digit <= 9
-																			    && (s < send))
-																			{
-																				do
-																				{
-																					s++;
-																				} while(s < send && isDIGIT(*s));
-																				numtype |= IS_NUMBER_GREATER_THAN_UV_MAX;
-																				goto skip_value;
-																			}
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-		numtype |= IS_NUMBER_IN_UV;
-		if(valuep)
-			*valuep = value;
-	skip_value:
-		if(GROK_NUMERIC_RADIX(&s, send))
-		{
-			numtype |= IS_NUMBER_NOT_INT;
-			while(s < send && isDIGIT(*s))
-				s++;
-		}
-	}
-	else if(GROK_NUMERIC_RADIX(&s, send))
-	{
-		numtype |= IS_NUMBER_NOT_INT | IS_NUMBER_IN_UV;
-		if(s < send && isDIGIT(*s))
-		{
-			do
-			{
-				s++;
-			} while(s < send && isDIGIT(*s));
-			if(valuep)
-			{
-				*valuep = 0;
-			}
-		}
-		else
-			return 0;
-	}
-	else if(*s == 'I' || *s == 'i')
-	{
-		s++;
-		if(s == send || (*s != 'N' && *s != 'n'))
-			return 0;
-		s++;
-		if(s == send || (*s != 'F' && *s != 'f'))
-			return 0;
-		s++;
-		if(s < send && (*s == 'I' || *s == 'i'))
-		{
-			s++;
-			if(s == send || (*s != 'N' && *s != 'n'))
-				return 0;
-			s++;
-			if(s == send || (*s != 'I' && *s != 'i'))
-				return 0;
-			s++;
-			if(s == send || (*s != 'T' && *s != 't'))
-				return 0;
-			s++;
-			if(s == send || (*s != 'Y' && *s != 'y'))
-				return 0;
-			s++;
-		}
-		sawinf = 1;
-	}
-	else if(*s == 'N' || *s == 'n')
-	{
-		s++;
-		if(s == send || (*s != 'A' && *s != 'a'))
-			return 0;
-		s++;
-		if(s == send || (*s != 'N' && *s != 'n'))
-			return 0;
-		s++;
-		sawnan = 1;
-	}
-	else
-		return 0;
-	if(sawinf)
-	{
-		numtype &= IS_NUMBER_NEG;
-		numtype |= IS_NUMBER_INFINITY | IS_NUMBER_NOT_INT;
-	}
-	else if(sawnan)
-	{
-		numtype &= IS_NUMBER_NEG;
-		numtype |= IS_NUMBER_NAN | IS_NUMBER_NOT_INT;
-	}
-	else if(s < send)
-	{
-		if(*s == 'e' || *s == 'E')
-		{
-			numtype &= IS_NUMBER_NEG;
-			numtype |= IS_NUMBER_NOT_INT;
-			s++;
-			if(s < send && (*s == '-' || *s == '+'))
-				s++;
-			if(s < send && isDIGIT(*s))
-			{
-				do
-				{
-					s++;
-				} while(s < send && isDIGIT(*s));
-			}
-			else
-				return 0;
-		}
-	}
-	while(s < send && isSPACE(*s))
-		s++;
-	if(s >= send)
-		return numtype;
-	if(len == 10 && memEQ(pv, "0 but true", 10))
-	{
-		if(valuep)
-			*valuep = 0;
-		return IS_NUMBER_IN_UV;
-	}
-	return 0;
+const char *s = pv;
+const char *send = pv + len;
+const UV max_div_10 = UV_MAX / 10;
+const char max_mod_10 = UV_MAX % 10;
+int numtype = 0;
+int sawinf = 0;
+int sawnan = 0;
+while (s < send && isSPACE(*s))
+s++;
+if (s == send) {
+return 0;
+} else if (*s == '-') {
+s++;
+numtype = IS_NUMBER_NEG;
+}
+else if (*s == '+')
+s++;
+if (s == send)
+return 0;
+if (isDIGIT(*s)) {
+UV value = *s - '0';
+if (++s < send) {
+int digit = *s - '0';
+if (digit >= 0 && digit <= 9) {
+value = value * 10 + digit;
+if (++s < send) {
+digit = *s - '0';
+if (digit >= 0 && digit <= 9) {
+value = value * 10 + digit;
+if (++s < send) {
+digit = *s - '0';
+if (digit >= 0 && digit <= 9) {
+value = value * 10 + digit;
+if (++s < send) {
+digit = *s - '0';
+if (digit >= 0 && digit <= 9) {
+value = value * 10 + digit;
+if (++s < send) {
+digit = *s - '0';
+if (digit >= 0 && digit <= 9) {
+value = value * 10 + digit;
+if (++s < send) {
+digit = *s - '0';
+if (digit >= 0 && digit <= 9) {
+value = value * 10 + digit;
+if (++s < send) {
+digit = *s - '0';
+if (digit >= 0 && digit <= 9) {
+value = value * 10 + digit;
+if (++s < send) {
+digit = *s - '0';
+if (digit >= 0 && digit <= 9) {
+value = value * 10 + digit;
+if (++s < send) {
+digit = *s - '0';
+while (digit >= 0 && digit <= 9
+&& (value < max_div_10
+|| (value == max_div_10
+&& digit <= max_mod_10))) {
+value = value * 10 + digit;
+if (++s < send)
+digit = *s - '0';
+else
+break;
+}
+if (digit >= 0 && digit <= 9
+&& (s < send)) {
+do {
+s++;
+} while (s < send && isDIGIT(*s));
+numtype |=
+IS_NUMBER_GREATER_THAN_UV_MAX;
+goto skip_value;
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+}
+numtype |= IS_NUMBER_IN_UV;
+if (valuep)
+*valuep = value;
+skip_value:
+if (GROK_NUMERIC_RADIX(&s, send)) {
+numtype |= IS_NUMBER_NOT_INT;
+while (s < send && isDIGIT(*s))
+s++;
+}
+}
+else if (GROK_NUMERIC_RADIX(&s, send)) {
+numtype |= IS_NUMBER_NOT_INT | IS_NUMBER_IN_UV;
+if (s < send && isDIGIT(*s)) {
+do {
+s++;
+} while (s < send && isDIGIT(*s));
+if (valuep) {
+*valuep = 0;
+}
+}
+else
+return 0;
+} else if (*s == 'I' || *s == 'i') {
+s++; if (s == send || (*s != 'N' && *s != 'n')) return 0;
+s++; if (s == send || (*s != 'F' && *s != 'f')) return 0;
+s++; if (s < send && (*s == 'I' || *s == 'i')) {
+s++; if (s == send || (*s != 'N' && *s != 'n')) return 0;
+s++; if (s == send || (*s != 'I' && *s != 'i')) return 0;
+s++; if (s == send || (*s != 'T' && *s != 't')) return 0;
+s++; if (s == send || (*s != 'Y' && *s != 'y')) return 0;
+s++;
+}
+sawinf = 1;
+} else if (*s == 'N' || *s == 'n') {
+s++; if (s == send || (*s != 'A' && *s != 'a')) return 0;
+s++; if (s == send || (*s != 'N' && *s != 'n')) return 0;
+s++;
+sawnan = 1;
+} else
+return 0;
+if (sawinf) {
+numtype &= IS_NUMBER_NEG;
+numtype |= IS_NUMBER_INFINITY | IS_NUMBER_NOT_INT;
+} else if (sawnan) {
+numtype &= IS_NUMBER_NEG;
+numtype |= IS_NUMBER_NAN | IS_NUMBER_NOT_INT;
+} else if (s < send) {
+if (*s == 'e' || *s == 'E') {
+numtype &= IS_NUMBER_NEG;
+numtype |= IS_NUMBER_NOT_INT;
+s++;
+if (s < send && (*s == '-' || *s == '+'))
+s++;
+if (s < send && isDIGIT(*s)) {
+do {
+s++;
+} while (s < send && isDIGIT(*s));
+}
+else
+return 0;
+}
+}
+while (s < send && isSPACE(*s))
+s++;
+if (s >= send)
+return numtype;
+if (len == 10 && memEQ(pv, "0 but true", 10)) {
+if (valuep)
+*valuep = 0;
+return IS_NUMBER_IN_UV;
+}
+return 0;
 }
 #endif
 #endif
@@ -3021,87 +2781,75 @@ extern UV DPPP_(my_grok_bin)(pTHX_ const char * start, STRLEN * len_p, I32 * fla
 #ifdef grok_bin
 #undef grok_bin
 #endif
-#define grok_bin(a, b, c, d) \
-	DPPP_(my_grok_bin)       \
-	(aTHX_ a, b, c, d)
+#define grok_bin(a,b,c,d) DPPP_(my_grok_bin)(aTHX_ a,b,c,d)
 #define Perl_grok_bin DPPP_(my_grok_bin)
 #if defined(NEED_grok_bin) || defined(NEED_grok_bin_GLOBAL)
-    UV
-        DPPP_(my_grok_bin)(pTHX_ const char * start, STRLEN * len_p, I32 * flags, NV * result)
+UV
+DPPP_(my_grok_bin)(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
 {
-	const char * s = start;
-	STRLEN len = *len_p;
-	UV value = 0;
-	NV value_nv = 0;
-	const UV max_div_2 = UV_MAX / 2;
-	bool allow_underscores = *flags & PERL_SCAN_ALLOW_UNDERSCORES;
-	bool overflowed = FALSE;
-	if(!(*flags & PERL_SCAN_DISALLOW_PREFIX))
-	{
-		if(len >= 1)
-		{
-			if(s[0] == 'b')
-			{
-				s++;
-				len--;
-			}
-			else if(len >= 2 && s[0] == '0' && s[1] == 'b')
-			{
-				s += 2;
-				len -= 2;
-			}
-		}
-	}
-	for(; len-- && *s; s++)
-	{
-		char bit = *s;
-		if(bit == '0' || bit == '1')
-		{
-		redo:
-			if(!overflowed)
-			{
-				if(value <= max_div_2)
-				{
-					value = (value << 1) | (bit - '0');
-					continue;
-				}
-				warn("Integer overflow in binary number");
-				overflowed = TRUE;
-				value_nv = (NV)value;
-			}
-			value_nv *= 2.0;
-			value_nv += (NV)(bit - '0');
-			continue;
-		}
-		if(bit == '_' && len && allow_underscores && (bit = s[1])
-		    && (bit == '0' || bit == '1'))
-		{
-			--len;
-			++s;
-			goto redo;
-		}
-		if(!(*flags & PERL_SCAN_SILENT_ILLDIGIT))
-			warn("Illegal binary digit '%c' ignored", *s);
-		break;
-	}
-	if((overflowed && value_nv > 4294967295.0)
+const char *s = start;
+STRLEN len = *len_p;
+UV value = 0;
+NV value_nv = 0;
+const UV max_div_2 = UV_MAX / 2;
+bool allow_underscores = *flags & PERL_SCAN_ALLOW_UNDERSCORES;
+bool overflowed = FALSE;
+if (!(*flags & PERL_SCAN_DISALLOW_PREFIX)) {
+if (len >= 1) {
+if (s[0] == 'b') {
+s++;
+len--;
+}
+else if (len >= 2 && s[0] == '0' && s[1] == 'b') {
+s+=2;
+len-=2;
+}
+}
+}
+for (; len-- && *s; s++) {
+char bit = *s;
+if (bit == '0' || bit == '1') {
+redo:
+if (!overflowed) {
+if (value <= max_div_2) {
+value = (value << 1) | (bit - '0');
+continue;
+}
+warn("Integer overflow in binary number");
+overflowed = TRUE;
+value_nv = (NV) value;
+}
+value_nv *= 2.0;
+value_nv += (NV)(bit - '0');
+continue;
+}
+if (bit == '_' && len && allow_underscores && (bit = s[1])
+&& (bit == '0' || bit == '1'))
+{
+--len;
+++s;
+goto redo;
+}
+if (!(*flags & PERL_SCAN_SILENT_ILLDIGIT))
+warn("Illegal binary digit '%c' ignored", *s);
+break;
+}
+if ( ( overflowed && value_nv > 4294967295.0)
 #if UVSIZE > 4
-	    || (!overflowed && value > 0xffffffff)
+|| (!overflowed && value > 0xffffffff )
 #endif
-	        )
-	{
-		warn("Binary number > 0b11111111111111111111111111111111 non-portable");
-	}
-	*len_p = s - start;
-	if(!overflowed)
-	{
-		*flags = 0;
-		return value;
-	}
-	*flags = PERL_SCAN_GREATER_THAN_UV_MAX;
-	if(result)
-		*result = value_nv;
-	return UV_MAX;
+) {
+warn("Binary number > 0b11111111111111111111111111111111 non-portable");
+}
+*len_p = s - start;
+if (!overflowed) {
+*flags = 0;
+return value;
+}
+*flags = PERL_SCAN_GREATER_THAN_UV_MAX;
+if (result)
+*result = value_nv;
+return UV_MAX;
 }
 #endif
 #endif
@@ -3115,88 +2863,76 @@ extern UV DPPP_(my_grok_hex)(pTHX_ const char * start, STRLEN * len_p, I32 * fla
 #ifdef grok_hex
 #undef grok_hex
 #endif
-#define grok_hex(a, b, c, d) \
-	DPPP_(my_grok_hex)       \
-	(aTHX_ a, b, c, d)
+#define grok_hex(a,b,c,d) DPPP_(my_grok_hex)(aTHX_ a,b,c,d)
 #define Perl_grok_hex DPPP_(my_grok_hex)
 #if defined(NEED_grok_hex) || defined(NEED_grok_hex_GLOBAL)
-    UV
-        DPPP_(my_grok_hex)(pTHX_ const char * start, STRLEN * len_p, I32 * flags, NV * result)
+UV
+DPPP_(my_grok_hex)(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
 {
-	const char * s = start;
-	STRLEN len = *len_p;
-	UV value = 0;
-	NV value_nv = 0;
-	const UV max_div_16 = UV_MAX / 16;
-	bool allow_underscores = *flags & PERL_SCAN_ALLOW_UNDERSCORES;
-	bool overflowed = FALSE;
-	const char * xdigit;
-	if(!(*flags & PERL_SCAN_DISALLOW_PREFIX))
-	{
-		if(len >= 1)
-		{
-			if(s[0] == 'x')
-			{
-				s++;
-				len--;
-			}
-			else if(len >= 2 && s[0] == '0' && s[1] == 'x')
-			{
-				s += 2;
-				len -= 2;
-			}
-		}
-	}
-	for(; len-- && *s; s++)
-	{
-		xdigit = strchr((char *)PL_hexdigit, *s);
-		if(xdigit)
-		{
-		redo:
-			if(!overflowed)
-			{
-				if(value <= max_div_16)
-				{
-					value = (value << 4) | ((xdigit - PL_hexdigit) & 15);
-					continue;
-				}
-				warn("Integer overflow in hexadecimal number");
-				overflowed = TRUE;
-				value_nv = (NV)value;
-			}
-			value_nv *= 16.0;
-			value_nv += (NV)((xdigit - PL_hexdigit) & 15);
-			continue;
-		}
-		if(*s == '_' && len && allow_underscores && s[1]
-		    && (xdigit = strchr((char *)PL_hexdigit, s[1])))
-		{
-			--len;
-			++s;
-			goto redo;
-		}
-		if(!(*flags & PERL_SCAN_SILENT_ILLDIGIT))
-			warn("Illegal hexadecimal digit '%c' ignored", *s);
-		break;
-	}
-	if((overflowed && value_nv > 4294967295.0)
+const char *s = start;
+STRLEN len = *len_p;
+UV value = 0;
+NV value_nv = 0;
+const UV max_div_16 = UV_MAX / 16;
+bool allow_underscores = *flags & PERL_SCAN_ALLOW_UNDERSCORES;
+bool overflowed = FALSE;
+const char *xdigit;
+if (!(*flags & PERL_SCAN_DISALLOW_PREFIX)) {
+if (len >= 1) {
+if (s[0] == 'x') {
+s++;
+len--;
+}
+else if (len >= 2 && s[0] == '0' && s[1] == 'x') {
+s+=2;
+len-=2;
+}
+}
+}
+for (; len-- && *s; s++) {
+xdigit = strchr((char *) PL_hexdigit, *s);
+if (xdigit) {
+redo:
+if (!overflowed) {
+if (value <= max_div_16) {
+value = (value << 4) | ((xdigit - PL_hexdigit) & 15);
+continue;
+}
+warn("Integer overflow in hexadecimal number");
+overflowed = TRUE;
+value_nv = (NV) value;
+}
+value_nv *= 16.0;
+value_nv += (NV)((xdigit - PL_hexdigit) & 15);
+continue;
+}
+if (*s == '_' && len && allow_underscores && s[1]
+&& (xdigit = strchr((char *) PL_hexdigit, s[1])))
+{
+--len;
+++s;
+goto redo;
+}
+if (!(*flags & PERL_SCAN_SILENT_ILLDIGIT))
+warn("Illegal hexadecimal digit '%c' ignored", *s);
+break;
+}
+if ( ( overflowed && value_nv > 4294967295.0)
 #if UVSIZE > 4
-	    || (!overflowed && value > 0xffffffff)
+|| (!overflowed && value > 0xffffffff )
 #endif
-	        )
-	{
-		warn("Hexadecimal number > 0xffffffff non-portable");
-	}
-	*len_p = s - start;
-	if(!overflowed)
-	{
-		*flags = 0;
-		return value;
-	}
-	*flags = PERL_SCAN_GREATER_THAN_UV_MAX;
-	if(result)
-		*result = value_nv;
-	return UV_MAX;
+) {
+warn("Hexadecimal number > 0xffffffff non-portable");
+}
+*len_p = s - start;
+if (!overflowed) {
+*flags = 0;
+return value;
+}
+*flags = PERL_SCAN_GREATER_THAN_UV_MAX;
+if (result)
+*result = value_nv;
+return UV_MAX;
 }
 #endif
 #endif
@@ -3210,74 +2946,65 @@ extern UV DPPP_(my_grok_oct)(pTHX_ const char * start, STRLEN * len_p, I32 * fla
 #ifdef grok_oct
 #undef grok_oct
 #endif
-#define grok_oct(a, b, c, d) \
-	DPPP_(my_grok_oct)       \
-	(aTHX_ a, b, c, d)
+#define grok_oct(a,b,c,d) DPPP_(my_grok_oct)(aTHX_ a,b,c,d)
 #define Perl_grok_oct DPPP_(my_grok_oct)
 #if defined(NEED_grok_oct) || defined(NEED_grok_oct_GLOBAL)
-    UV
-        DPPP_(my_grok_oct)(pTHX_ const char * start, STRLEN * len_p, I32 * flags, NV * result)
+UV
+DPPP_(my_grok_oct)(pTHX_ const char *start, STRLEN *len_p, I32 *flags, NV *result)
 {
-	const char * s = start;
-	STRLEN len = *len_p;
-	UV value = 0;
-	NV value_nv = 0;
-	const UV max_div_8 = UV_MAX / 8;
-	bool allow_underscores = *flags & PERL_SCAN_ALLOW_UNDERSCORES;
-	bool overflowed = FALSE;
-	for(; len-- && *s; s++)
-	{
-		int digit = *s - '0';
-		if(digit >= 0 && digit <= 7)
-		{
-		redo:
-			if(!overflowed)
-			{
-				if(value <= max_div_8)
-				{
-					value = (value << 3) | digit;
-					continue;
-				}
-				warn("Integer overflow in octal number");
-				overflowed = TRUE;
-				value_nv = (NV)value;
-			}
-			value_nv *= 8.0;
-			value_nv += (NV)digit;
-			continue;
-		}
-		if(digit == ('_' - '0') && len && allow_underscores
-		    && (digit = s[1] - '0') && (digit >= 0 && digit <= 7))
-		{
-			--len;
-			++s;
-			goto redo;
-		}
-		if(digit == 8 || digit == 9)
-		{
-			if(!(*flags & PERL_SCAN_SILENT_ILLDIGIT))
-				warn("Illegal octal digit '%c' ignored", *s);
-		}
-		break;
-	}
-	if((overflowed && value_nv > 4294967295.0)
+const char *s = start;
+STRLEN len = *len_p;
+UV value = 0;
+NV value_nv = 0;
+const UV max_div_8 = UV_MAX / 8;
+bool allow_underscores = *flags & PERL_SCAN_ALLOW_UNDERSCORES;
+bool overflowed = FALSE;
+for (; len-- && *s; s++) {
+int digit = *s - '0';
+if (digit >= 0 && digit <= 7) {
+redo:
+if (!overflowed) {
+if (value <= max_div_8) {
+value = (value << 3) | digit;
+continue;
+}
+warn("Integer overflow in octal number");
+overflowed = TRUE;
+value_nv = (NV) value;
+}
+value_nv *= 8.0;
+value_nv += (NV)digit;
+continue;
+}
+if (digit == ('_' - '0') && len && allow_underscores
+&& (digit = s[1] - '0') && (digit >= 0 && digit <= 7))
+{
+--len;
+++s;
+goto redo;
+}
+if (digit == 8 || digit == 9) {
+if (!(*flags & PERL_SCAN_SILENT_ILLDIGIT))
+warn("Illegal octal digit '%c' ignored", *s);
+}
+break;
+}
+if ( ( overflowed && value_nv > 4294967295.0)
 #if UVSIZE > 4
-	    || (!overflowed && value > 0xffffffff)
+|| (!overflowed && value > 0xffffffff )
 #endif
-	        )
-	{
-		warn("Octal number > 037777777777 non-portable");
-	}
-	*len_p = s - start;
-	if(!overflowed)
-	{
-		*flags = 0;
-		return value;
-	}
-	*flags = PERL_SCAN_GREATER_THAN_UV_MAX;
-	if(result)
-		*result = value_nv;
-	return UV_MAX;
+) {
+warn("Octal number > 037777777777 non-portable");
+}
+*len_p = s - start;
+if (!overflowed) {
+*flags = 0;
+return value;
+}
+*flags = PERL_SCAN_GREATER_THAN_UV_MAX;
+if (result)
+*result = value_nv;
+return UV_MAX;
 }
 #endif
 #endif
@@ -3291,22 +3018,22 @@ extern int DPPP_(my_my_snprintf)(char * buffer, const Size_t len, const char * f
 #define my_snprintf DPPP_(my_my_snprintf)
 #define Perl_my_snprintf DPPP_(my_my_snprintf)
 #if defined(NEED_my_snprintf) || defined(NEED_my_snprintf_GLOBAL)
-    int
-        DPPP_(my_my_snprintf)(char * buffer, const Size_t len, const char * format, ...)
+int
+DPPP_(my_my_snprintf)(char *buffer, const Size_t len, const char *format, ...)
 {
-	dTHX;
-	int retval;
-	va_list ap;
-	va_start(ap, format);
+dTHX;
+int retval;
+va_list ap;
+va_start(ap, format);
 #ifdef HAS_VSNPRINTF
-	retval = vsnprintf(buffer, len, format, ap);
+retval = vsnprintf(buffer, len, format, ap);
 #else
-	retval = vsprintf(buffer, format, ap);
+retval = vsprintf(buffer, format, ap);
 #endif
-	va_end(ap);
-	if(retval < 0 || (len > 0 && (Size_t)retval >= len))
-		Perl_croak(aTHX_ "panic: my_snprintf buffer overflow");
-	return retval;
+va_end(ap);
+if (retval < 0 || (len > 0 && (Size_t)retval >= len))
+Perl_croak(aTHX_ "panic: my_snprintf buffer overflow");
+return retval;
 }
 #endif
 #endif
@@ -3320,38 +3047,29 @@ extern int DPPP_(my_my_sprintf)(char * buffer, const char * pat, ...);
 #define my_sprintf DPPP_(my_my_sprintf)
 #define Perl_my_sprintf DPPP_(my_my_sprintf)
 #if defined(NEED_my_sprintf) || defined(NEED_my_sprintf_GLOBAL)
-    int
-        DPPP_(my_my_sprintf)(char * buffer, const char * pat, ...)
+int
+DPPP_(my_my_sprintf)(char *buffer, const char* pat, ...)
 {
-	va_list args;
-	va_start(args, pat);
-	vsprintf(buffer, pat, args);
-	va_end(args);
-	return strlen(buffer);
+va_list args;
+va_start(args, pat);
+vsprintf(buffer, pat, args);
+va_end(args);
+return strlen(buffer);
 }
 #endif
 #endif
 #ifdef NO_XSLOCKS
 #ifdef dJMPENV
-#define dXCPT \
-	dJMPENV;  \
-	int rEtV = 0
-#define XCPT_TRY_START \
-	JMPENV_PUSH(rEtV); \
-	if(rEtV == 0)
+#define dXCPT dJMPENV; int rEtV = 0
+#define XCPT_TRY_START JMPENV_PUSH(rEtV); if (rEtV == 0)
 #define XCPT_TRY_END JMPENV_POP;
-#define XCPT_CATCH if(rEtV != 0)
+#define XCPT_CATCH if (rEtV != 0)
 #define XCPT_RETHROW JMPENV_JUMP(rEtV)
 #else
-#define dXCPT          \
-	Sigjmp_buf oldTOP; \
-	int rEtV = 0
-#define XCPT_TRY_START                    \
-	Copy(top_env, oldTOP, 1, Sigjmp_buf); \
-	rEtV = Sigsetjmp(top_env, 1);         \
-	if(rEtV == 0)
+#define dXCPT Sigjmp_buf oldTOP; int rEtV = 0
+#define XCPT_TRY_START Copy(top_env, oldTOP, 1, Sigjmp_buf); rEtV = Sigsetjmp(top_env, 1); if (rEtV == 0)
 #define XCPT_TRY_END Copy(oldTOP, top_env, 1, Sigjmp_buf);
-#define XCPT_CATCH if(rEtV != 0)
+#define XCPT_CATCH if (rEtV != 0)
 #define XCPT_RETHROW Siglongjmp(top_env, rEtV)
 #endif
 #endif
@@ -3365,19 +3083,18 @@ extern Size_t DPPP_(my_my_strlcat)(char * dst, const char * src, Size_t size);
 #define my_strlcat DPPP_(my_my_strlcat)
 #define Perl_my_strlcat DPPP_(my_my_strlcat)
 #if defined(NEED_my_strlcat) || defined(NEED_my_strlcat_GLOBAL)
-    Size_t
-        DPPP_(my_my_strlcat)(char * dst, const char * src, Size_t size)
+Size_t
+DPPP_(my_my_strlcat)(char *dst, const char *src, Size_t size)
 {
-	Size_t used, length, copy;
-	used = strlen(dst);
-	length = strlen(src);
-	if(size > 0 && used < size - 1)
-	{
-		copy = (length >= size - used) ? size - used - 1 : length;
-		memcpy(dst + used, src, copy);
-		dst[used + copy] = '\0';
-	}
-	return used + length;
+Size_t used, length, copy;
+used = strlen(dst);
+length = strlen(src);
+if (size > 0 && used < size - 1) {
+copy = (length >= size - used) ? size - used - 1 : length;
+memcpy(dst + used, src, copy);
+dst[used + copy] = '\0';
+}
+return used + length;
 }
 #endif
 #endif
@@ -3391,18 +3108,17 @@ extern Size_t DPPP_(my_my_strlcpy)(char * dst, const char * src, Size_t size);
 #define my_strlcpy DPPP_(my_my_strlcpy)
 #define Perl_my_strlcpy DPPP_(my_my_strlcpy)
 #if defined(NEED_my_strlcpy) || defined(NEED_my_strlcpy_GLOBAL)
-    Size_t
-        DPPP_(my_my_strlcpy)(char * dst, const char * src, Size_t size)
+Size_t
+DPPP_(my_my_strlcpy)(char *dst, const char *src, Size_t size)
 {
-	Size_t length, copy;
-	length = strlen(src);
-	if(size > 0)
-	{
-		copy = (length >= size) ? size - 1 : length;
-		memcpy(dst, src, copy);
-		dst[copy] = '\0';
-	}
-	return length;
+Size_t length, copy;
+length = strlen(src);
+if (size > 0) {
+copy = (length >= size) ? size - 1 : length;
+memcpy(dst, src, copy);
+dst[copy] = '\0';
+}
+return length;
 }
 #endif
 #endif
@@ -3443,10 +3159,10 @@ extern Size_t DPPP_(my_my_strlcpy)(char * dst, const char * src, Size_t size);
 #define PERL_PV_PRETTY_NOCLEAR PERL_PV_ESCAPE_NOCLEAR
 #endif
 #ifndef PERL_PV_PRETTY_DUMP
-#define PERL_PV_PRETTY_DUMP PERL_PV_PRETTY_ELLIPSES | PERL_PV_PRETTY_QUOTE
+#define PERL_PV_PRETTY_DUMP PERL_PV_PRETTY_ELLIPSES|PERL_PV_PRETTY_QUOTE
 #endif
 #ifndef PERL_PV_PRETTY_REGPROP
-#define PERL_PV_PRETTY_REGPROP PERL_PV_PRETTY_ELLIPSES | PERL_PV_PRETTY_LTGT | PERL_PV_ESCAPE_RE
+#define PERL_PV_PRETTY_REGPROP PERL_PV_PRETTY_ELLIPSES|PERL_PV_PRETTY_LTGT|PERL_PV_ESCAPE_RE
 #endif
 #ifndef pv_escape
 #if defined(NEED_pv_escape)
@@ -3458,125 +3174,93 @@ extern char * DPPP_(my_pv_escape)(pTHX_ SV * dsv, char const * const str, const 
 #ifdef pv_escape
 #undef pv_escape
 #endif
-#define pv_escape(a, b, c, d, e, f) \
-	DPPP_(my_pv_escape)             \
-	(aTHX_ a, b, c, d, e, f)
+#define pv_escape(a,b,c,d,e,f) DPPP_(my_pv_escape)(aTHX_ a,b,c,d,e,f)
 #define Perl_pv_escape DPPP_(my_pv_escape)
 #if defined(NEED_pv_escape) || defined(NEED_pv_escape_GLOBAL)
-    char *
-        DPPP_(my_pv_escape)(pTHX_ SV * dsv, char const * const str,
-            const STRLEN count, const STRLEN max,
-            STRLEN * const escaped, const U32 flags)
+char *
+DPPP_(my_pv_escape)(pTHX_ SV *dsv, char const * const str,
+const STRLEN count, const STRLEN max,
+STRLEN * const escaped, const U32 flags)
 {
-	const char esc = flags & PERL_PV_ESCAPE_RE ? '%' : '\\';
-	const char dq = flags & PERL_PV_ESCAPE_QUOTE ? '"' : esc;
-	char octbuf[32] = "%123456789ABCDF";
-	STRLEN wrote = 0;
-	STRLEN chsize = 0;
-	STRLEN readsize = 1;
+const char esc = flags & PERL_PV_ESCAPE_RE ? '%' : '\\';
+const char dq = flags & PERL_PV_ESCAPE_QUOTE ? '"' : esc;
+char octbuf[32] = "%123456789ABCDF";
+STRLEN wrote = 0;
+STRLEN chsize = 0;
+STRLEN readsize = 1;
 #if defined(is_utf8_string) && defined(utf8_to_uvchr)
-	bool isuni = flags & PERL_PV_ESCAPE_UNI ? 1 : 0;
+bool isuni = flags & PERL_PV_ESCAPE_UNI ? 1 : 0;
 #endif
-	const char * pv = str;
-	const char * const end = pv + count;
-	octbuf[0] = esc;
-	if(!(flags & PERL_PV_ESCAPE_NOCLEAR))
-		sv_setpvs(dsv, "");
+const char *pv = str;
+const char * const end = pv + count;
+octbuf[0] = esc;
+if (!(flags & PERL_PV_ESCAPE_NOCLEAR))
+sv_setpvs(dsv, "");
 #if defined(is_utf8_string) && defined(utf8_to_uvchr)
-	if((flags & PERL_PV_ESCAPE_UNI_DETECT) && is_utf8_string((U8 *)pv, count))
-		isuni = 1;
+if ((flags & PERL_PV_ESCAPE_UNI_DETECT) && is_utf8_string((U8*)pv, count))
+isuni = 1;
 #endif
-	for(; pv < end && (!max || wrote < max); pv += readsize)
-	{
-		const UV u =
+for (; pv < end && (!max || wrote < max) ; pv += readsize) {
+const UV u =
 #if defined(is_utf8_string) && defined(utf8_to_uvchr)
-		    isuni ? utf8_to_uvchr((U8 *)pv, &readsize) :
+isuni ? utf8_to_uvchr((U8*)pv, &readsize) :
 #endif
-		          (U8)*pv;
-		const U8 c = (U8)u & 0xFF;
-		if(u > 255 || (flags & PERL_PV_ESCAPE_ALL))
-		{
-			if(flags & PERL_PV_ESCAPE_FIRSTCHAR)
-				chsize = my_snprintf(octbuf, sizeof octbuf,
-				    "%" UVxf, u);
-			else
-				chsize = my_snprintf(octbuf, sizeof octbuf,
-				    "%cx{%" UVxf "}", esc, u);
-		}
-		else if(flags & PERL_PV_ESCAPE_NOBACKSLASH)
-		{
-			chsize = 1;
-		}
-		else
-		{
-			if(c == dq || c == esc || !isPRINT(c))
-			{
-				chsize = 2;
-				switch(c)
-				{
-					case '\\':
-					case '%':
-						if(c == esc)
-							octbuf[1] = esc;
-						else
-							chsize = 1;
-						break;
-					case '\v':
-						octbuf[1] = 'v';
-						break;
-					case '\t':
-						octbuf[1] = 't';
-						break;
-					case '\r':
-						octbuf[1] = 'r';
-						break;
-					case '\n':
-						octbuf[1] = 'n';
-						break;
-					case '\f':
-						octbuf[1] = 'f';
-						break;
-					case '"':
-						if(dq == '"')
-							octbuf[1] = '"';
-						else
-							chsize = 1;
-						break;
-					default:
-						chsize = my_snprintf(octbuf, sizeof octbuf,
-						    pv < end && isDIGIT((U8) * (pv + readsize))
-						        ? "%c%03o"
-						        : "%c%o",
-						    esc, c);
-				}
-			}
-			else
-			{
-				chsize = 1;
-			}
-		}
-		if(max && wrote + chsize > max)
-		{
-			break;
-		}
-		else if(chsize > 1)
-		{
-			sv_catpvn(dsv, octbuf, chsize);
-			wrote += chsize;
-		}
-		else
-		{
-			char tmp[2];
-			my_snprintf(tmp, sizeof tmp, "%c", c);
-			sv_catpvn(dsv, tmp, 1);
-			wrote++;
-		}
-		if(flags & PERL_PV_ESCAPE_FIRSTCHAR)
-			break;
-	}
-	if(escaped != NULL)
-		*escaped = pv - str;
-	return SvPVX(dsv);
+(U8)*pv;
+const U8 c = (U8)u & 0xFF;
+if (u > 255 || (flags & PERL_PV_ESCAPE_ALL)) {
+if (flags & PERL_PV_ESCAPE_FIRSTCHAR)
+chsize = my_snprintf(octbuf, sizeof octbuf,
+"%" UVxf, u);
+else
+chsize = my_snprintf(octbuf, sizeof octbuf,
+"%cx{%" UVxf "}", esc, u);
+} else if (flags & PERL_PV_ESCAPE_NOBACKSLASH) {
+chsize = 1;
+} else {
+if (c == dq || c == esc || !isPRINT(c)) {
+chsize = 2;
+switch (c) {
+case '\\' :
+case '%' : if (c == esc)
+octbuf[1] = esc;
+else
+chsize = 1;
+break;
+case '\v' : octbuf[1] = 'v'; break;
+case '\t' : octbuf[1] = 't'; break;
+case '\r' : octbuf[1] = 'r'; break;
+case '\n' : octbuf[1] = 'n'; break;
+case '\f' : octbuf[1] = 'f'; break;
+case '"' : if (dq == '"')
+octbuf[1] = '"';
+else
+chsize = 1;
+break;
+default: chsize = my_snprintf(octbuf, sizeof octbuf,
+pv < end && isDIGIT((U8)*(pv+readsize))
+? "%c%03o" : "%c%o", esc, c);
+}
+} else {
+chsize = 1;
+}
+}
+if (max && wrote + chsize > max) {
+break;
+} else if (chsize > 1) {
+sv_catpvn(dsv, octbuf, chsize);
+wrote += chsize;
+} else {
+char tmp[2];
+my_snprintf(tmp, sizeof tmp, "%c", c);
+sv_catpvn(dsv, tmp, 1);
+wrote++;
+}
+if (flags & PERL_PV_ESCAPE_FIRSTCHAR)
+break;
+}
+if (escaped != NULL)
+*escaped= pv - str;
+return SvPVX(dsv);
 }
 #endif
 #endif
@@ -3590,36 +3274,34 @@ extern char * DPPP_(my_pv_pretty)(pTHX_ SV * dsv, char const * const str, const 
 #ifdef pv_pretty
 #undef pv_pretty
 #endif
-#define pv_pretty(a, b, c, d, e, f, g) \
-	DPPP_(my_pv_pretty)                \
-	(aTHX_ a, b, c, d, e, f, g)
+#define pv_pretty(a,b,c,d,e,f,g) DPPP_(my_pv_pretty)(aTHX_ a,b,c,d,e,f,g)
 #define Perl_pv_pretty DPPP_(my_pv_pretty)
 #if defined(NEED_pv_pretty) || defined(NEED_pv_pretty_GLOBAL)
-    char *
-        DPPP_(my_pv_pretty)(pTHX_ SV * dsv, char const * const str, const STRLEN count,
-            const STRLEN max, char const * const start_color, char const * const end_color,
-            const U32 flags)
+char *
+DPPP_(my_pv_pretty)(pTHX_ SV *dsv, char const * const str, const STRLEN count,
+const STRLEN max, char const * const start_color, char const * const end_color,
+const U32 flags)
 {
-	const U8 dq = (flags & PERL_PV_PRETTY_QUOTE) ? '"' : '%';
-	STRLEN escaped;
-	if(!(flags & PERL_PV_PRETTY_NOCLEAR))
-		sv_setpvs(dsv, "");
-	if(dq == '"')
-		sv_catpvs(dsv, "\"");
-	else if(flags & PERL_PV_PRETTY_LTGT)
-		sv_catpvs(dsv, "<");
-	if(start_color != NULL)
-		sv_catpv(dsv, D_PPP_CONSTPV_ARG(start_color));
-	pv_escape(dsv, str, count, max, &escaped, flags | PERL_PV_ESCAPE_NOCLEAR);
-	if(end_color != NULL)
-		sv_catpv(dsv, D_PPP_CONSTPV_ARG(end_color));
-	if(dq == '"')
-		sv_catpvs(dsv, "\"");
-	else if(flags & PERL_PV_PRETTY_LTGT)
-		sv_catpvs(dsv, ">");
-	if((flags & PERL_PV_PRETTY_ELLIPSES) && escaped < count)
-		sv_catpvs(dsv, "...");
-	return SvPVX(dsv);
+const U8 dq = (flags & PERL_PV_PRETTY_QUOTE) ? '"' : '%';
+STRLEN escaped;
+if (!(flags & PERL_PV_PRETTY_NOCLEAR))
+sv_setpvs(dsv, "");
+if (dq == '"')
+sv_catpvs(dsv, "\"");
+else if (flags & PERL_PV_PRETTY_LTGT)
+sv_catpvs(dsv, "<");
+if (start_color != NULL)
+sv_catpv(dsv, D_PPP_CONSTPV_ARG(start_color));
+pv_escape(dsv, str, count, max, &escaped, flags | PERL_PV_ESCAPE_NOCLEAR);
+if (end_color != NULL)
+sv_catpv(dsv, D_PPP_CONSTPV_ARG(end_color));
+if (dq == '"')
+sv_catpvs(dsv, "\"");
+else if (flags & PERL_PV_PRETTY_LTGT)
+sv_catpvs(dsv, ">");
+if ((flags & PERL_PV_PRETTY_ELLIPSES) && escaped < count)
+sv_catpvs(dsv, "...");
+return SvPVX(dsv);
 }
 #endif
 #endif
@@ -3633,18 +3315,16 @@ extern char * DPPP_(my_pv_display)(pTHX_ SV * dsv, const char * pv, STRLEN cur, 
 #ifdef pv_display
 #undef pv_display
 #endif
-#define pv_display(a, b, c, d, e) \
-	DPPP_(my_pv_display)          \
-	(aTHX_ a, b, c, d, e)
+#define pv_display(a,b,c,d,e) DPPP_(my_pv_display)(aTHX_ a,b,c,d,e)
 #define Perl_pv_display DPPP_(my_pv_display)
 #if defined(NEED_pv_display) || defined(NEED_pv_display_GLOBAL)
-    char *
-        DPPP_(my_pv_display)(pTHX_ SV * dsv, const char * pv, STRLEN cur, STRLEN len, STRLEN pvlim)
+char *
+DPPP_(my_pv_display)(pTHX_ SV *dsv, const char *pv, STRLEN cur, STRLEN len, STRLEN pvlim)
 {
-	pv_pretty(dsv, pv, cur, pvlim, NULL, NULL, PERL_PV_PRETTY_DUMP);
-	if(len > cur && pv[cur] == '\0')
-		sv_catpvs(dsv, "\\0");
-	return SvPVX(dsv);
+pv_pretty(dsv, pv, cur, pvlim, NULL, NULL, PERL_PV_PRETTY_DUMP);
+if (len > cur && pv[cur] == '\0')
+sv_catpvs(dsv, "\\0");
+return SvPVX(dsv);
 }
 #endif
 #endif


### PR DESCRIPTION
Seems this fixes  #1965 

Its a straight up revert of the file to https://github.com/kvirc/KVIrc/commit/90bbe90d44f517b85c5a17f6d3cbb86a13bac760 

@Dessa since you did 90bbe90 and @DarthGandalf because hes the master clanger and because Ive no idea why this works.
