### PR TITLE
 OptionsWidget_interfaceFeatures: remove broken options

### DIFF
--- a/src/kvirc/kernel/KviOptions.cpp
+++ b/src/kvirc/kernel/KviOptions.cpp
@@ -59,6 +59,7 @@ KviRectOption g_rectOptionsTable[KVI_NUM_RECT_OPTIONS] = {
 
 #define BOOL_OPTION(_txt, _val, _flags) KviBoolOption(KVI_BOOL_OPTIONS_PREFIX _txt, _val, _flags)
 
+// NOTICE: REUSE EQUIVALENT UNUSED KviOption_bool in KviOptions.h ENTRIES BEFORE ADDING NEW ENTRIES BELOW
 KviBoolOption g_boolOptionsTable[KVI_NUM_BOOL_OPTIONS] = {
 	BOOL_OPTION("WindowsRememberProperties", true, KviOption_sectFlagWindows),
 	BOOL_OPTION("IrcViewShowImages", false, KviOption_sectFlagIrcView | KviOption_resetUpdateGui | KviOption_groupTheme),
@@ -68,7 +69,7 @@ KviBoolOption g_boolOptionsTable[KVI_NUM_BOOL_OPTIONS] = {
 	BOOL_OPTION("InputHistoryCursorAtEnd", true, KviOption_sectFlagInput),
 	BOOL_OPTION("AvoidParserWarnings", false, KviOption_sectFlagUserParser),
 	BOOL_OPTION("UseProxyHost", false, KviOption_sectFlagConnection),
-	BOOL_OPTION("ShowGeneralOptionsDialogAsToplevel", true, KviOption_sectFlagFrame),
+	BOOL_OPTION("ShowGeneralOptionsDialogAsToplevel", true, KviOption_sectFlagFrame), //UNUSED
 	BOOL_OPTION("ForceBrutalQuit", false, KviOption_sectFlagIrcSocket),
 	BOOL_OPTION("ShowPingPong", true, KviOption_sectFlagConnection),
 	BOOL_OPTION("PopupNotifierOnNewQueryMessages", true, KviOption_sectFlagFrame),
@@ -125,7 +126,7 @@ KviBoolOption g_boolOptionsTable[KVI_NUM_BOOL_OPTIONS] = {
 	BOOL_OPTION("CreateMinimizedDccSendWhenAutoAccepted", true, KviOption_sectFlagDcc),
 	BOOL_OPTION("CreateMinimizedDccChatWhenAutoAccepted", true, KviOption_sectFlagDcc),
 	BOOL_OPTION("DccGuessIpFromServerWhenLocalIsUnroutable", true, KviOption_sectFlagDcc),
-	BOOL_OPTION("ShowRegisteredUsersDialogAsToplevel", true, KviOption_sectFlagFrame),
+	BOOL_OPTION("ShowRegisteredUsersDialogAsToplevel", true, KviOption_sectFlagFrame),  //UNUSED
 	BOOL_OPTION("AutoLogQueries", true, KviOption_sectFlagLogging), /* this options enabled by default in mIRC,XChat and irssi. People are confused while they want to see logs, but see empty dir*/
 	BOOL_OPTION("AutoLogChannels", true, KviOption_sectFlagLogging),
 	BOOL_OPTION("AutoLogDccChat", false, KviOption_sectFlagLogging),
@@ -168,14 +169,14 @@ KviBoolOption g_boolOptionsTable[KVI_NUM_BOOL_OPTIONS] = {
 	BOOL_OPTION("ExitAwayOnInput", false, KviOption_sectFlagConnection),
 	BOOL_OPTION("AlwaysHighlightNick", true, KviOption_sectFlagIrcView),
 	BOOL_OPTION("ShowChannelsJoinOnIrc", true, KviOption_sectFlagFrame),
-	BOOL_OPTION("ShowChannelsJoinDialogAsToplevel", true, KviOption_sectFlagFrame),
+	BOOL_OPTION("ShowChannelsJoinDialogAsToplevel", true, KviOption_sectFlagFrame), //UNUSED
 	BOOL_OPTION("UserDefinedPortRange", false, KviOption_sectFlagDcc),
 	BOOL_OPTION("CreateQueryOnPrivmsg", true, KviOption_sectFlagConnection),
 	BOOL_OPTION("CreateQueryOnNotice", false, KviOption_sectFlagConnection),
 	BOOL_OPTION("CreateIncomingQueriesAsMinimized", true, KviOption_sectFlagConnection),
 	BOOL_OPTION("AutoJoinOnInvite", false, KviOption_sectFlagConnection),
 	BOOL_OPTION("ShowServersConnectDialogOnStart", true, KviOption_sectFlagFrame),
-	BOOL_OPTION("ShowServersConnectDialogAsToplevel", true, KviOption_sectFlagFrame),
+	BOOL_OPTION("ShowServersConnectDialogAsToplevel", true, KviOption_sectFlagFrame),  //UNUSED
 	BOOL_OPTION("AcceptBrokenFileNameDccResumeRequests", true, KviOption_sectFlagDcc),
 	BOOL_OPTION("AutoReconnectOnUnexpectedDisconnect", true, KviOption_sectFlagFrame),
 	BOOL_OPTION("RejoinChannelsAfterReconnect", true, KviOption_sectFlagFrame),
@@ -187,7 +188,7 @@ KviBoolOption g_boolOptionsTable[KVI_NUM_BOOL_OPTIONS] = {
 	BOOL_OPTION("DccSendFakeAddressByDefault", false, KviOption_sectFlagDcc),
 	BOOL_OPTION("UseWindowListActivityMeter", false, KviOption_sectFlagWindowList | KviOption_resetUpdateGui | KviOption_groupTheme),
 	BOOL_OPTION("CloseServerWidgetAfterConnect", false, KviOption_sectFlagFrame),
-	BOOL_OPTION("ShowIdentityDialogAsToplevel", true, KviOption_sectFlagFrame),
+	BOOL_OPTION("ShowIdentityDialogAsToplevel", true, KviOption_sectFlagFrame), //UNUSED
 	BOOL_OPTION("ShowUserChannelIcons", true, KviOption_sectFlagUserListView | KviOption_resetUpdateGui | KviOption_groupTheme),
 	BOOL_OPTION("ShowUserChannelState", false, KviOption_sectFlagUserListView | KviOption_resetUpdateGui | KviOption_groupTheme),
 	BOOL_OPTION("EnableIgnoreOnPrivMsg", true, KviOption_sectFlagConnection),
@@ -333,6 +334,8 @@ KviBoolOption g_boolOptionsTable[KVI_NUM_BOOL_OPTIONS] = {
 	BOOL_OPTION("WarnAboutHidingMenuBar", true, KviOption_sectFlagFrame),
 	BOOL_OPTION("WhoRepliesToActiveWindow", false, KviOption_sectFlagConnection)
 };
+
+// NOTICE: REUSE EQUIVALENT UNUSED KviOption_bool in KviOptions.h ENTRIES BEFORE ADDING NEW ENTRIES ABOVE
 
 #define STRING_OPTION(_txt, _val, _flags) KviStringOption(KVI_STRING_OPTIONS_PREFIX _txt, _val, _flags)
 

--- a/src/kvirc/kernel/KviOptions.h
+++ b/src/kvirc/kernel/KviOptions.h
@@ -88,6 +88,8 @@ DECLARE_OPTION_STRUCT(KviStringListOption, QStringList)
 #define KVI_BOOL_OPTIONS_PREFIX "bool"
 #define KVI_BOOL_OPTIONS_PREFIX_LEN 4
 
+// NOTICE: REUSE EQUIVALENT UNUSED BOOL_OPTION in KviOptions.cpp ENTRIES BEFORE ADDING NEW ENTRIES BELOW
+
 #define KviOption_boolWindowsRememberProperties 0                              /* interface::features::global */
 #define KviOption_boolIrcViewShowImages 1                                      /* interface::features::components::ircview */
 #define KviOption_boolIrcViewTimestamp 2                                       /* interface::features::components::ircview */
@@ -96,7 +98,7 @@ DECLARE_OPTION_STRUCT(KviStringListOption, QStringList)
 #define KviOption_boolInputHistoryCursorAtEnd 5                                /* interface::features::components::input */
 #define KviOption_boolAvoidParserWarnings 6                                    /* ircengine::uparser */
 #define KviOption_boolUseProxyHost 7                                           /* transport */
-#define KviOption_boolShowGeneralOptionsDialogAsToplevel 8                     /* interface::features::global */
+//#define KviOption_boolShowGeneralOptionsDialogAsToplevel 8                     /* interface::features::global */ // UNUSED
 #define KviOption_boolForceBrutalQuit 9                                        /* irc */
 #define KviOption_boolShowPingPong 10                                          /* ircoutput */
 #define KviOption_boolPopupNotifierOnNewQueryMessages 11                       /* query */
@@ -153,7 +155,7 @@ DECLARE_OPTION_STRUCT(KviStringListOption, QStringList)
 #define KviOption_boolCreateMinimizedDccSendWhenAutoAccepted 62                /* dcc::send */
 #define KviOption_boolCreateMinimizedDccChatWhenAutoAccepted 63                /* dcc::chat */
 #define KviOption_boolDccGuessIpFromServerWhenLocalIsUnroutable 64             /* dcc */
-#define KviOption_boolShowRegisteredUsersDialogAsToplevel 65                   /* interface::features::global */
+//#define KviOption_boolShowRegisteredUsersDialogAsToplevel 65                   /* interface::features::global */ //UNUSED
 #define KviOption_boolAutoLogQueries 66                                        /* ircengine::logging */
 #define KviOption_boolAutoLogChannels 67                                       /* ircendine::logging */
 #define KviOption_boolAutoLogDccChat 68                                        /* ircengine::logging */
@@ -192,14 +194,14 @@ DECLARE_OPTION_STRUCT(KviStringListOption, QStringList)
 #define KviOption_boolExitAwayOnInput 101                                      /* ircengine::away */
 #define KviOption_boolAlwaysHighlightNick 102                                  /* ircengine::outputcontrol::highlighting */
 #define KviOption_boolShowChannelsJoinOnIrc 103                                /* internal */
-#define KviOption_boolShowChannelsJoinDialogAsToplevel 104                     /* FIXME: internal ??? */
+//#define KviOption_boolShowChannelsJoinDialogAsToplevel 104                     /* FIXME: internal ??? */ //UNUSED
 #define KviOption_boolUserDefinedPortRange 105                                 /* dcc */
 #define KviOption_boolCreateQueryOnPrivmsg 106                                 /* query */
 #define KviOption_boolCreateQueryOnNotice 107                                  /* query */
 #define KviOption_boolCreateIncomingQueriesAsMinimized 108                     /* query */
 #define KviOption_boolAutoJoinOnInvite 109                                     /* channel */
 #define KviOption_boolShowServersConnectDialogOnStart 110                      /* connection::ircservers */
-#define KviOption_boolShowServersConnectDialogAsToplevel 111                   /* FIXME: internal ?? */
+//#define KviOption_boolShowServersConnectDialogAsToplevel 111                   /* FIXME: internal ?? */  //UNUSED
 #define KviOption_boolAcceptBrokenFileNameDccResumeRequests 112                /* dcc::send */
 #define KviOption_boolAutoReconnectOnUnexpectedDisconnect 113                  /* connection */
 #define KviOption_boolRejoinChannelsAfterReconnect 114                         /* connection */
@@ -211,7 +213,7 @@ DECLARE_OPTION_STRUCT(KviStringListOption, QStringList)
 #define KviOption_boolDccSendFakeAddressByDefault 120                          /* dcc::general */
 #define KviOption_boolUseWindowListActivityMeter 121                           /* irc::output */
 #define KviOption_boolCloseServerWidgetAfterConnect 122                        /* IMPLEMENTATION NEEDED !!! */
-#define KviOption_boolShowIdentityDialogAsToplevel 123                         /* ??? */
+//#define KviOption_boolShowIdentityDialogAsToplevel 123                         /* ??? */  //UNUSED
 #define KviOption_boolShowUserChannelIcons 124                                 /* look & feel::interface features::userlist */
 #define KviOption_boolShowUserChannelState 125                                 /* look & feel::interface features::userlist */
 #define KviOption_boolEnableIgnoreOnPrivMsg 126                                /* irc::ignore */
@@ -352,6 +354,8 @@ DECLARE_OPTION_STRUCT(KviStringListOption, QStringList)
 #define KviOption_boolMenuBarVisible 261
 #define KviOption_boolWarnAboutHidingMenuBar 262
 #define KviOption_boolWhoRepliesToActiveWindow 263                             /* irc::output */
+
+// NOTICE: REUSE EQUIVALENT UNUSED BOOL_OPTION in KviOptions.cpp ENTRIES BEFORE ADDING NEW ENTRIES ABOVE
 
 #define KVI_NUM_BOOL_OPTIONS 264
 

--- a/src/modules/options/OptionsWidget_interfaceFeatures.cpp
+++ b/src/modules/options/OptionsWidget_interfaceFeatures.cpp
@@ -54,20 +54,12 @@ OptionsWidget_interfaceFeatures::OptionsWidget_interfaceFeatures(QWidget * paren
 #endif
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
 	addBoolSelector(0, 6, 0, 6, __tr2qs_ctx("Show taskbar button (change requires restart)", "options"), KviOption_boolShowTaskBarButton);
-	g = addGroupBox(0, 7, 0, 7, Qt::Horizontal, __tr2qs_ctx("Open Dialog Window for", "options"));
-#else
-	g = addGroupBox(0, 6, 0, 6, Qt::Horizontal, __tr2qs_ctx("Open Dialog Window for", "options"));
 #endif
-	addBoolSelector(g, __tr2qs_ctx("Preferences", "options"), KviOption_boolShowGeneralOptionsDialogAsToplevel);
-	addBoolSelector(g, __tr2qs_ctx("Registered users", "options"), KviOption_boolShowRegisteredUsersDialogAsToplevel);
-	addBoolSelector(g, __tr2qs_ctx("Identity", "options"), KviOption_boolShowIdentityDialogAsToplevel);
-	addBoolSelector(g, __tr2qs_ctx("Servers", "options"), KviOption_boolShowServersConnectDialogAsToplevel);
-	addBoolSelector(g, __tr2qs_ctx("Join channels", "options"), KviOption_boolShowChannelsJoinDialogAsToplevel);
 
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
-	addRowSpacer(0, 8, 0, 8);
-#else
 	addRowSpacer(0, 7, 0, 7);
+#else
+	addRowSpacer(0, 6, 0, 6);
 #endif
 }
 


### PR DESCRIPTION
## fixes #1978
#### Changes proposed
- Remove broken options from UI - Open Windows at toplevel
- Mark removed options Unused in KViOptions.h/cpp and add reuse notice

Pragma expressed that all these type things should open in dialogs only
and I agree see https://github.com/kvirc/KVIrc/issues/1978

these options have been broken and are unlikely ever to be fixed

This has been tested in LInux / Windows
