### PR TITLE
Add italic text. Resolves #1070.

### DIFF
--- a/src/kvilib/config/kvi_shortcuts.h
+++ b/src/kvilib/config/kvi_shortcuts.h
@@ -155,7 +155,7 @@
 #define KVI_SHORTCUTS_INPUT_CUT QKeySequence::Cut             // Ctrl+X
 #define KVI_SHORTCUTS_INPUT_COMMANDLINE "Ctrl+Y"
 #define KVI_SHORTCUTS_INPUT_UNDO QKeySequence::Undo           // Ctrl+Z
-#define KVI_SHORTCUTS_INPUT_ICON "Ctrl+Alt+E"                 // CtrlAlt++E
+#define KVI_SHORTCUTS_INPUT_ICON "Ctrl+Alt+E"                 // Ctrl+Alt+E
 #define KVI_SHORTCUTS_AWAY "Ctrl+Shift+A"
 #define KVI_SHORTCUTS_EDITORS_TOOLBAR "Ctrl+Shift+B"
 #define KVI_SHORTCUTS_CONNECT "Ctrl+Shift+C"

--- a/src/kvilib/config/kvi_shortcuts.h
+++ b/src/kvilib/config/kvi_shortcuts.h
@@ -133,7 +133,6 @@
 #define KVI_SHORTCUTS_INPUT_SELECT_ALL QKeySequence::SelectAll // Ctrl+A
 #define KVI_SHORTCUTS_INPUT_BOLD QKeySequence::Bold            // Ctrl+B
 #define KVI_SHORTCUTS_INPUT_COPY QKeySequence::Copy            // Ctrl+C
-#define KVI_SHORTCUTS_INPUT_ICON "Ctrl+E"                      // Ctrl+E
 #define KVI_SHORTCUTS_WIN_SEARCH QKeySequence::Find            // Ctrl+F
 #define KVI_SHORTCUTS_INPUT_ITALIC QKeySequence::Italic        // Ctrl+I
 #define KVI_SHORTCUTS_JOIN "Ctrl+J"
@@ -155,7 +154,8 @@
 #define KVI_SHORTCUTS_WIN_CLOSE "Ctrl+W"                      // QKeySequence::Close seems to be problematic
 #define KVI_SHORTCUTS_INPUT_CUT QKeySequence::Cut             // Ctrl+X
 #define KVI_SHORTCUTS_INPUT_COMMANDLINE "Ctrl+Y"
-#define KVI_SHORTCUTS_INPUT_UNDO QKeySequence::Undo // Ctrl+Z
+#define KVI_SHORTCUTS_INPUT_UNDO QKeySequence::Undo           // Ctrl+Z
+#define KVI_SHORTCUTS_INPUT_ICON "Ctrl+Alt+E"                 // CtrlAlt++E
 #define KVI_SHORTCUTS_AWAY "Ctrl+Shift+A"
 #define KVI_SHORTCUTS_EDITORS_TOOLBAR "Ctrl+Shift+B"
 #define KVI_SHORTCUTS_CONNECT "Ctrl+Shift+C"
@@ -246,7 +246,6 @@
 		[b]Ctrl+A:[/b] Select all[br]
 		[b]Ctrl+B:[/b] Insert Bold control character[br]
 		[b]Ctrl+C:[/b] Copy to clipboard[br]
-		[b]Ctrl+E:[/b] Open [i]Insert icon[/i] dialog[br]
 		[b]Ctrl+F:[/b] Open [i]Find Text[/i] dialog[br]
 		[b]Ctrl+G:[/b] Activate spell-checker[br]
 		[b]Ctrl+I:[/b] Insert italic control character[br]
@@ -269,6 +268,7 @@
 		[b]Ctrl+"+":[/b] Increase font size[br]
 		[b]Ctrl+"-":[/b] Decrease font size[br]
 		[b]Ctrl+0:[/b] Restore default font (and font size)[br]
+		[b]Ctrl+Alt+E:[/b] Open [i]Insert icon[/i] dialog[br]
 		[b]Ctrl+Shift+A:[/b] Go away/back[br]
 		[b]Ctrl+Shift+B:[/b] Open [i]Manage Toolbars[/i] dialog[br]
 		[b]Ctrl+Shift+C:[/b] Connect/disconnect current irc context[br]
@@ -324,7 +324,7 @@
 		[b]Ctrl+C:[/b] Copy the selected text to clipboard[br]
 		[b]Ctrl+X:[/b] Cut the selected text[br]
 		[b]Ctrl+V:[/b] Paste the clipboard contents (same as middle mouse click)[br]
-		[b]Ctrl+E:[/b] Insert the 'icon' control code and pops up the icon list box[br]
+		[b]Ctrl+Alt+E:[/b] Insert the 'icon' control code and pops up the icon list box[br]
 		[b]UpArrow:[/b] Move backward in the command history and in the history popup[br]
 		[b]DownArrow:[/b] Move forward in the command history and in the history popup[br]
 		[b]Ctrl+PageUp:[/b] Open the history popup[br]

--- a/src/kvilib/config/kvi_shortcuts.h
+++ b/src/kvilib/config/kvi_shortcuts.h
@@ -57,6 +57,7 @@
 * \def KVI_SHORTCUTS_INPUT_BACKSPACE Backspace key
 * \def KVI_SHORTCUTS_INPUT_BACKSPACE_2 Shift + Backspace key
 * \def KVI_SHORTCUTS_INPUT_BOLD Insert the 'bold' mIRC text control character
+* \def KVI_SHORTCUTS_INPUT_ITALIC Insert the 'italic' mIRC text control character
 * \def KVI_SHORTCUTS_INPUT_COLOR Insert the 'color' mIRC text control character
 * \def KVI_SHORTCUTS_INPUT_COMMANDLINE Toggle the commandline's KVS/User-friendly mode
 * \def KVI_SHORTCUTS_INPUT_COPY Copy the selected text to clipboard
@@ -132,8 +133,9 @@
 #define KVI_SHORTCUTS_INPUT_SELECT_ALL QKeySequence::SelectAll // Ctrl+A
 #define KVI_SHORTCUTS_INPUT_BOLD QKeySequence::Bold            // Ctrl+B
 #define KVI_SHORTCUTS_INPUT_COPY QKeySequence::Copy            // Ctrl+C
+#define KVI_SHORTCUTS_INPUT_ICON "Ctrl+E"                      // Ctrl+E
 #define KVI_SHORTCUTS_WIN_SEARCH QKeySequence::Find            // Ctrl+F
-#define KVI_SHORTCUTS_INPUT_ICON QKeySequence::Italic          // Ctrl+I <= yes we know this should be "italic"
+#define KVI_SHORTCUTS_INPUT_ITALIC QKeySequence::Italic        // Ctrl+I
 #define KVI_SHORTCUTS_JOIN "Ctrl+J"
 #define KVI_SHORTCUTS_INPUT_COLOR "Ctrl+K"
 #define KVI_SHORTCUTS_WIN_SCROLL_TO_LAST_READ_LINE "Ctrl+L"
@@ -244,10 +246,11 @@
 		[b]Ctrl+A:[/b] Select all[br]
 		[b]Ctrl+B:[/b] Insert Bold control character[br]
 		[b]Ctrl+C:[/b] Copy to clipboard[br]
+		[b]Ctrl+E:[/b] Open [i]Insert icon[/i] dialog[br]
 		[b]Ctrl+F:[/b] Open [i]Find Text[/i] dialog[br]
 		[b]Ctrl+G:[/b] Activate spell-checker[br]
+		[b]Ctrl+I:[/b] Insert italic control character[br]
 		[b]Ctrl+L:[/b] Scroll to the [i]last read[/i] line marker[br]
-		[b]Ctrl+I:[/b] Open [i]Insert icon[/i] dialog[br]
 		[b]Ctrl+J:[/b] Open [i]Join Channels[/i] dialog[br]
 		[b]Ctrl+K:[/b] Open [i]Insert Color[/i] dialog[br]
 		[b]Ctrl+L:[/b] Scroll to the last read line[br]
@@ -312,6 +315,7 @@
 		[b]Ctrl+<digit>:[/b] Script accelerators (see OnAccelKeyPressed)[br]
 		[b]F2-F12, Shift+(F1-F12):[/b] Script accelerators (see OnAccelKeyPressed)[br]
 		[b]Ctrl+B:[/b] Insert the 'bold' mIRC text control character[br]
+		[b]Ctrl+I:[/b] Insert the 'italic' mIRC text control character[br]
 		[b]Ctrl+K:[/b] Insert the 'color' mIRC text control character[br]
 		[b]Ctrl+R:[/b] Insert the 'reverse' mIRC text control character[br]
 		[b]Ctrl+U:[/b] Insert the 'underline' mIRC text control character[br]
@@ -320,7 +324,7 @@
 		[b]Ctrl+C:[/b] Copy the selected text to clipboard[br]
 		[b]Ctrl+X:[/b] Cut the selected text[br]
 		[b]Ctrl+V:[/b] Paste the clipboard contents (same as middle mouse click)[br]
-		[b]Ctrl+I:[/b] Insert the 'icon' control code and pops up the icon list box[br]
+		[b]Ctrl+E:[/b] Insert the 'icon' control code and pops up the icon list box[br]
 		[b]UpArrow:[/b] Move backward in the command history and in the history popup[br]
 		[b]DownArrow:[/b] Move forward in the command history and in the history popup[br]
 		[b]Ctrl+PageUp:[/b] Open the history popup[br]

--- a/src/kvilib/irc/KviControlCodes.cpp
+++ b/src/kvilib/irc/KviControlCodes.cpp
@@ -42,6 +42,7 @@ namespace KviControlCodes
 			{
 				case KviControlCodes::Underline:
 				case KviControlCodes::Bold:
+				case KviControlCodes::Italic:
 				case KviControlCodes::Reset:
 				case KviControlCodes::Reverse:
 				case KviControlCodes::CryptEscape:

--- a/src/kvilib/irc/KviControlCodes.h
+++ b/src/kvilib/irc/KviControlCodes.h
@@ -158,7 +158,8 @@ namespace KviControlCodes
 		UnIcon = 0x06,      /**< Unicon, totally artificial and internal to KviIrcView */
 		Reset = 0x0f,       /**< Reset */
 		Reverse = 0x16,     /**< Reverse */
-		Icon = 0x1d,        /**< Icon, KVIrc control code */
+		Icon = 0x1c,        /**< Icon, KVIrc control code */
+		Italic = 0x1d,
 		CryptEscape = 0x1e, /**< Crypt escape, KVIrc control code */
 		Underline = 0x1f    /**< Underline */
 	};

--- a/src/kvirc/kernel/KviHtmlGenerator.cpp
+++ b/src/kvirc/kernel/KviHtmlGenerator.cpp
@@ -35,6 +35,7 @@ namespace KviHtmlGenerator
 	{
 		QString szResult = "<qt>";
 		bool bCurBold = false;
+		bool bCurItalic = false;
 		bool bCurUnderline = false;
 		bool bIgnoreIcons = false;
 		bool bShowIcons = KVI_OPTION_BOOL(KviOption_boolDrawEmoticons);
@@ -50,7 +51,7 @@ namespace KviHtmlGenerator
 			unsigned int uStart = uIdx;
 
 			while(
-			    (c != KviControlCodes::Color) && (c != KviControlCodes::Bold) && (c != KviControlCodes::Underline) && (c != KviControlCodes::Reverse) && (c != KviControlCodes::Reset) && (c != KviControlCodes::Icon) && ((c != ':') || bIgnoreIcons) && ((c != ';') || bIgnoreIcons) && ((c != '=') || bIgnoreIcons))
+			    (c != KviControlCodes::Color) && (c != KviControlCodes::Bold) && (c != KviControlCodes::Italic) && (c != KviControlCodes::Underline) && (c != KviControlCodes::Reverse) && (c != KviControlCodes::Reset) && (c != KviControlCodes::Icon) && ((c != ':') || bIgnoreIcons) && ((c != ';') || bIgnoreIcons) && ((c != '=') || bIgnoreIcons))
 			{
 				bIgnoreIcons = false;
 				if(c == '&')
@@ -138,6 +139,19 @@ namespace KviHtmlGenerator
 					}
 				}
 
+				if(bCurItalic)
+				{
+					if(!bOpened)
+					{
+						szResult.append("<span style=\"font-style:italic");
+						bOpened = true;
+					}
+					else
+					{
+						szResult.append(";font-style:italic");
+					}
+				}
+
 				if(bOpened)
 					szResult.append(";\">");
 
@@ -152,6 +166,12 @@ namespace KviHtmlGenerator
 				case KviControlCodes::Bold:
 				{
 					bCurBold = !bCurBold;
+					++uIdx;
+					break;
+				}
+				case KviControlCodes::Italic:
+				{
+					bCurItalic = !bCurItalic;
 					++uIdx;
 					break;
 				}
@@ -174,6 +194,7 @@ namespace KviHtmlGenerator
 					uCurFore = Foreground;
 					uCurBack = Background;
 					bCurBold = false;
+					bCurItalic = false;
 					bCurUnderline = false;
 					++uIdx;
 					break;

--- a/src/kvirc/kvs/KviKvsCoreFunctions.cpp
+++ b/src/kvirc/kvs/KviKvsCoreFunctions.cpp
@@ -75,6 +75,7 @@ namespace KviKvsCoreFunctions
 		_REGFNC("hexToAscii", hexToAscii);
 		_REGFNC("hostname", hostname);
 		_REGFNC("hptimestamp", hptimestamp);
+		_REGFNC("i", i);
 		_REGFNC("ic", context);
 		_REGFNC("icon", icon);
 		_REGFNC("iconName", iconName);

--- a/src/kvirc/kvs/KviKvsCoreFunctions.h
+++ b/src/kvirc/kvs/KviKvsCoreFunctions.h
@@ -82,6 +82,7 @@ namespace KviKvsCoreFunctions
 	KVSCF(hexToAscii);
 	KVSCF(hostname);
 	KVSCF(hptimestamp);
+	KVSCF(i);
 	KVSCF(icon);
 	KVSCF(iconName);
 	KVSCF(insideAlias);

--- a/src/kvirc/kvs/KviKvsCoreFunctions_af.cpp
+++ b/src/kvirc/kvs/KviKvsCoreFunctions_af.cpp
@@ -356,7 +356,7 @@ namespace KviKvsCoreFunctions
 		@description:
 			Returns the BOLD mIRC control character (Ctrl+B).[br]
 		@seealso:
-			[fnc]$k[/fnc], [fnc]$u[/fnc]
+			[fnc]$k[/fnc], [fnc]$i[/fnc], [fnc]$u[/fnc], [fnc]$r[/fnc], [fnc]$o[/fnc]
 	*/
 
 	KVSCF(b)

--- a/src/kvirc/kvs/KviKvsCoreFunctions_gl.cpp
+++ b/src/kvirc/kvs/KviKvsCoreFunctions_gl.cpp
@@ -380,11 +380,11 @@ namespace KviKvsCoreFunctions
 		@type:
 			function
 		@title:
-			$b
+			$i
 		@short:
 			Returns the ITALIC mIRC control character
 		@syntax:
-			<string> $b
+			<string> $i
 		@description:
 			Returns the ITALIC mIRC control character (Ctrl+I).[br]
 		@seealso:

--- a/src/kvirc/kvs/KviKvsCoreFunctions_gl.cpp
+++ b/src/kvirc/kvs/KviKvsCoreFunctions_gl.cpp
@@ -375,6 +375,31 @@ namespace KviKvsCoreFunctions
 			[fnc]$iconName[/fnc]
 	*/
 
+	/*
+		@doc: i
+		@type:
+			function
+		@title:
+			$b
+		@short:
+			Returns the ITALIC mIRC control character
+		@syntax:
+			<string> $b
+		@description:
+			Returns the ITALIC mIRC control character (Ctrl+I).[br]
+		@seealso:
+			[fnc]$k[/fnc], [fnc]$b[/fnc], [fnc]$u[/fnc], [fnc]$r[/fnc], [fnc]$o[/fnc]
+	*/
+
+	KVSCF(i)
+	{
+		Q_UNUSED(__pContext);
+		Q_UNUSED(__pParams);
+
+		KVSCF_pRetBuffer->setString(QString(QChar(KviControlCodes::Italic)));
+		return true;
+	}
+
 	KVSCF(icon)
 	{
 		QString szName;
@@ -865,7 +890,7 @@ namespace KviKvsCoreFunctions
 			If <foreground> and <background> are passed, a standard mIRC
 			color escape is returned.[br]
 		@seealso:
-			[fnc]$b[/fnc]
+			[fnc]$b[/fnc], [fnc]$i[/fnc], [fnc]$u[/fnc], [fnc]$r[/fnc], [fnc]$o[/fnc]
 	*/
 
 	KVSCF(k)

--- a/src/kvirc/kvs/KviKvsCoreFunctions_mr.cpp
+++ b/src/kvirc/kvs/KviKvsCoreFunctions_mr.cpp
@@ -381,11 +381,11 @@ namespace KviKvsCoreFunctions
 		@short:
 			Returns the RESET mIRC control character
 		@syntax:
-			<string> $o
+			<string> $oE
 		@description:
 			Returns the RESET mIRC control character (Ctrl+O).[br]
 		@seealso:
-			[fnc]$k[/fnc], [fnc]$b[/fnc], [fnc]$u[/fnc], [fnc]$r[/fnc]
+			[fnc]$k[/fnc], [fnc]$b[/fnc], [fnc]$i[/fnc], [fnc]$u[/fnc], [fnc]$r[/fnc]
 	*/
 
 	KVSCF(o)
@@ -526,7 +526,7 @@ namespace KviKvsCoreFunctions
 		@description:
 			Returns the REVERSE mIRC control character (Ctrl+R).[br]
 		@seealso:
-			[fnc]$k[/fnc], [fnc]$b[/fnc], [fnc]$u[/fnc], [fnc]$o[/fnc]
+			[fnc]$k[/fnc], [fnc]$b[/fnc], [fnc]$i[/fnc], [fnc]$u[/fnc], [fnc]$o[/fnc]
 	*/
 
 	KVSCF(r)

--- a/src/kvirc/kvs/KviKvsCoreFunctions_mr.cpp
+++ b/src/kvirc/kvs/KviKvsCoreFunctions_mr.cpp
@@ -381,7 +381,7 @@ namespace KviKvsCoreFunctions
 		@short:
 			Returns the RESET mIRC control character
 		@syntax:
-			<string> $oE
+			<string> $o
 		@description:
 			Returns the RESET mIRC control character (Ctrl+O).[br]
 		@seealso:

--- a/src/kvirc/kvs/KviKvsCoreFunctions_sz.cpp
+++ b/src/kvirc/kvs/KviKvsCoreFunctions_sz.cpp
@@ -789,7 +789,7 @@ namespace KviKvsCoreFunctions
 		@description:
 			Returns the UNDERLINE mIRC control character (Ctrl+U).[br]
 		@seealso:
-			[fnc]$k[/fnc], [fnc]$b[/fnc], [fnc]$r[/fnc], [fnc]$o[/fnc]
+			[fnc]$k[/fnc], [fnc]$b[/fnc], [fnc]$i[/fnc], [fnc]$r[/fnc], [fnc]$o[/fnc]
 	*/
 
 	KVSCF(u)

--- a/src/kvirc/ui/KviInput.cpp
+++ b/src/kvirc/ui/KviInput.cpp
@@ -124,7 +124,7 @@ KviInput::KviInput(KviWindow * pPar, KviUserListView * pView)
 	QIcon is3;
 	is3.addPixmap(*(g_pIconManager->getSmallIcon(KviIconManager::BigGrin)));
 	m_pIconButton->setIcon(is3);
-	KviTalToolTip::add(m_pIconButton, __tr2qs("Show icons popup<br>&lt;Ctrl+E&gt;<br>See also /help texticons"));
+	KviTalToolTip::add(m_pIconButton, __tr2qs("Show icons popup<br>&lt;Ctrl+Alt+E&gt;<br>See also /help texticons"));
 	connect(m_pIconButton, SIGNAL(clicked()), this, SLOT(iconButtonClicked()));
 
 	m_pCommandlineModeButton = new QToolButton(m_pButtonContainer);

--- a/src/kvirc/ui/KviInput.cpp
+++ b/src/kvirc/ui/KviInput.cpp
@@ -124,7 +124,7 @@ KviInput::KviInput(KviWindow * pPar, KviUserListView * pView)
 	QIcon is3;
 	is3.addPixmap(*(g_pIconManager->getSmallIcon(KviIconManager::BigGrin)));
 	m_pIconButton->setIcon(is3);
-	KviTalToolTip::add(m_pIconButton, __tr2qs("Show icons popup<br>&lt;Ctrl+I&gt;<br>See also /help texticons"));
+	KviTalToolTip::add(m_pIconButton, __tr2qs("Show icons popup<br>&lt;Ctrl+E&gt;<br>See also /help texticons"));
 	connect(m_pIconButton, SIGNAL(clicked()), this, SLOT(iconButtonClicked()));
 
 	m_pCommandlineModeButton = new QToolButton(m_pButtonContainer);

--- a/src/kvirc/ui/KviInputEditor.h
+++ b/src/kvirc/ui/KviInputEditor.h
@@ -671,6 +671,11 @@ private slots:
 	void insertBold();
 
 	/**
+	* \brief Inserts italic control character
+	* \return void
+	*/
+	void insertItalic();
+	/**
 	* \brief Inserts reset control character
 	* \return void
 	*/

--- a/src/kvirc/ui/KviIrcView.cpp
+++ b/src/kvirc/ui/KviIrcView.cpp
@@ -1063,6 +1063,8 @@ void KviIrcView::paintEvent(QPaintEvent * p)
 	int rectHeight = r.height();
 	int rectBottom = rectTop + rectHeight;
 
+	QFont newFont;
+
 	QPainter pa(this);
 
 	SET_ANTI_ALIASING(pa);
@@ -1180,6 +1182,7 @@ void KviIrcView::paintEvent(QPaintEvent * p)
 		char defaultBack = pCurTextLine->pBlocks->pChunk->colors.back;
 		char defaultFore = pCurTextLine->pBlocks->pChunk->colors.fore;
 		bool curBold = false;
+		bool curItalic = false;
 		bool curUnderline = false;
 		char foreBeforeEscape = KviControlCodes::Black;
 		bool curLink = false;
@@ -1235,11 +1238,15 @@ void KviIrcView::paintEvent(QPaintEvent * p)
 					case KviControlCodes::Bold:
 						curBold = !curBold;
 						break;
+					case KviControlCodes::Italic:
+						curItalic = !curItalic;
+						break;
 					case KviControlCodes::Underline:
 						curUnderline = !curUnderline;
 						break;
 					case KviControlCodes::Reset:
 						curBold = false;
+						curItalic = false;
 						curUnderline = false;
 						bacWasTransp = false;
 						curFore = defaultFore;
@@ -1353,6 +1360,9 @@ void KviIrcView::paintEvent(QPaintEvent * p)
 			theWdth = width() - (curLeftCoord + KVI_IRCVIEW_HORIZONTAL_BORDER + scrollbarWidth);                                                                    \
 		pa.fillRect(curLeftCoord, curBottomCoord - m_iFontLineSpacing + m_iFontDescent, theWdth, m_iFontLineSpacing, KVI_OPTION_MIRCCOLOR((unsigned char)curBack)); \
 	}                                                                                                                                                               \
+	newFont = pa.font();                                                                                                                                               \
+	newFont.setStyle(curItalic ? QFont::StyleItalic : QFont::StyleNormal);                                                                                             \
+	pa.setFont(newFont);                                                                                                                                               \
 	pa.drawText(curLeftCoord, curBottomCoord, _text_str.mid(_text_idx, _text_len));                                                                                 \
 	if(curBold)                                                                                                                                                     \
 		pa.drawText(curLeftCoord + 1, curBottomCoord, _text_str.mid(_text_idx, _text_len));                                                                         \
@@ -1497,6 +1507,10 @@ void KviIrcView::paintEvent(QPaintEvent * p)
 					{
 						pa.fillRect(curLeftCoord, curBottomCoord - m_iFontLineSpacing + m_iFontDescent, wdth, m_iFontLineSpacing, KVI_OPTION_MIRCCOLOR((unsigned char)curBack));
 					}
+
+					newFont = pa.font();
+					newFont.setStyle(curItalic ? QFont::StyleItalic : QFont::StyleNormal);
+					pa.setFont(newFont);
 
 					if(curLink)
 					{
@@ -2826,6 +2840,7 @@ KviIrcViewWrappedBlock * KviIrcView::getLinkUnderMouse(int xPos, int yPos, QRect
 											switch(l->pBlocks[iEndOfLInk].pChunk->type)
 											{
 												case KviControlCodes::Bold:
+												case KviControlCodes::Italic:
 												case KviControlCodes::Underline:
 												case KviControlCodes::Reverse:
 												case KviControlCodes::Reset:

--- a/src/kvirc/ui/KviIrcView_events.cpp
+++ b/src/kvirc/ui/KviIrcView_events.cpp
@@ -432,6 +432,7 @@ void KviIrcView::addControlCharacter(KviIrcViewLineChunk * pC, QString & szSelec
 	switch(pC->type)
 	{
 		case KviControlCodes::Bold:
+		case KviControlCodes::Italic:
 		case KviControlCodes::Underline:
 		case KviControlCodes::Reverse:
 		case KviControlCodes::Reset:

--- a/src/kvirc/ui/KviIrcView_getTextLine.cpp
+++ b/src/kvirc/ui/KviIrcView_getTextLine.cpp
@@ -356,36 +356,36 @@ const kvi_wchar_t * KviIrcView::getTextLine(
 
 	static void * char_to_check_jump_table[256] = {
 		// clang-format off
-		&&found_end_of_buffer  ,nullptr                      ,&&found_mirc_escape    ,&&found_color_escape   ,
+		&&found_end_of_buffer        ,nullptr                      ,&&found_mirc_escape          ,&&found_color_escape         ,
 		nullptr                      ,nullptr                      ,nullptr                      ,nullptr                      ,
-		nullptr                      ,nullptr                      ,&&found_end_of_line    ,nullptr                      ,
-		nullptr                      ,&&found_command_escape ,nullptr                      ,&&found_mirc_escape    ,
+		nullptr                      ,nullptr                      ,&&found_end_of_line          ,nullptr                      ,
+		nullptr                      ,&&found_command_escape       ,nullptr                      ,&&found_mirc_escape          ,
 		nullptr                      ,nullptr                      ,nullptr                      ,nullptr                      ,
-		nullptr                      ,nullptr                      ,&&found_mirc_escape    ,nullptr                      ,
+		nullptr                      ,nullptr                      ,&&found_mirc_escape          ,nullptr                      ,
 		nullptr                      ,nullptr                      ,nullptr                      ,nullptr                      ,
-		nullptr                      ,&&found_icon_escape    ,nullptr                      ,&&found_mirc_escape    , // 000-031
+		&&found_icon_escape          ,&&found_mirc_escape          ,nullptr                      ,&&found_mirc_escape          , // 000-031
 		nullptr                      ,nullptr                      ,nullptr                      ,nullptr                      ,
 		nullptr                      ,nullptr                      ,nullptr                      ,nullptr                      ,
 		nullptr                      ,nullptr                      ,nullptr                      ,nullptr                      ,
 		nullptr                      ,nullptr                      ,nullptr                      ,nullptr                      , // 032-047
 		nullptr                      ,nullptr                      ,nullptr                      ,nullptr                      ,
 		nullptr                      ,nullptr                      ,nullptr                      ,nullptr                      ,
-		nullptr                      ,nullptr                      ,&&check_emoticon_char  ,&&check_emoticon_char  ,
-		nullptr                      ,&&check_emoticon_char  ,nullptr                      ,nullptr                      , // 048-063 // 61='=' , 59=';' , 58=':'
+		nullptr                      ,nullptr                      ,&&check_emoticon_char        ,&&check_emoticon_char        ,
+		nullptr                      ,&&check_emoticon_char        ,nullptr                      ,nullptr                      , // 048-063 // 61='=' , 59=';' , 58=':'
 		nullptr                      ,nullptr                      ,nullptr                      ,nullptr                      ,
-		nullptr                      ,&&check_e2k_url        ,&&check_file_or_ftp_url,nullptr                      ,
-		&&check_http_url       ,&&check_irc_url        ,nullptr                      ,nullptr                      ,
-		nullptr                      ,&&check_mailto_or_magnet_url     ,nullptr            ,nullptr                      , // 064-079  // 070==F 072==H 073==I  077==M
-		nullptr                      ,nullptr                      ,nullptr                      ,&&check_spotify_url    ,
-		nullptr                      ,nullptr                      ,nullptr                      ,&&check_www_url        ,
+		nullptr                      ,&&check_e2k_url              ,&&check_file_or_ftp_url      ,nullptr                      ,
+		&&check_http_url             ,&&check_irc_url              ,nullptr                      ,nullptr                      ,
+		nullptr                      ,&&check_mailto_or_magnet_url ,nullptr                      ,nullptr                      , // 064-079  // 070==F 072==H 073==I  077==M
+		nullptr                      ,nullptr                      ,nullptr                      ,&&check_spotify_url          ,
+		nullptr                      ,nullptr                      ,nullptr                      ,&&check_www_url              ,
 		nullptr                      ,nullptr                      ,nullptr                      ,nullptr                      ,
 		nullptr                      ,nullptr                      ,nullptr                      ,nullptr                      , // 080-095  // 083==S 087==W
 		nullptr                      ,nullptr                      ,nullptr                      ,nullptr                      ,
-		nullptr                      ,&&check_e2k_url        ,&&check_file_or_ftp_url,nullptr                      ,
-		&&check_http_url       ,&&check_irc_url        ,nullptr                      ,nullptr                      ,
-		nullptr                      ,&&check_mailto_or_magnet_url     ,nullptr            ,nullptr                      , // 096-111  // 101=e 102=f 104=h 105=i 109==m
-		nullptr                      ,nullptr                      ,nullptr                      ,&&check_spotify_url    ,
-		nullptr                      ,nullptr                      ,nullptr                      ,&&check_www_url        ,
+		nullptr                      ,&&check_e2k_url              ,&&check_file_or_ftp_url      ,nullptr                      ,
+		&&check_http_url             ,&&check_irc_url              ,nullptr                      ,nullptr                      ,
+		nullptr                      ,&&check_mailto_or_magnet_url ,nullptr                      ,nullptr                      , // 096-111  // 101=e 102=f 104=h 105=i 109==m
+		nullptr                      ,nullptr                      ,nullptr                      ,&&check_spotify_url          ,
+		nullptr                      ,nullptr                      ,nullptr                      ,&&check_www_url              ,
 		nullptr                      ,nullptr                      ,nullptr                      ,nullptr                      ,
 		nullptr                      ,nullptr                      ,nullptr                      ,nullptr                      , // 112-127  // 115==s 119==w
 		nullptr                      ,nullptr                      ,nullptr                      ,nullptr                      ,
@@ -730,6 +730,7 @@ check_escape_switch:
 			}
 			break;
 		case KviControlCodes::Bold:
+		case KviControlCodes::Italic:
 		case KviControlCodes::Underline:
 		case KviControlCodes::Reverse:
 		case KviControlCodes::Reset:

--- a/src/kvirc/ui/KviTextIconWindow.h
+++ b/src/kvirc/ui/KviTextIconWindow.h
@@ -65,12 +65,12 @@ public:
 private:
 	QWidget * m_pOwner;
 	QTableWidget * m_pTable;
-	bool m_bAltMode; // in alt mode the inserted string will contains also the Ctrl+I escape code
+	bool m_bAltMode; // in alt mode the inserted string will contains also the Ctrl+E escape code
 public:
 	/**
 	* \brief Shows the popup
 	* \param pOwner The owner of the widget
-	* \param bAltMode Whether to prepend the Ctrl+I escape code in the inserted string
+	* \param bAltMode Whether to prepend the Ctrl+E escape code in the inserted string
 	* \return void
 	*/
 	void popup(QWidget * pOwner, bool bAltMode);

--- a/src/kvirc/ui/KviTextIconWindow.h
+++ b/src/kvirc/ui/KviTextIconWindow.h
@@ -65,12 +65,12 @@ public:
 private:
 	QWidget * m_pOwner;
 	QTableWidget * m_pTable;
-	bool m_bAltMode; // in alt mode the inserted string will contains also the Ctrl+E escape code
+	bool m_bAltMode; // in alt mode the inserted string will contains also the Ctrl+Alt+E escape code
 public:
 	/**
 	* \brief Shows the popup
 	* \param pOwner The owner of the widget
-	* \param bAltMode Whether to prepend the Ctrl+E escape code in the inserted string
+	* \param bAltMode Whether to prepend the Ctrl+Alt+E escape code in the inserted string
 	* \return void
 	*/
 	void popup(QWidget * pOwner, bool bAltMode);

--- a/src/kvirc/ui/KviTopicWidget.cpp
+++ b/src/kvirc/ui/KviTopicWidget.cpp
@@ -190,6 +190,7 @@ void KviTopicWidget::paintColoredText(QPainter * p, QString text, const QPalette
 {
 	QFontMetrics fm(p->fontMetrics());
 	bool curBold = false;
+	bool curItalic = false;
 	bool curUnderline = false;
 	unsigned char curFore = KVI_LABEL_DEF_FORE; //default fore
 	unsigned char curBack = KVI_LABEL_DEF_BACK; //default back
@@ -205,7 +206,7 @@ void KviTopicWidget::paintColoredText(QPainter * p, QString text, const QPalette
 
 		unsigned int start = idx;
 
-		while((idx < (unsigned int)text.length()) && (c != KviControlCodes::Color) && (c != KviControlCodes::Bold) && (c != KviControlCodes::Underline) && (c != KviControlCodes::Reverse) && (c != KviControlCodes::Reset) && (c != KviControlCodes::Icon))
+		while((idx < (unsigned int)text.length()) && (c != KviControlCodes::Color) && (c != KviControlCodes::Bold) && (c != KviControlCodes::Italic) && (c != KviControlCodes::Underline) && (c != KviControlCodes::Reverse) && (c != KviControlCodes::Reset) && (c != KviControlCodes::Icon))
 		{
 			idx++;
 			c = text[(int)idx].unicode();
@@ -250,6 +251,9 @@ void KviTopicWidget::paintColoredText(QPainter * p, QString text, const QPalette
 
 			if(curBold)
 				p->drawText(curX + 1, baseline, szText.left(len));
+			QFont newFont = p->font();
+			newFont.setStyle(curItalic ? QFont::StyleItalic : QFont::StyleNormal);
+			p->setFont(newFont);
 			if(curUnderline)
 			{
 				p->drawLine(curX, baseline + 1, curX + wdth, baseline + 1);
@@ -268,6 +272,10 @@ void KviTopicWidget::paintColoredText(QPainter * p, QString text, const QPalette
 				curBold = !curBold;
 				++idx;
 				break;
+			case KviControlCodes::Italic:
+				curItalic = !curItalic;
+				++idx;
+				break;
 			case KviControlCodes::Underline:
 				curUnderline = !curUnderline;
 				++idx;
@@ -284,6 +292,7 @@ void KviTopicWidget::paintColoredText(QPainter * p, QString text, const QPalette
 				curFore = KVI_LABEL_DEF_FORE;
 				curBack = KVI_LABEL_DEF_BACK;
 				curBold = false;
+				curItalic = false;
 				curUnderline = false;
 				++idx;
 				break;
@@ -715,6 +724,9 @@ QChar KviTopicWidget::getSubstituteChar(unsigned short control_code)
 		case KviControlCodes::Bold:
 			return QChar('B');
 			break;
+		case KviControlCodes::Italic:
+			return QChar('I');
+			break;
 		case KviControlCodes::Reset:
 			return QChar('O');
 			break;
@@ -725,7 +737,7 @@ QChar KviTopicWidget::getSubstituteChar(unsigned short control_code)
 			return QChar('U');
 			break;
 		case KviControlCodes::Icon:
-			return QChar('I');
+			return QChar('E');
 			break;
 		default:
 			return QChar(control_code);

--- a/src/modules/options/OptionsWidget_textIcons.cpp
+++ b/src/modules/options/OptionsWidget_textIcons.cpp
@@ -87,7 +87,7 @@ OptionsWidget_textIcons::OptionsWidget_textIcons(QWidget * parent)
 	m_pTable->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
 	mergeTip(m_pTable->viewport(), __tr2qs_ctx("This table contains the text icon associations.<br>"
-	                                           "KVIrc will use them to display the Ctrl+I escape sequences "
+	                                           "KVIrc will use them to display the Ctrl+E escape sequences "
 	                                           "and eventually the emoticons.", "options"));
 
 	layout()->addWidget(m_pTable, 0, 0, 1, 3);

--- a/src/modules/options/OptionsWidget_textIcons.cpp
+++ b/src/modules/options/OptionsWidget_textIcons.cpp
@@ -87,7 +87,7 @@ OptionsWidget_textIcons::OptionsWidget_textIcons(QWidget * parent)
 	m_pTable->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
 	mergeTip(m_pTable->viewport(), __tr2qs_ctx("This table contains the text icon associations.<br>"
-	                                           "KVIrc will use them to display the Ctrl+E escape sequences "
+	                                           "KVIrc will use them to display the Ctrl+Alt+E escape sequences "
 	                                           "and eventually the emoticons.", "options"));
 
 	layout()->addWidget(m_pTable, 0, 0, 1, 3);

--- a/src/modules/texticons/libkvitexticons.cpp
+++ b/src/modules/texticons/libkvitexticons.cpp
@@ -180,11 +180,11 @@ KVIRC_MODULE(
 		The idea is quite simple: the IRC client (and it's user) associates
 		some small images to text strings (called icon tokens) and the strings are sent
 		in place of the images preceded by a special escape character.[br]
-		The chosen escape character is 29 (hex 0x1d) which corresponds
+		The chosen escape character is 29 (hex 0x1c) which corresponds
 		to the ASCII group separator.[br]
 		So for example if a client has the association of the icon token "rose" with a small
 		icon containing a red rose flower then KVIrc could send the string
-		"&lt;0x1d&gt;rose" in the message stream to ask the remote parties to
+		"&lt;0x1c&gt;rose" in the message stream to ask the remote parties to
 		display such an icon. If the remote parties don't have this association
 		then they will simply strip the control code and display the string "rose",
 		(eventually showing it in some enhanced way).[br]
@@ -192,12 +192,12 @@ KVIRC_MODULE(
 		so the receiving clients stop the extraction of the icon strings
 		when a space, an icon escape or the message termination is encountered.
 		[br]
-		&lt;icon escape&gt; := character 0x1d (ASCII group separator)[br]
-		&lt;icon token&gt; := any character with the exception of 0x1d, CR,LF and SPACE.[br]
+		&lt;icon escape&gt; := character 0x1c (ASCII group separator)[br]
+		&lt;icon token&gt; := any character with the exception of 0x1c, CR,LF and SPACE.[br]
 		[br]
 		Please note that this is a KVIrc extension and the remote clients
 		that don't support this feature will not display the icon (and will
-		eventually show the 0x1d character in the data stream).[br]
+		eventually show the 0x1c character in the data stream).[br]
 		If you like this feature please either convince the remote users
 		to try KVIrc or tell them to write to their client developers asking
 		for this simple feature to be implemented.[br]


### PR DESCRIPTION
This branch adds support for _italic text_, using the control code **U+001D**, as per mIRC, HexChat and others.
Since that code was previously used **for emoticons, that functionality has been moved to U+001C.**
#### Known issues

I tried moving the keyboard shortcut for emoticons from Ctrl+I to Ctrl+E, but Ctrl+E specifically doesn't seem to be working.
