### PR TITLE
kvioptions: reuse unused bools

### DIFF
--- a/src/kvirc/kernel/KviOptions.cpp
+++ b/src/kvirc/kernel/KviOptions.cpp
@@ -66,7 +66,6 @@ KviBoolOption g_boolOptionsTable[KVI_NUM_BOOL_OPTIONS] = {
 	BOOL_OPTION("IrcViewUrlHighlighting", true, KviOption_sectFlagIrcView | KviOption_groupTheme),
 	BOOL_OPTION("IrcViewWrapMargin", true, KviOption_sectFlagIrcView | KviOption_resetUpdateGui | KviOption_groupTheme),
 	BOOL_OPTION("InputHistoryCursorAtEnd", true, KviOption_sectFlagInput),
-
 	BOOL_OPTION("AvoidParserWarnings", false, KviOption_sectFlagUserParser),
 	BOOL_OPTION("UseProxyHost", false, KviOption_sectFlagConnection),
 	BOOL_OPTION("ShowGeneralOptionsDialogAsToplevel", true, KviOption_sectFlagFrame),
@@ -303,12 +302,12 @@ KviBoolOption g_boolOptionsTable[KVI_NUM_BOOL_OPTIONS] = {
 	BOOL_OPTION("AutoAcceptDccVideo", false, KviOption_sectFlagDcc),
 	BOOL_OPTION("CreateMinimizedDccVideo", false, KviOption_sectFlagDcc),
 	BOOL_OPTION("CreateMinimizedDccVideoWhenAutoAccepted", true, KviOption_sectFlagDcc),
-	BOOL_OPTION("UNUSED:ShowTreeWindowListHeader", false, KviOption_sectFlagWindowList | KviOption_resetUpdateGui | KviOption_groupTheme),
+	BOOL_OPTION("ShowTaskBarButton", true, KviOption_sectFlagFrame),
 	BOOL_OPTION("FlashDccChatWindowOnNewMessages", true, KviOption_sectFlagFrame),
 	BOOL_OPTION("PopupNotifierOnNewDccChatMessages", true, KviOption_sectFlagFrame),
 	BOOL_OPTION("UseAwayMessage", true, KviOption_sectFlagConnection),
 	BOOL_OPTION("DisableQuietBanListRequestOnJoin", true, KviOption_sectFlagConnection),
-	BOOL_OPTION("UNUSED:UseSaslIfAvailable", true, KviOption_sectFlagConnection),
+	BOOL_OPTION("UseWindowListCloseButton", false, KviOption_sectFlagWindowList | KviOption_resetUpdateGui | KviOption_groupTheme),
 	BOOL_OPTION("FrameIsMaximized", false, KviOption_sectFlagGeometry),
 	BOOL_OPTION("PrependNickColorInfoToRealname", true, KviOption_sectFlagConnection),
 	BOOL_OPTION("DontShowNotifierIfActiveWindowIsFullScreen", true, KviOption_sectFlagFrame),
@@ -337,9 +336,7 @@ KviBoolOption g_boolOptionsTable[KVI_NUM_BOOL_OPTIONS] = {
 	BOOL_OPTION("ShowTreeWindowListHandle", true, KviOption_sectFlagWindowList | KviOption_resetUpdateGui | KviOption_groupTheme),
 	BOOL_OPTION("MenuBarVisible", true, KviOption_sectFlagFrame | KviOption_resetUpdateGui),
 	BOOL_OPTION("WarnAboutHidingMenuBar", true, KviOption_sectFlagFrame),
-	BOOL_OPTION("WhoRepliesToActiveWindow", false, KviOption_sectFlagConnection),
-	BOOL_OPTION("ShowTaskBarButton", true, KviOption_sectFlagFrame),
-	BOOL_OPTION("UseWindowListCloseButton", false, KviOption_sectFlagWindowList | KviOption_resetUpdateGui | KviOption_groupTheme)
+	BOOL_OPTION("WhoRepliesToActiveWindow", false, KviOption_sectFlagConnection)
 };
 
 #define STRING_OPTION(_txt, _val, _flags) KviStringOption(KVI_STRING_OPTIONS_PREFIX _txt, _val, _flags)

--- a/src/kvirc/kernel/KviOptions.h
+++ b/src/kvirc/kernel/KviOptions.h
@@ -322,12 +322,12 @@ DECLARE_OPTION_STRUCT(KviStringListOption, QStringList)
 #define KviOption_boolAutoAcceptDccVideo 231                      /* dcc::video */
 #define KviOption_boolCreateMinimizedDccVideo 232                 /* dcc::video */
 #define KviOption_boolCreateMinimizedDccVideoWhenAutoAccepted 233 /* dcc::video */
-// #define KviOption_boolShowTreeWindowListHeader 234
+#define KviOption_boolShowTaskBarButton 234                       /* windows only, used in KviApplication::createFrame only */
 #define KviOption_boolFlashDccChatWindowOnNewMessages 235   /* dcc:chat */
 #define KviOption_boolPopupNotifierOnNewDccChatMessages 236 /* dcc:chat */
 #define KviOption_boolUseAwayMessage 237                    /* away */
 #define KviOption_boolDisableQuietBanListRequestOnJoin 238  /* channel */
-//#define KviOption_boolUseSaslIfAvailable 239 // UNUSED
+#define KviOption_boolUseWindowListCloseButton 239          /* irc::output */
 #define KviOption_boolFrameIsMaximized 240 /* internal */
 #define KviOption_boolPrependNickColorInfoToRealname 241
 #define KviOption_boolDontShowNotifierIfActiveWindowIsFullScreen 242 /* notifier */
@@ -357,10 +357,8 @@ DECLARE_OPTION_STRUCT(KviStringListOption, QStringList)
 #define KviOption_boolMenuBarVisible 266
 #define KviOption_boolWarnAboutHidingMenuBar 267
 #define KviOption_boolWhoRepliesToActiveWindow 268 /* irc::output */
-#define KviOption_boolShowTaskBarButton 269        /* windows only, used in KviApplication::createFrame only */
-#define KviOption_boolUseWindowListCloseButton 270             /* irc::output */
 
-#define KVI_NUM_BOOL_OPTIONS 271
+#define KVI_NUM_BOOL_OPTIONS 269
 
 #define KVI_STRING_OPTIONS_PREFIX "string"
 #define KVI_STRING_OPTIONS_PREFIX_LEN 6


### PR DESCRIPTION
**KviOptions.cpp** and **KviOptions.h** get cluttered over time and no one is reusing the unused options.

So this is my first part on fixing this. **tested and works** but want to test the windows options hence PR.

Im working on actually removing the really unused ones and adjust both files so it works both compile and runtime but this is my proof of concept to show theres nothing to fear.
#### Changes proposed
- Resuse unused bool entries

this is what we need to do from now on
and do away with these leftovers once and for all.
