### PR TITLE
 KviMenuBar: help menu entries; have one help entry only

### DIFF
--- a/src/kvirc/kernel/KviCoreActions.cpp
+++ b/src/kvirc/kernel/KviCoreActions.cpp
@@ -309,7 +309,7 @@ void register_core_actions(KviActionManager * m)
 
 	SCRIPT_ACTION(
 	    KVI_COREACTION_HELPINDEX,
-	    "help -m",
+	    "help.open -m",
 	    __tr2qs("Help Index"),
 	    __tr2qs("Shows the documentation index"),
 	    KviActionManager::categoryGeneric(),

--- a/src/kvirc/ui/KviMenuBar.cpp
+++ b/src/kvirc/ui/KviMenuBar.cpp
@@ -116,10 +116,7 @@ void KviMenuBar::setupHelpPopup(QMenu * pop)
 
 	ACTION_POPUP_ITEM(KVI_COREACTION_HELPINDEX, help)
 
-	QAction * pAction = help->addAction(*(g_pIconManager->getSmallIcon(KviIconManager::Help)), __tr2qs("&Help Browser (Panel)"));
-	pAction->setData(KVI_INTERNALCOMMAND_HELP_NEWSTATICWINDOW);
-
-	pAction = help->addAction(*(g_pIconManager->getSmallIcon(KviIconManager::Idea)), __tr2qs("&Tip of the Day"));
+	QAction * pAction = help->addAction(*(g_pIconManager->getSmallIcon(KviIconManager::Idea)), __tr2qs("&Tip of the Day"));
 	pAction->setData(KVI_INTERNALCOMMAND_TIP_OPEN);
 	help->addSeparator();
 

--- a/src/modules/help/HelpWidget.cpp
+++ b/src/modules/help/HelpWidget.cpp
@@ -93,8 +93,8 @@ HelpWidget::HelpWidget(QWidget * par, bool bIsStandalone)
 	connect(m_pFindText, SIGNAL(textChanged(const QString)), this, SLOT(slotTextChanged(const QString)));
 
 	m_pToolBarHighlight->addAction(*g_pIconManager->getSmallIcon(KviIconManager::Discard), __tr2qs("Reset"), this, SLOT(slotResetFind()));
-	m_pToolBarHighlight->addAction(*g_pIconManager->getSmallIcon(KviIconManager::Part), __tr2qs("Find previous"), this, SLOT(slotFindPrev()));
-	m_pToolBarHighlight->addAction(*g_pIconManager->getSmallIcon(KviIconManager::Join), __tr2qs("Find next"), this, SLOT(slotFindNext()));
+	m_pToolBarHighlight->addAction(*g_pIconManager->getBigIcon(KVI_BIGICON_HELPBACK), __tr2qs("Find previous"), this, SLOT(slotFindPrev()));
+	m_pToolBarHighlight->addAction(*g_pIconManager->getBigIcon(KVI_BIGICON_HELPFORWARD), __tr2qs("Find next"), this, SLOT(slotFindNext()));
 
 	// upper toolbar contents (depends on webview)
 	QLabel * pBrowsingLabel = new QLabel();
@@ -165,6 +165,7 @@ void HelpWidget::slotFindNext()
 {
 	m_pTextBrowser->findText(m_pFindText->text());
 }
+
 void HelpWidget::slotZoomIn()
 {
 	kvs_real_t dZoom = m_pTextBrowser->zoomFactor();
@@ -214,19 +215,19 @@ HelpWidget::HelpWidget(QWidget * par, bool bIsStandalone)
 	connect(m_pBtnForward, SIGNAL(clicked()), m_pTextBrowser, SLOT(forward()));
 	m_pBtnForward->setEnabled(false);
 
-	QWidget * pSpacer = new QWidget(m_pToolBar);
-
 	if(bIsStandalone)
 	{
 		setAttribute(Qt::WA_DeleteOnClose);
-		QToolButton * b = new QToolButton(m_pToolBar);
-		b->setIcon(*g_pIconManager->getBigIcon(KVI_BIGICON_HELPCLOSE));
-		connect(b, SIGNAL(clicked()), this, SLOT(close()));
+		QToolButton * m_pBtnClose = new QToolButton(m_pToolBar);
+		m_pBtnClose->setIcon(*g_pIconManager->getBigIcon(KVI_BIGICON_HELPCLOSE));
+		connect(m_pBtnClose, SIGNAL(clicked()), this, SLOT(close()));
 	}
 
-	m_pToolBar->setStretchFactor(pSpacer, 1);
 	connect(m_pTextBrowser, SIGNAL(backwardAvailable(bool)), m_pBtnBackward, SLOT(setEnabled(bool)));
 	connect(m_pTextBrowser, SIGNAL(forwardAvailable(bool)), m_pBtnForward, SLOT(setEnabled(bool)));
+
+	QWidget * pSpacer = new QWidget(m_pToolBar);
+	m_pToolBar->setStretchFactor(pSpacer, 1);
 }
 
 #endif

--- a/src/modules/help/HelpWindow.cpp
+++ b/src/modules/help/HelpWindow.cpp
@@ -73,10 +73,8 @@ HelpWindow::HelpWindow(const char * name)
 
 	KviTalHBox * pSearchBox = new KviTalHBox(m_pIndexTab);
 	m_pIndexSearch = new QLineEdit(pSearchBox);
-	connect(m_pIndexSearch, SIGNAL(textChanged(const QString &)),
-	    this, SLOT(searchInIndex(const QString &)));
-	connect(m_pIndexSearch, SIGNAL(returnPressed()),
-	    this, SLOT(showIndexTopic()));
+	connect(m_pIndexSearch, SIGNAL(textChanged(const QString &)), this, SLOT(searchInIndex(const QString &)));
+	connect(m_pIndexSearch, SIGNAL(returnPressed()), this, SLOT(showIndexTopic()));
 
 	m_pBtnRefreshIndex = new QPushButton(pSearchBox);
 	m_pBtnRefreshIndex->setIcon(*g_pIconManager->getBigIcon(KVI_REFRESH_IMAGE_NAME));
@@ -91,8 +89,7 @@ HelpWindow::HelpWindow(const char * name)
 
 	m_pTermsEdit = new QLineEdit(m_pSearchTab);
 
-	connect(m_pTermsEdit, SIGNAL(returnPressed()),
-	    this, SLOT(startSearch()));
+	connect(m_pTermsEdit, SIGNAL(returnPressed()), this, SLOT(startSearch()));
 
 	m_pResultBox = new KviTalListWidget(m_pSearchTab);
 	connect(m_pResultBox, SIGNAL(itemActivated(QListWidgetItem *)), this, SLOT(searchSelected(QListWidgetItem *)));
@@ -133,10 +130,7 @@ void HelpWindow::initialSetup()
 		m_pBtnRefreshIndex->setEnabled(true);
 	}
 	else
-	{
 		g_pDocIndex->makeIndex();
-	}
-	//}
 }
 
 void HelpWindow::indexingStart(int iNum)
@@ -146,6 +140,7 @@ void HelpWindow::indexingStart(int iNum)
 	m_pProgressBar->setRange(0, iNum);
 	m_pProgressBar->setValue(0);
 }
+
 void HelpWindow::indexingProgress(int iNum)
 {
 	m_pProgressBar->setValue(iNum);
@@ -219,8 +214,8 @@ void HelpWindow::startSearch()
 				s = s.simplified();
 				if(s.contains('*'))
 				{
-					QMessageBox::warning(this, tr("Full Text Search - KVIrc"),
-					    tr("Using a wildcard within phrases is not allowed."));
+					QMessageBox::warning(this, __tr2qs("Full Text Search - KVIrc"),
+					    __tr2qs("Using a wildcard within phrases is not allowed."));
 					return;
 				}
 				seqWords += s.split(' ', QString::SkipEmptyParts);
@@ -230,8 +225,8 @@ void HelpWindow::startSearch()
 		}
 		else
 		{
-			QMessageBox::warning(this, tr("Full Text Search - KVIrc"),
-			    tr("The closing quotation mark is missing."));
+			QMessageBox::warning(this, __tr2qs("Full Text Search - KVIrc"),
+			    __tr2qs("The closing quotation mark is missing."));
 			return;
 		}
 	}


### PR DESCRIPTION
There is no good practical reason to have multiple entries on main menu especially when one entry is not searchable.
#### Changes proposed
-  Drop non searchable help options -- have one help entry only on MenuBar
-  make F1 entry also open an undocked window by default (like most apps use)
### Know issues

If closing help window from main window controls, at next reopen teh window size is shrunk to a square
**Hence WIP status and not merge recommendation is set.**
