### PR TITLE
Implement boolShowUserFlagForChannelsInWindowList for KviTreeWindowList

### DIFF
--- a/src/kvirc/ui/KviTreeWindowList.cpp
+++ b/src/kvirc/ui/KviTreeWindowList.cpp
@@ -88,7 +88,10 @@ void KviTreeWindowListItem::captionChanged()
 		break;
 		case KviWindow::Channel:
 		case KviWindow::DeadChannel:
-			szText = ((KviChannelWindow *)m_pWindow)->nameWithUserFlag();
+			if(KVI_OPTION_BOOL(KviOption_boolShowUserFlagForChannelsInWindowList))
+				szText = ((KviChannelWindow *)m_pWindow)->nameWithUserFlag();
+			else
+				szText = ((KviChannelWindow *)m_pWindow)->target();
 			break;
 		case KviWindow::Query:
 		case KviWindow::DeadQuery:


### PR DESCRIPTION
Previously, `boolShowUserFlagForChannelsInWindowList` only applied to the old tab-bar-style window list. This implements the option for the tree-style window list as well.
