### PR TITLE
Shortcut change + source cleanups

### DIFF
--- a/src/kvilib/config/kvi_shortcuts.h
+++ b/src/kvilib/config/kvi_shortcuts.h
@@ -80,6 +80,7 @@
 * \def KVI_SHORTCUTS_INPUT_NEXT_CHAR_SELECT Move the selection to the right
 * \def KVI_SHORTCUTS_INPUT_NEXT_WORD Move to the end of the next word
 * \def KVI_SHORTCUTS_INPUT_NEXT_WORD_SELECT Select up to the end of the next word
+* \def KVI_SHORTCUTS_INPUT_UNDERLINE Insert Underline control character
 * \def KVI_SHORTCUTS_INPUT_PASTE Paste the clipboard contents (same as middle mouse click)
 * \def KVI_SHORTCUTS_INPUT_PLAINTEXT Insert the 'non-crypt' (plain text) KVIrc control character used to disable encryption of the current text line
 * \def KVI_SHORTCUTS_INPUT_PREV_CHAR Move the cursor to the left
@@ -128,101 +129,109 @@
 * \def KVI_SHORTCUTS_WIN_ZOOM_OUT Decrease font size
 */
 
+//
 // Please keep this list ordered by shortcut key and not by name :)
+//
+
 #define KVI_SHORTCUTS_HELP QKeySequence::HelpContents          // F1
 #define KVI_SHORTCUTS_INPUT_SELECT_ALL QKeySequence::SelectAll // Ctrl+A
 #define KVI_SHORTCUTS_INPUT_BOLD QKeySequence::Bold            // Ctrl+B
 #define KVI_SHORTCUTS_INPUT_COPY QKeySequence::Copy            // Ctrl+C
 #define KVI_SHORTCUTS_WIN_SEARCH QKeySequence::Find            // Ctrl+F
 #define KVI_SHORTCUTS_INPUT_ITALIC QKeySequence::Italic        // Ctrl+I
-#define KVI_SHORTCUTS_JOIN "Ctrl+J"
-#define KVI_SHORTCUTS_INPUT_COLOR "Ctrl+K"
-#define KVI_SHORTCUTS_WIN_SCROLL_TO_LAST_READ_LINE "Ctrl+L"
-#define KVI_SHORTCUTS_TOGGLE_MENU_BAR "Ctrl+M"
-#define KVI_SHORTCUTS_CONTEXT QKeySequence::New // Ctrl+N
-#define KVI_SHORTCUTS_INPUT_RESET "Ctrl+O"
-#define KVI_SHORTCUTS_INPUT_PLAINTEXT "Ctrl+P"
-#ifdef COMPILE_ON_MAC
-#define KVI_SHORTCUTS_QUIT QString()
-#else
-#define KVI_SHORTCUTS_QUIT "Ctrl+Q"
-#endif
-#define KVI_SHORTCUTS_INPUT_REVERSE "Ctrl+R"
-#define KVI_SHORTCUTS_SERVERS "Ctrl+S"
-#define KVI_SHORTCUTS_TOGGLE_TREE_LIST "Ctrl+T"               // Ctrl+T
-#define KVI_SHORTCUTS_INPUT_UNDERLINE QKeySequence::Underline // Ctrl+U
-#define KVI_SHORTCUTS_INPUT_PASTE QKeySequence::Paste         // Ctrl+V
-#define KVI_SHORTCUTS_WIN_CLOSE "Ctrl+W"                      // QKeySequence::Close seems to be problematic
-#define KVI_SHORTCUTS_INPUT_CUT QKeySequence::Cut             // Ctrl+X
-#define KVI_SHORTCUTS_INPUT_COMMANDLINE "Ctrl+Y"
-#define KVI_SHORTCUTS_INPUT_UNDO QKeySequence::Undo           // Ctrl+Z
-#define KVI_SHORTCUTS_INPUT_ICON "Ctrl+Alt+E"                 // Ctrl+Alt+E
-#define KVI_SHORTCUTS_AWAY "Ctrl+Shift+A"
-#define KVI_SHORTCUTS_EDITORS_TOOLBAR "Ctrl+Shift+B"
-#define KVI_SHORTCUTS_CONNECT "Ctrl+Shift+C"
-#define KVI_SHORTCUTS_EDITORS_CLASS "Ctrl+Shift+D"
-#define KVI_SHORTCUTS_EDITORS_EVENT "Ctrl+Shift+E"
-#define KVI_SHORTCUTS_IDENTITY "Ctrl+Shift+I"
-#define KVI_SHORTCUTS_EDITORS_ALIAS "Ctrl+Shift+L"
-#define KVI_SHORTCUTS_MANAGE_THEMES "Ctrl+Shift+M"
-#define KVI_SHORTCUTS_MANAGE_ADDONS "Ctrl+Shift+N"
-#define KVI_SHORTCUTS_OPTIONS "Ctrl+Shift+O"
-#define KVI_SHORTCUTS_EDITORS_POPUP "Ctrl+Shift+P"
-#define KVI_SHORTCUTS_EDITORS_ACTION "Ctrl+Shift+Q"
-#define KVI_SHORTCUTS_EDITORS_RAW "Ctrl+Shift+R"
-#define KVI_SHORTCUTS_EDITORS_TESTER "Ctrl+Shift+S"
-#define KVI_SHORTCUTS_THEME "Ctrl+Shift+T"
-#define KVI_SHORTCUTS_USERS "Ctrl+Shift+U"
-#define KVI_SHORTCUTS_EXEC "Ctrl+Shift+X"
-#define KVI_SHORTCUTS_INPUT_REDO QKeySequence::Redo // Ctrl+Shift+Z
-#define KVI_SHORTCUTS_WIN_PREV Qt::AltModifier + Qt::Key_Up
-#define KVI_SHORTCUTS_WIN_NEXT Qt::AltModifier + Qt::Key_Down
-#define KVI_SHORTCUTS_WIN_NEXT_TAB Qt::ControlModifier + Qt::Key_Tab // Ctrl+Tab
-#if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
-#define KVI_SHORTCUTS_WIN_PREV_TAB Qt::ControlModifier + Qt::ShiftModifier + Qt::Key_Tab // Ctrl+Shift+Tab
-#else
-#define KVI_SHORTCUTS_WIN_PREV_TAB Qt::ControlModifier + Qt::Key_Backtab // Ctrl+Shift+Tab
-#endif
-#define KVI_SHORTCUTS_WIN_PREV_CONTEXT Qt::AltModifier + Qt::ShiftModifier + Qt::Key_Up
-#define KVI_SHORTCUTS_WIN_NEXT_CONTEXT Qt::AltModifier + Qt::ShiftModifier + Qt::Key_Down
-#define KVI_SHORTCUTS_WIN_PREV_HIGHLIGHT Qt::AltModifier + Qt::Key_PageUp
-#define KVI_SHORTCUTS_WIN_NEXT_HIGHLIGHT Qt::AltModifier + Qt::Key_PageDown
-#define KVI_SHORTCUTS_WIN_PREV_PAGE QKeySequence::MoveToPreviousPage // Qt::Key_PageUp
-#define KVI_SHORTCUTS_WIN_NEXT_PAGE QKeySequence::MoveToNextPage     // Qt::Key_PageDown
-#define KVI_SHORTCUTS_WIN_PREV_LINE Qt::ShiftModifier + Qt::Key_PageUp
-#define KVI_SHORTCUTS_WIN_NEXT_LINE Qt::ShiftModifier + Qt::Key_PageDown
-#define KVI_SHORTCUTS_INPUT_PREV_WORD QKeySequence::MoveToPreviousWord        // Qt::ControlModifier + Qt::Key_Left
-#define KVI_SHORTCUTS_INPUT_NEXT_WORD QKeySequence::MoveToNextWord            // Qt::ControlModifier + Qt::Key_Right
-#define KVI_SHORTCUTS_INPUT_PREV_WORD_SELECT QKeySequence::SelectPreviousWord // Qt::ControlModifier + Qt::ShiftModifier + Qt::Key_Left
-#define KVI_SHORTCUTS_INPUT_NEXT_WORD_SELECT QKeySequence::SelectNextWord     // Qt::ControlModifier + Qt::ShiftModifier + Qt::Key_Right
-//Ctrl+<digit>: Script accelerators (see OnAccelKeyPressed)
-//F2-F12, Shift+(F1-F12): Script accelerators (see OnAccelKeyPressed)
-#define KVI_SHORTCUTS_INPUT_HISTORY Qt::ControlModifier + Qt::Key_PageUp
-#define KVI_SHORTCUTS_INPUT_PREV_CHAR QKeySequence::MoveToPreviousChar        // Qt::Key_Left
-#define KVI_SHORTCUTS_INPUT_NEXT_CHAR QKeySequence::MoveToNextChar            // Qt::Key_Right
-#define KVI_SHORTCUTS_INPUT_PREV_CHAR_SELECT QKeySequence::SelectPreviousChar // Qt::ShiftModifier + Qt::Key_Left
-#define KVI_SHORTCUTS_INPUT_NEXT_CHAR_SELECT QKeySequence::SelectNextChar     // Qt::ShiftModifier + Qt::Key_Right
-#define KVI_SHORTCUTS_INPUT_DELETE_PREV_WORD QKeySequence::DeleteStartOfWord  // Qt::ControlModifier + Qt::Key_Backspace
-#define KVI_SHORTCUTS_INPUT_DELETE_NEXT_WORD QKeySequence::DeleteEndOfWord    // Qt::ControlModifier + Qt::Key_Delete
-#define KVI_SHORTCUTS_INPUT_MULTILINE Qt::AltModifier + Qt::Key_Return
-#define KVI_SHORTCUTS_INPUT_MULTILINE_2 Qt::AltModifier + Qt::Key_Enter
-#define KVI_SHORTCUTS_INPUT_SEND_PLAIN Qt::ControlModifier + Qt::Key_Return
-#define KVI_SHORTCUTS_INPUT_SEND_PLAIN_2 Qt::ControlModifier + Qt::Key_Enter
-#define KVI_SHORTCUTS_INPUT_SEND_KVS Qt::ShiftModifier + Qt::Key_Return
-#define KVI_SHORTCUTS_INPUT_SEND_KVS_2 Qt::ShiftModifier + Qt::Key_Enter
-#define KVI_SHORTCUTS_INPUT_HOME QKeySequence::MoveToStartOfLine          // Qt::Key_Home
-#define KVI_SHORTCUTS_INPUT_END QKeySequence::MoveToEndOfLine             // Qt::Key_End
-#define KVI_SHORTCUTS_INPUT_HOME_SELECT QKeySequence::SelectStartOfLine   // Qt::ShiftModifier + Qt::Key_Home
-#define KVI_SHORTCUTS_INPUT_END_SELECT QKeySequence::SelectEndOfLine      // Qt::ShiftModifier + Qt::Key_End
-#define KVI_SHORTCUTS_INPUT_HISTORY_PREV QKeySequence::MoveToPreviousLine // Qt::Key_Up
-#define KVI_SHORTCUTS_INPUT_HISTORY_NEXT QKeySequence::MoveToNextLine     // Qt::Key_Down
-#define KVI_SHORTCUTS_INPUT_ESCAPE Qt::Key_Escape
-#define KVI_SHORTCUTS_INPUT_DUMMY Qt::ShiftModifier + Qt::Key_Escape
-#define KVI_SHORTCUTS_WIN_ZOOM_IN QKeySequence::ZoomIn   // Ctrl++
-#define KVI_SHORTCUTS_WIN_ZOOM_OUT QKeySequence::ZoomOut // Ctrl+-
-#define KVI_SHORTCUTS_WIN_ZOOM_DEFAULT Qt::ControlModifier + Qt::Key_0
-#define KVI_SHORTCUTS_INPUT_CORRECT_SPELLING Qt::ControlModifier + Qt::Key_G
-#define KVI_SHORTCUTS_INPUT_MENU Qt::Key_Menu
+#define KVI_SHORTCUTS_JOIN "Ctrl+J"                            // Ctrl+J
+#define KVI_SHORTCUTS_INPUT_COLOR "Ctrl+K"                     // Ctrl+K
+#define KVI_SHORTCUTS_WIN_SCROLL_TO_LAST_READ_LINE "Ctrl+L"    // Ctrl+L
+#define KVI_SHORTCUTS_TOGGLE_MENU_BAR "Ctrl+M"                 // Ctrl+M
+#define KVI_SHORTCUTS_CONTEXT QKeySequence::New                // Ctrl+N
+#define KVI_SHORTCUTS_INPUT_RESET "Ctrl+O"                     // Ctrl+O
+#define KVI_SHORTCUTS_INPUT_PLAINTEXT "Ctrl+P"                 // Ctrl+P
+#ifdef COMPILE_ON_MAC                                          // ------
+#define KVI_SHORTCUTS_QUIT QString()                           // Qstring()
+#else                                                          // ------
+#define KVI_SHORTCUTS_QUIT "Ctrl+Q"                            // Ctrl+Q
+#endif                                                         // ------
+#define KVI_SHORTCUTS_INPUT_REVERSE "Ctrl+R"                   // Ctrl+R
+#define KVI_SHORTCUTS_SERVERS "Ctrl+S"                         // Ctrl+S
+#define KVI_SHORTCUTS_TOGGLE_TREE_LIST "Ctrl+T"                // Ctrl+T
+#define KVI_SHORTCUTS_INPUT_UNDERLINE QKeySequence::Underline  // Ctrl+U
+#define KVI_SHORTCUTS_INPUT_PASTE QKeySequence::Paste          // Ctrl+V
+#define KVI_SHORTCUTS_WIN_CLOSE "Ctrl+W"                       // Ctrl+W QKeySequence::Close seems to be problematic
+#define KVI_SHORTCUTS_INPUT_CUT QKeySequence::Cut              // Ctrl+X
+#define KVI_SHORTCUTS_INPUT_COMMANDLINE "Ctrl+Y"               // Ctrl+Y
+#define KVI_SHORTCUTS_INPUT_UNDO QKeySequence::Undo            // Ctrl+Z
+
+#define KVI_SHORTCUTS_INPUT_ICON "Ctrl+Alt+E"                  // Ctrl+Alt+E
+
+#define KVI_SHORTCUTS_AWAY "Ctrl+Shift+A"                      // Ctrl+Shift+A
+#define KVI_SHORTCUTS_EDITORS_TOOLBAR "Ctrl+Shift+B"           // Ctrl+Shift+B
+#define KVI_SHORTCUTS_CONNECT "Ctrl+Shift+C"                   // Ctrl+Shift+C
+#define KVI_SHORTCUTS_EDITORS_CLASS "Ctrl+Shift+D"             // Ctrl+Shift+D
+#define KVI_SHORTCUTS_EDITORS_EVENT "Ctrl+Shift+E"             // Ctrl+Shift+E
+#define KVI_SHORTCUTS_IDENTITY "Ctrl+Shift+I"                  // Ctrl+Shift+I
+#define KVI_SHORTCUTS_EDITORS_ALIAS "Ctrl+Shift+L"             // Ctrl+Shift+L
+#define KVI_SHORTCUTS_MANAGE_THEMES "Ctrl+Shift+M"             // Ctrl+Shift+M
+#define KVI_SHORTCUTS_MANAGE_ADDONS "Ctrl+Shift+N"             // Ctrl+Shift+N
+#define KVI_SHORTCUTS_OPTIONS "Ctrl+Shift+O"                   // Ctrl+Shift+O
+#define KVI_SHORTCUTS_EDITORS_POPUP "Ctrl+Shift+P"             // Ctrl+Shift+P
+#define KVI_SHORTCUTS_EDITORS_ACTION "Ctrl+Shift+Q"            // Ctrl+Shift+Q
+#define KVI_SHORTCUTS_EDITORS_RAW "Ctrl+Shift+R"               // Ctrl+Shift+R
+#define KVI_SHORTCUTS_EDITORS_TESTER "Ctrl+Shift+S"            // Ctrl+Shift+S
+#define KVI_SHORTCUTS_THEME "Ctrl+Shift+T"                     // Ctrl+Shift+T
+#define KVI_SHORTCUTS_USERS "Ctrl+Shift+U"                     // Ctrl+Shift+U
+#define KVI_SHORTCUTS_EXEC "Ctrl+Shift+X"                      // Ctrl+Shift+X
+#define KVI_SHORTCUTS_INPUT_REDO QKeySequence::Redo            // Ctrl+Shift+Z
+
+#define KVI_SHORTCUTS_WIN_PREV Qt::AltModifier + Qt::Key_Up                               // Qt::AltModifier + Qt::Key_Up
+#define KVI_SHORTCUTS_WIN_NEXT Qt::AltModifier + Qt::Key_Down                             // Qt::AltModifier + Qt::Key_Down
+#define KVI_SHORTCUTS_WIN_NEXT_TAB Qt::ControlModifier + Qt::Key_Tab                      // Ctrl+Tab
+#if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)                              // --------------
+#define KVI_SHORTCUTS_WIN_PREV_TAB Qt::ControlModifier + Qt::ShiftModifier + Qt::Key_Tab  // Ctrl+Shift+Tab
+#else                                                                                     // --------------
+#define KVI_SHORTCUTS_WIN_PREV_TAB Qt::ControlModifier + Qt::Key_Backtab                  // Ctrl+Shift+Tab
+#endif                                                                                    // --------------
+#define KVI_SHORTCUTS_WIN_PREV_CONTEXT Qt::AltModifier + Qt::ShiftModifier + Qt::Key_Up   // Qt::AltModifier + Qt::ShiftModifier + Qt::Key_Up
+#define KVI_SHORTCUTS_WIN_NEXT_CONTEXT Qt::AltModifier + Qt::ShiftModifier + Qt::Key_Down // Qt::AltModifier + Qt::ShiftModifier + Qt::Key_Down
+#define KVI_SHORTCUTS_WIN_PREV_HIGHLIGHT Qt::AltModifier + Qt::Key_PageUp                 // Qt::AltModifier + Qt::Key_PageUp
+#define KVI_SHORTCUTS_WIN_NEXT_HIGHLIGHT Qt::AltModifier + Qt::Key_PageDown               // Qt::AltModifier + Qt::Key_PageDown
+#define KVI_SHORTCUTS_WIN_PREV_PAGE QKeySequence::MoveToPreviousPage                      // Qt::Key_PageUp
+#define KVI_SHORTCUTS_WIN_NEXT_PAGE QKeySequence::MoveToNextPage                          // Qt::Key_PageDown
+#define KVI_SHORTCUTS_WIN_PREV_LINE Qt::ShiftModifier + Qt::Key_PageUp                    // Qt::ShiftModifier + Qt::Key_PageUp
+#define KVI_SHORTCUTS_WIN_NEXT_LINE Qt::ShiftModifier + Qt::Key_PageDown                  // Qt::ShiftModifier + Qt::Key_PageDown
+#define KVI_SHORTCUTS_INPUT_PREV_WORD QKeySequence::MoveToPreviousWord                    // Qt::ControlModifier + Qt::Key_Left
+#define KVI_SHORTCUTS_INPUT_NEXT_WORD QKeySequence::MoveToNextWord                        // Qt::ControlModifier + Qt::Key_Right
+#define KVI_SHORTCUTS_INPUT_PREV_WORD_SELECT QKeySequence::SelectPreviousWord             // Qt::ControlModifier + Qt::ShiftModifier + Qt::Key_Left
+#define KVI_SHORTCUTS_INPUT_NEXT_WORD_SELECT QKeySequence::SelectNextWord                 // Qt::ControlModifier + Qt::ShiftModifier + Qt::Key_Right
+//
+//Ctrl+<digit>: Script accelerators (see OnAccelKeyPressed)                               // --------------
+//F2-F12, Shift+(F1-F12): Script accelerators (see OnAccelKeyPressed)                     // --------------
+//
+#define KVI_SHORTCUTS_INPUT_HISTORY Qt::ControlModifier + Qt::Key_PageUp                  // Qt::ControlModifier + Qt::Key_PageUp
+#define KVI_SHORTCUTS_INPUT_PREV_CHAR QKeySequence::MoveToPreviousChar                    // Qt::Key_Left
+#define KVI_SHORTCUTS_INPUT_NEXT_CHAR QKeySequence::MoveToNextChar                        // Qt::Key_Right
+#define KVI_SHORTCUTS_INPUT_PREV_CHAR_SELECT QKeySequence::SelectPreviousChar             // Qt::ShiftModifier + Qt::Key_Left
+#define KVI_SHORTCUTS_INPUT_NEXT_CHAR_SELECT QKeySequence::SelectNextChar                 // Qt::ShiftModifier + Qt::Key_Right
+#define KVI_SHORTCUTS_INPUT_DELETE_PREV_WORD QKeySequence::DeleteStartOfWord              // Qt::ControlModifier + Qt::Key_Backspace
+#define KVI_SHORTCUTS_INPUT_DELETE_NEXT_WORD QKeySequence::DeleteEndOfWord                // Qt::ControlModifier + Qt::Key_Delete
+#define KVI_SHORTCUTS_INPUT_MULTILINE Qt::AltModifier + Qt::Key_Return                    // Qt::AltModifier + Qt::Key_Return
+#define KVI_SHORTCUTS_INPUT_MULTILINE_2 Qt::AltModifier + Qt::Key_Enter                   // Qt::AltModifier + Qt::Key_Enter
+#define KVI_SHORTCUTS_INPUT_SEND_PLAIN Qt::ControlModifier + Qt::Key_Return               // Qt::ControlModifier + Qt::Key_Return
+#define KVI_SHORTCUTS_INPUT_SEND_PLAIN_2 Qt::ControlModifier + Qt::Key_Enter              // Qt::ControlModifier + Qt::Key_Enter
+#define KVI_SHORTCUTS_INPUT_SEND_KVS Qt::ShiftModifier + Qt::Key_Return                   // Qt::ShiftModifier + Qt::Key_Return
+#define KVI_SHORTCUTS_INPUT_SEND_KVS_2 Qt::ShiftModifier + Qt::Key_Enter                  // Qt::ShiftModifier + Qt::Key_Enter
+#define KVI_SHORTCUTS_INPUT_HOME QKeySequence::MoveToStartOfLine                          // Qt::Key_Home
+#define KVI_SHORTCUTS_INPUT_END QKeySequence::MoveToEndOfLine                             // Qt::Key_End
+#define KVI_SHORTCUTS_INPUT_HOME_SELECT QKeySequence::SelectStartOfLine                   // Qt::ShiftModifier + Qt::Key_Home
+#define KVI_SHORTCUTS_INPUT_END_SELECT QKeySequence::SelectEndOfLine                      // Qt::ShiftModifier + Qt::Key_End
+#define KVI_SHORTCUTS_INPUT_HISTORY_PREV QKeySequence::MoveToPreviousLine                 // Qt::Key_Up
+#define KVI_SHORTCUTS_INPUT_HISTORY_NEXT QKeySequence::MoveToNextLine                     // Qt::Key_Down
+#define KVI_SHORTCUTS_INPUT_ESCAPE Qt::Key_Escape                                         // Qt::Key_Escape
+#define KVI_SHORTCUTS_INPUT_DUMMY Qt::ShiftModifier + Qt::Key_Escape                      // Qt::ShiftModifier + Qt::Key_Escape
+#define KVI_SHORTCUTS_WIN_ZOOM_IN QKeySequence::ZoomIn                                    // Ctrl++
+#define KVI_SHORTCUTS_WIN_ZOOM_OUT QKeySequence::ZoomOut                                  // Ctrl+-
+#define KVI_SHORTCUTS_WIN_ZOOM_DEFAULT Qt::ControlModifier + Qt::Key_0                    // Qt::ControlModifier + Qt::Key_0
+#define KVI_SHORTCUTS_INPUT_CORRECT_SPELLING Qt::ControlModifier + Qt::Key_G              // Qt::ControlModifier + Qt::Key_G
+#define KVI_SHORTCUTS_INPUT_MENU Qt::Key_Menu                                             // Qt::Key_Menu
 
 /*
 	@doc: keyboard
@@ -260,6 +269,7 @@
 		[b]Ctrl+Q:[/b] Quit [br]
 		[b]Ctrl+R:[/b] Insert Reverse control character[br]
 		[b]Ctrl+S:[/b] Open [i]Servers[/i] dialog [br]
+		[b]Ctrl+T:[/b] Switch between [i]Tree Window List[/i] and [i]Classic Window List[/i][br]
 		[b]Ctrl+U:[/b] Insert Underline control character[br]
 		[b]Ctrl+V:[/b] Paste clipboard contents[br]
 		[b]Ctrl+W:[/b] Close current window[br]
@@ -269,7 +279,9 @@
 		[b]Ctrl+"+":[/b] Increase font size[br]
 		[b]Ctrl+"-":[/b] Decrease font size[br]
 		[b]Ctrl+0:[/b] Restore default font (and font size)[br]
+
 		[b]Ctrl+Alt+E:[/b] Open [i]Insert icon[/i] dialog[br]
+
 		[b]Ctrl+Shift+A:[/b] Go away/back[br]
 		[b]Ctrl+Shift+B:[/b] Open [i]Manage Toolbars[/i] dialog[br]
 		[b]Ctrl+Shift+C:[/b] Connect/disconnect current irc context[br]
@@ -338,11 +350,11 @@
 		[b]Shift+Enter:[/b] Send message as a kvs command[br]
 		[b]Alt+<numeric_sequence>:[/b] Insert the character by ASCII/Unicode code[br]
 		[example]
-		[b]Alt+32:[/b] Inserts ASCII/Unicode character 32: ' ' (a space)
-		[b]Alt+00032:[/b] Same as above :)
-		[b]Alt+13:[/b] Inserts the Carriage Return (CR) control character
-		[b]Alt+77:[/b] Inserts ASCII/Unicode character 77: 'M'
-		[b]Alt+23566:[/b] Inserts Unicode character 23566 (an ideogram)
+			[b]Alt+32:[/b] Inserts ASCII/Unicode character 32: ' ' (a space)
+			[b]Alt+00032:[/b] Same as above :)
+			[b]Alt+13:[/b] Inserts the Carriage Return (CR) control character
+			[b]Alt+77:[/b] Inserts ASCII/Unicode character 77: 'M'
+			[b]Alt+23566:[/b] Inserts Unicode character 23566 (an ideogram)
 		[/example]
 
 		[big]Completion hotkeys[/big][br]

--- a/src/kvilib/config/kvi_shortcuts.h
+++ b/src/kvilib/config/kvi_shortcuts.h
@@ -80,7 +80,6 @@
 * \def KVI_SHORTCUTS_INPUT_NEXT_CHAR_SELECT Move the selection to the right
 * \def KVI_SHORTCUTS_INPUT_NEXT_WORD Move to the end of the next word
 * \def KVI_SHORTCUTS_INPUT_NEXT_WORD_SELECT Select up to the end of the next word
-* \def KVI_SHORTCUTS_INPUT_UNDERLINE Insert Underline control character
 * \def KVI_SHORTCUTS_INPUT_PASTE Paste the clipboard contents (same as middle mouse click)
 * \def KVI_SHORTCUTS_INPUT_PLAINTEXT Insert the 'non-crypt' (plain text) KVIrc control character used to disable encryption of the current text line
 * \def KVI_SHORTCUTS_INPUT_PREV_CHAR Move the cursor to the left
@@ -161,7 +160,8 @@
 #define KVI_SHORTCUTS_INPUT_COMMANDLINE "Ctrl+Y"               // Ctrl+Y
 #define KVI_SHORTCUTS_INPUT_UNDO QKeySequence::Undo            // Ctrl+Z
 
-#define KVI_SHORTCUTS_INPUT_ICON "Ctrl+Alt+E"                  // Ctrl+Alt+E
+#define KVI_SHORTCUTS_INPUT_ICON "Alt+E"                       // Alt+E
+#define KVI_SHORTCUTS_USERS "Alt+U"                            // Alt+U
 
 #define KVI_SHORTCUTS_AWAY "Ctrl+Shift+A"                      // Ctrl+Shift+A
 #define KVI_SHORTCUTS_EDITORS_TOOLBAR "Ctrl+Shift+B"           // Ctrl+Shift+B
@@ -178,7 +178,6 @@
 #define KVI_SHORTCUTS_EDITORS_RAW "Ctrl+Shift+R"               // Ctrl+Shift+R
 #define KVI_SHORTCUTS_EDITORS_TESTER "Ctrl+Shift+S"            // Ctrl+Shift+S
 #define KVI_SHORTCUTS_THEME "Ctrl+Shift+T"                     // Ctrl+Shift+T
-#define KVI_SHORTCUTS_USERS "Ctrl+Shift+U"                     // Ctrl+Shift+U
 #define KVI_SHORTCUTS_EXEC "Ctrl+Shift+X"                      // Ctrl+Shift+X
 #define KVI_SHORTCUTS_INPUT_REDO QKeySequence::Redo            // Ctrl+Shift+Z
 
@@ -280,7 +279,8 @@
 		[b]Ctrl+"-":[/b] Decrease font size[br]
 		[b]Ctrl+0:[/b] Restore default font (and font size)[br]
 
-		[b]Ctrl+Alt+E:[/b] Open [i]Insert icon[/i] dialog[br]
+		[b]Alt+E:[/b] Open [i]Insert icon[/i] dialog[br]
+		[b]Alt+U:[/b] Open [i]Registered users[/i] dialog[br]
 
 		[b]Ctrl+Shift+A:[/b] Go away/back[br]
 		[b]Ctrl+Shift+B:[/b] Open [i]Manage Toolbars[/i] dialog[br]
@@ -297,7 +297,6 @@
 		[b]Ctrl+Shift+R:[/b] Open Raw events editor[br]
 		[b]Ctrl+Shift+S:[/b] Open Script tester[br]
 		[b]Ctrl+Shift+T:[/b] Open [i]Theme Options[/i] dialog[br]
-		[b]Ctrl+Shift+U:[/b] Open [i]Registered users[/i] dialog[br]
 		[b]Ctrl+Shift+X:[/b] Open [i]Execute Script[/i] dialog[br]
 		[b]Ctrl+Shift+Z:[/b] Redo last action[br]
 

--- a/src/kvirc/kernel/KviApplication.cpp
+++ b/src/kvirc/kernel/KviApplication.cpp
@@ -1331,7 +1331,7 @@ void KviApplication::updatePseudoTransparency()
 		else
 #endif // COMPILE_ON_WINDOWS || COMPILE_ON_MINGW
 
-		    if(KVI_OPTION_PIXMAP(KviOption_pixmapGlobalTransparencyBackground).pixmap())
+		if(KVI_OPTION_PIXMAP(KviOption_pixmapGlobalTransparencyBackground).pixmap())
 		{
 			createGlobalBackgrounds(KVI_OPTION_PIXMAP(KviOption_pixmapGlobalTransparencyBackground).pixmap());
 		}
@@ -1356,7 +1356,6 @@ void KviApplication::updatePseudoTransparency()
 	else
 	{
 		//transparency is disabled
-
 		//destroy pseudo transparency pixmaps
 		destroyPseudoTransparency();
 		//make sure real transparency is disabled

--- a/src/kvirc/kernel/KviCoreActions.cpp
+++ b/src/kvirc/kernel/KviCoreActions.cpp
@@ -89,7 +89,7 @@ void register_core_actions(KviActionManager * m)
 
 	SCRIPT_ACTION(
 	    KVI_COREACTION_SERVEROPTIONS,
-	    "options.edit -t OptionsWidget_servers",
+	    "options.edit OptionsWidget_servers",
 	    __tr2qs("Configure Servers..."),
 	    __tr2qs("Allows you to configure the servers and eventually to connect to them"),
 	    KviActionManager::categorySettings(),
@@ -122,7 +122,7 @@ void register_core_actions(KviActionManager * m)
 
 	SCRIPT_ACTION(
 	    KVI_COREACTION_IDENTITYOPTIONS,
-	    "options.edit -t OptionsWidget_identity",
+	    "options.edit OptionsWidget_identity",
 	    __tr2qs("Configure Identity..."),
 	    __tr2qs("Allows you to configure nickname, username, avatar etc..."),
 	    KviActionManager::categorySettings(),
@@ -136,7 +136,7 @@ void register_core_actions(KviActionManager * m)
 	    "socketspy.open",
 	    __tr2qs("Show Socket Spy"),
 	    __tr2qs("Shows a window that allows monitoring the socket traffic"),
-	    KviActionManager::categoryScripting(),
+	    KviActionManager::categoryIrc(),
 	    "kvi_bigicon_socketspy.png",
 	    KviIconManager::Spy,
 	    KviAction::NeedsContext,
@@ -166,7 +166,7 @@ void register_core_actions(KviActionManager * m)
 
 	SCRIPT_ACTION(
 	    KVI_COREACTION_GENERALOPTIONS,
-	    "options.dialog -t",
+	    "options.dialog",
 	    __tr2qs("Configure KVIrc..."),
 	    __tr2qs("Shows the general options dialog"),
 	    KviActionManager::categorySettings(),
@@ -177,7 +177,7 @@ void register_core_actions(KviActionManager * m)
 
 	SCRIPT_ACTION(
 	    KVI_COREACTION_THEMEOPTIONS,
-	    "options.dialog -t theme",
+	    "options.dialog theme",
 	    __tr2qs("Configure Theme..."),
 	    __tr2qs("Shows the theme options dialog"),
 	    KviActionManager::categorySettings(),
@@ -378,7 +378,7 @@ void register_core_actions(KviActionManager * m)
 	    "iograph.open",
 	    __tr2qs("Show I/O &Traffic Graph"),
 	    __tr2qs("Shows a graph representing I/O bandwidth traffic"),
-	    KviActionManager::categoryGeneric(),
+	    KviActionManager::categoryIrc(),
 	    "kvi_bigicon_sysmonitor.png",
 	    KviIconManager::SysMonitor,
 	    0,
@@ -435,7 +435,7 @@ void register_core_actions(KviActionManager * m)
 	    SLOT(close()),
 	    __tr2qs("&Quit KVIrc"),
 	    __tr2qs("Quits KVIrc closing all the current connections"),
-	    KviActionManager::categoryGeneric(),
+	    KviActionManager::categoryIrc(),
 	    "kvi_bigicon_quitapp.png",
 	    KviIconManager::QuitApp,
 	    0,

--- a/src/kvirc/ui/KviInput.cpp
+++ b/src/kvirc/ui/KviInput.cpp
@@ -136,7 +136,7 @@ KviInput::KviInput(KviWindow * pPar, KviUserListView * pView)
 	is0.addPixmap(*(g_pIconManager->getSmallIcon(KviIconManager::SaySmile)), QIcon::Normal, QIcon::On);
 	is0.addPixmap(*(g_pIconManager->getSmallIcon(KviIconManager::SayKvs)), QIcon::Normal, QIcon::Off);
 	m_pCommandlineModeButton->setIcon(is0);
-	KviTalToolTip::add(m_pCommandlineModeButton, __tr2qs("User friendly commandline mode<br>See also /help commandline"));
+	KviTalToolTip::add(m_pCommandlineModeButton, __tr2qs("User friendly command-line mode Ctrl+Y<br>See also /help commandline"));
 	
 	if(KVI_OPTION_BOOL(KviOption_boolCommandlineInUserFriendlyModeByDefault))
 		m_pCommandlineModeButton->setChecked(true);
@@ -152,6 +152,9 @@ KviInput::KviInput(KviWindow * pPar, KviUserListView * pView)
 	m_pMultiEditorButton->setIcon(is2);
 
 	QString szTip = __tr2qs("Multi-line editor Alt+Return");
+#ifdef COMPILE_ON_MAC
+	szTip.replace(QString("Alt+Return;"), QString("⌥↩"));
+#endif
 	KviTalToolTip::add(m_pMultiEditorButton, szTip);
 
 	connect(m_pMultiEditorButton, SIGNAL(toggled(bool)), this, SLOT(multiLineEditorButtonToggled(bool)));

--- a/src/kvirc/ui/KviInput.cpp
+++ b/src/kvirc/ui/KviInput.cpp
@@ -107,7 +107,7 @@ KviInput::KviInput(KviWindow * pPar, KviUserListView * pView)
 	{
 		is1.addPixmap(*(g_pIconManager->getSmallIcon(KviIconManager::History)));
 		m_pHistoryButton->setIcon(is1);
-		KviTalToolTip::add(m_pHistoryButton, __tr2qs("Show history<br>&lt;Ctrl+PageUp&gt;"));
+		KviTalToolTip::add(m_pHistoryButton, __tr2qs("Show history Ctrl+PageUp"));
 		connect(m_pHistoryButton, SIGNAL(clicked()), this, SLOT(historyButtonClicked()));
 	}
 	else
@@ -124,7 +124,7 @@ KviInput::KviInput(KviWindow * pPar, KviUserListView * pView)
 	QIcon is3;
 	is3.addPixmap(*(g_pIconManager->getSmallIcon(KviIconManager::BigGrin)));
 	m_pIconButton->setIcon(is3);
-	KviTalToolTip::add(m_pIconButton, __tr2qs("Show icons popup<br>&lt;Ctrl+Alt+E&gt;<br>See also /help texticons"));
+	KviTalToolTip::add(m_pIconButton, __tr2qs("Show icons popup Alt+E<br>See also /help texticons"));
 	connect(m_pIconButton, SIGNAL(clicked()), this, SLOT(iconButtonClicked()));
 
 	m_pCommandlineModeButton = new QToolButton(m_pButtonContainer);
@@ -151,7 +151,7 @@ KviInput::KviInput(KviWindow * pPar, KviUserListView * pView)
 	is2.addPixmap(*(g_pIconManager->getSmallIcon(KviIconManager::Terminal)), QIcon::Normal, QIcon::Off);
 	m_pMultiEditorButton->setIcon(is2);
 
-	QString szTip = __tr2qs("Multi-line editor<br>&lt;Alt+Return&gt;");
+	QString szTip = __tr2qs("Multi-line editor Alt+Return");
 	KviTalToolTip::add(m_pMultiEditorButton, szTip);
 
 	connect(m_pMultiEditorButton, SIGNAL(toggled(bool)), this, SLOT(multiLineEditorButtonToggled(bool)));
@@ -319,10 +319,10 @@ void KviInput::multiLineEditorButtonToggled(bool bOn)
 		m_pHelpLabel = new QLabel();
 		m_pHelpLabel->setContentsMargins(15, 5, 0, 0);
 
-		QString tmpHelpLabel = __tr2qs("<Ctrl+Return>; submits, <Alt+Return>; hides this editor");
+		QString tmpHelpLabel = __tr2qs("Ctrl+Return; submits contents, Alt+Return; hides this editor");
 #ifdef COMPILE_ON_MAC
-		tmpHelpLabel.replace(QString("<Ctrl+Return>;"), QString("⌘↩"));
-		tmpHelpLabel.replace(QString("<Alt+Return>;"), QString("⌥↩"));
+		tmpHelpLabel.replace(QString("Ctrl+Return;"), QString("⌘↩"));
+		tmpHelpLabel.replace(QString("Alt+Return;"), QString("⌥↩"));
 #endif
 		m_pHelpLabel->setText(tmpHelpLabel);
 		m_pLayout->addWidget(m_pHelpLabel, 0, 0, 1, 1);
@@ -405,7 +405,7 @@ void KviInput::applyOptions()
 		QIcon is1;
 		is1.addPixmap(*(g_pIconManager->getSmallIcon(KviIconManager::History)));
 		m_pHistoryButton->setIcon(is1);
-		KviTalToolTip::add(m_pHistoryButton, __tr2qs("Show history<br>&lt;Ctrl+PageUp&gt;"));
+		KviTalToolTip::add(m_pHistoryButton, __tr2qs("Show history Ctrl+PageUp"));
 		connect(m_pHistoryButton, SIGNAL(clicked()), this, SLOT(historyButtonClicked()));
 	}
 	else

--- a/src/kvirc/ui/KviTextIconWindow.h
+++ b/src/kvirc/ui/KviTextIconWindow.h
@@ -65,12 +65,12 @@ public:
 private:
 	QWidget * m_pOwner;
 	QTableWidget * m_pTable;
-	bool m_bAltMode; // in alt mode the inserted string will contains also the Ctrl+Alt+E escape code
+	bool m_bAltMode; // in alt mode the inserted string will contains also the Alt+E escape code
 public:
 	/**
 	* \brief Shows the popup
 	* \param pOwner The owner of the widget
-	* \param bAltMode Whether to prepend the Ctrl+Alt+E escape code in the inserted string
+	* \param bAltMode Whether to prepend the Alt+E escape code in the inserted string
 	* \return void
 	*/
 	void popup(QWidget * pOwner, bool bAltMode);

--- a/src/modules/options/OptionsWidget_textIcons.cpp
+++ b/src/modules/options/OptionsWidget_textIcons.cpp
@@ -87,7 +87,7 @@ OptionsWidget_textIcons::OptionsWidget_textIcons(QWidget * parent)
 	m_pTable->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
 	mergeTip(m_pTable->viewport(), __tr2qs_ctx("This table contains the text icon associations.<br>"
-	                                           "KVIrc will use them to display the Ctrl+Alt+E escape sequences "
+	                                           "KVIrc will use them to display the Alt+E escape sequences "
 	                                           "and eventually the emoticons.", "options"));
 
 	layout()->addWidget(m_pTable, 0, 0, 1, 3);

--- a/src/modules/options/OptionsWidget_windowList.cpp
+++ b/src/modules/options/OptionsWidget_windowList.cpp
@@ -98,7 +98,6 @@ OptionsWidget_windowListTreeBackground::OptionsWidget_windowListTreeBackground(Q
     : KviOptionsWidget(parent)
 {
 	setObjectName("treewindowlist_options_widget");
-
 	createLayout();
 
 	KviTalGroupBox * g = addGroupBox(0, 0, 1, 0, Qt::Horizontal, __tr2qs_ctx("Background Colors", "options"));


### PR DESCRIPTION
Some minor cleanups and fixes: let appveyor build windows executable to test this there also.
#### Changes proposed
-  source cleanups: indenting + obsolete switches + grouping
-  kvi_shortcuts: add recently added + cleanup formatting
-  kvi_shortcuts: replace Ctrl+Shift+U -> Alt+U **resolves #1879**
-  kvi_shortcuts: replace Ctrl+Shift+E -> Alt+E
-  replace Alt+Return with OS X equivalent (via #ifdef  like other entries)
