### PR TITLE
Add Cuff-Link to server list.

### DIFF
--- a/data/config/serverdb.kvc
+++ b/data/config/serverdb.kvc
@@ -99,6 +99,14 @@ NServers=1
 0_Hostname=irc.criten.net
 0_Description=Criten:%20Random%20server
 NServers=1
+[Cuff-Link]
+0_Hostname=irc.cuff-link.me
+0_Description=Cuff-Link:%20Random%20server
+1_Hostname=irc.cuff-link.me
+1_Description=Cuff-Link:%20Random%20server%20%28SSL%29 
+1_Port=6697
+1_SSL=true
+NServers=2
 [DALnet]
 0_Hostname=irc.dal.net
 0_Description=Main%20Random%20Server


### PR DESCRIPTION
#### Changes proposed
- Add irc.cuff-link.me/6667 and irc.cuff-link.me/6697 to the server list.

Our hostnames can be found at http://blog.cuff-link.me/chat/

User statistics can be seen at http://search.mibbit.com/networks/Cuff-Link

Additional information about us: http://irc.netsplit.de/networks/Cuff-Link/
