### PR TITLE
add toggle + shortcut to switch between treewidow list <-> classic window list 

### DIFF
--- a/src/kvilib/config/kvi_shortcuts.h
+++ b/src/kvilib/config/kvi_shortcuts.h
@@ -149,6 +149,7 @@
 #endif
 #define KVI_SHORTCUTS_INPUT_REVERSE "Ctrl+R"
 #define KVI_SHORTCUTS_SERVERS "Ctrl+S"
+#define KVI_SHORTCUTS_TOGGLE_TREE_LIST "Ctrl+T"               // Ctrl+T
 #define KVI_SHORTCUTS_INPUT_UNDERLINE QKeySequence::Underline // Ctrl+U
 #define KVI_SHORTCUTS_INPUT_PASTE QKeySequence::Paste         // Ctrl+V
 #define KVI_SHORTCUTS_WIN_CLOSE "Ctrl+W"                      // QKeySequence::Close seems to be problematic

--- a/src/kvirc/ui/KviMainWindow.cpp
+++ b/src/kvirc/ui/KviMainWindow.cpp
@@ -1059,6 +1059,13 @@ void KviMainWindow::toggleMenuBar()
 	}
 }
 
+void KviMainWindow::toggleWindowList()
+{
+	KVI_OPTION_BOOL(KviOption_boolUseTreeWindowList) = !KVI_OPTION_BOOL(KviOption_boolUseTreeWindowList);
+	recreateWindowList();
+	applyOptions();
+}
+
 void KviMainWindow::fillToolBarsPopup(QMenu * p)
 {
 	p->clear();

--- a/src/kvirc/ui/KviMainWindow.h
+++ b/src/kvirc/ui/KviMainWindow.h
@@ -159,6 +159,7 @@ public slots:
 	void executeInternalCommand(int index);
 	void toggleStatusBar();
 	void toggleMenuBar();
+	void toggleWindowList();
 	void customizeToolBars();
 
 protected:

--- a/src/kvirc/ui/KviMenuBar.cpp
+++ b/src/kvirc/ui/KviMenuBar.cpp
@@ -186,6 +186,11 @@ void KviMenuBar::setupSettingsPopup(QMenu * pop)
 	m_pStatusBarAction = opt->addAction(*(g_pIconManager->getSmallIcon(KviIconManager::StatusBar)), __tr2qs("Show Status Bar"), m_pFrm, SLOT(toggleStatusBar()));
 	m_pStatusBarAction->setCheckable(true);
 
+	m_pWindowListAction = opt->addAction(*(g_pIconManager->getSmallIcon(KviIconManager::TreeWindowList)), __tr2qs("Show Tree Window List"), m_pFrm, SLOT(toggleWindowList()));
+	g_pMainWindow->addAction(m_pWindowListAction);
+	m_pWindowListAction->setCheckable(true);
+	m_pWindowListAction->setShortcut(QKeySequence::fromString(KVI_SHORTCUTS_TOGGLE_TREE_LIST));
+
 	opt->addSeparator();
 	// FIXME: #warning "Toggle these items on the fly ?"
 	ACTION_POPUP_ITEM(KVI_COREACTION_GENERALOPTIONS, opt)
@@ -197,15 +202,6 @@ void KviMenuBar::setupSettingsPopup(QMenu * pop)
 	opt->addSeparator();
 	ACTION_POPUP_ITEM(KVI_COREACTION_MANAGETHEMES, opt)
 	ACTION_POPUP_ITEM(KVI_COREACTION_MANAGEADDONS, opt)
-
-	// In 2010 this is not professional :D
-	// The app must take care of saving user options whenever they are changed.
-	//
-	// If you're playing with unstable stuff then use /options.save to obtain
-	// the same effect.
-	//
-	//opt->addSeparator();
-	//opt->addAction(*(g_pIconManager->getSmallIcon(KVI_SMALLICON_FLOPPY)),__tr2qs("&Save Configuration"),g_pApp,SLOT(saveConfiguration()));
 }
 
 void KviMenuBar::setupScriptingPopup(QMenu * pop)

--- a/src/kvirc/ui/KviMenuBar.cpp
+++ b/src/kvirc/ui/KviMenuBar.cpp
@@ -35,6 +35,7 @@
 #include "KviKvsPopupMenu.h"
 #include "KviMemory.h"
 #include "KviModuleExtension.h"
+#include "KviOptions.h"
 #include "KviActionManager.h"
 #include "KviCoreActionNames.h"
 #include "KviKvsScript.h"
@@ -165,6 +166,7 @@ void KviMenuBar::updateSettingsPopup()
 #ifndef COMPILE_ON_MAC
 	m_pMenuBarAction->setChecked(true);
 #endif
+	m_pWindowListAction->setChecked(KVI_OPTION_BOOL(KviOption_boolUseTreeWindowList));
 }
 
 void KviMenuBar::setupSettingsPopup(QMenu * pop)

--- a/src/kvirc/ui/KviMenuBar.h
+++ b/src/kvirc/ui/KviMenuBar.h
@@ -58,6 +58,7 @@ protected:
 	// Dynamic actions
 	QAction * m_pMenuBarAction;
 	QAction * m_pStatusBarAction;
+	QAction * m_pWindowListAction;
 	QAction * m_pDisconnectAction;
 	QAction * m_pModulesToolsAction;
 	QAction * m_pActionsToolsAction;


### PR DESCRIPTION
This does pretty much what it says on the tin with exception to known issues.
#### Changes proposed
- add toggle + shortcut to switch between tree widow list <-> classic window list 
### Know issues

https://github.com/kvirc/KVIrc/commit/df1c813e110ba5d4c777be68845ab78ebb807100 was supposed to read the current state of **boolUseTreeWindowList** if it is set manually/via theme or other method and reflect state in menubar toggle, however this does not work as intended.

What happens is if the theme has set **boolUseTreeWindowList** to false/true the toggle doesnt seem to update to reflect change, same with manual `/option  boolUseTreeWindowList (0/1)`
