### PR TITLE
source: obsolete dirbrowser entries  cleanup

### DIFF
--- a/src/kvilib/ext/KviMediaManager.cpp
+++ b/src/kvilib/ext/KviMediaManager.cpp
@@ -228,23 +228,6 @@ KviMediaType * KviMediaManager::findMediaType(const char * filename, bool bCheck
 #endif
 	}
 
-	if(S_ISDIR(st.st_mode))
-	{
-		// Directory : return default media type
-		KviMediaType * mtd = findMediaTypeByIanaType("inode/directory");
-		if(!mtd)
-		{
-			// Add it
-			mtd = new KviMediaType;
-			mtd->szIanaType = "inode/directory";
-			mtd->szDescription = __tr("Directory");
-			mtd->szCommandline = "dirbrowser.open -m $0";
-			mtd->szIcon = "kvi_dbfolder.png"; // hardcoded ?
-			insertMediaType(mtd);
-		}
-		return mtd;
-	}
-
 #if !defined(COMPILE_ON_WINDOWS) && !defined(COMPILE_ON_MINGW)
 	if(S_ISSOCK(st.st_mode))
 	{

--- a/src/kvirc/kernel/KviApplication.cpp
+++ b/src/kvirc/kernel/KviApplication.cpp
@@ -787,7 +787,6 @@ void KviApplication::notifierMessage(KviWindow * pWnd, int iIconId, const QStrin
 			//KviWindow::DccVideo
 			//KviWindow::Tool
 			//KviWindow::IOGraph
-			//KviWindow::DirBrowser
 			//KviWindow::ScriptEditor
 			//KviWindow::ScriptObject
 			//KviWindow::LogView

--- a/src/kvirc/ui/KviWindow.cpp
+++ b/src/kvirc/ui/KviWindow.cpp
@@ -325,14 +325,14 @@ const char * KviWindow::m_typeTable[TypeCount] = {
 	"userwindow",   // 16
 	"tool",         // 17
 	"iograph",      // 18
-	"dirbrowser",   // 19
+	"dirbrowser",   // 19 /!\ no longer exists please reuse entry
 	"scripteditor", // 20
 	"scriptobject", // 21
 	"logview",      // 22
 	"offer",        // 23
 	"debug",        // 24
 	// <------ NEW TYPES GO HERE!
-	"unknown" // 25
+	"unknown"       // 25
 };
 
 const char * KviWindow::typeString()

--- a/src/kvirc/ui/KviWindow.h
+++ b/src/kvirc/ui/KviWindow.h
@@ -148,7 +148,7 @@ public:
 		UserWindow = 16,
 		Tool = 17,
 		IOGraph = 18,
-		DirBrowser = 19,
+		DirBrowser = 19,   //!\ no longer exists please reuse entry
 		ScriptEditor = 20,
 		ScriptObject = 21,
 		LogView = 22,


### PR DESCRIPTION
#### Changes proposed
- dirbrowser module has been gone for a long time say good bye to remnants 

resolves #2005 

cleaned-up in:
- KviMediaManager.cpp
- KviWindow.h/.cpp

Tagged for attention from dev due to entries in https://github.com/un1versal/KVIrc/blob/633afc75164bbe272ef1897d4b5854ef12209368/src/kvilib/ext/KviMediaManager.cpp#L231-L297

Ide like to know what they do and when they are shown or if they are even used currently or was this all part of same dirbrowser?
