### PR TITLE
KviIrcView_loghandling: add spaces to logging after timestamps

### DIFF
--- a/src/kvirc/ui/KviIrcView_loghandling.cpp
+++ b/src/kvirc/ui/KviIrcView_loghandling.cpp
@@ -56,12 +56,15 @@ void KviIrcView::stopLogging()
 				// this is the equivalent to an empty date.toString() call, but it's needed
 				// to ensure qt4 will use the default() locale and not the system() one
 				szDate = QLocale().toString(date, "ddd MMM d hh:mm:ss yyyy");
+				szDate += " ";
 				break;
 			case 1:
 				szDate = date.toString(Qt::ISODate);
+				szDate += " ";
 				break;
 			case 2:
 				szDate = date.toString(Qt::SystemLocaleShortDate);
+				szDate += " ";
 				break;
 		}
 
@@ -242,12 +245,15 @@ bool KviIrcView::startLogging(const QString & fname, bool bPrependCurBuffer)
 			// this is the equivalent to an empty date.toString() call, but it's needed
 			// to ensure qt4 will use the default() locale and not the system() one
 			szDate = QLocale().toString(date, "ddd MMM d hh:mm:ss yyyy");
+			szDate += " ";
 			break;
 		case 1:
 			szDate = date.toString(Qt::ISODate);
+			szDate += " ";
 			break;
 		case 2:
 			szDate = date.toString(Qt::SystemLocaleShortDate);
+			szDate += " ";
 			break;
 	}
 
@@ -291,9 +297,11 @@ void KviIrcView::add2Log(const QString & szBuffer, int iMsgType, bool bPrependDa
 				break;
 			case 1:
 				szDate = date.toString(Qt::ISODate);
+				szDate += " ";
 				break;
 			case 2:
 				szDate = date.toString(Qt::SystemLocaleShortDate);
+				szDate += " ";
 				break;
 		}
 


### PR DESCRIPTION
SM0TVI requested this on IRC, its here for SM0TVI to test and confirm this works for all timestamps and user action msg type etc...
#### Changes proposed
- Add spaces after timestamp in log events
