### PR TITLE
KviUserListView: add minimum width for userlist

### DIFF
--- a/src/kvirc/kernel/KviOptions.cpp
+++ b/src/kvirc/kernel/KviOptions.cpp
@@ -635,7 +635,8 @@ KviUIntOption g_uintOptionsTable[KVI_NUM_UINT_OPTIONS] = {
 	UINT_OPTION("ToolBarIconSize", 22, KviOption_groupTheme | KviOption_resetReloadImages),
 	UINT_OPTION("ToolBarButtonStyle", 0, KviOption_groupTheme), // 0 = Qt::ToolButtonIconOnly
 	UINT_OPTION("MaximumBlowFishKeySize", 56, KviOption_sectFlagNone),
-	UINT_OPTION("CustomCursorWidth", 1, KviOption_resetUpdateGui)
+	UINT_OPTION("CustomCursorWidth", 1, KviOption_resetUpdateGui),
+	UINT_OPTION("UserListMinimumWidth", 100, KviOption_sectFlagUserListView | KviOption_resetUpdateGui | KviOption_groupTheme)
 };
 
 #define FONT_OPTION(_name, _face, _size, _flags) \

--- a/src/kvirc/kernel/KviOptions.h
+++ b/src/kvirc/kernel/KviOptions.h
@@ -594,8 +594,9 @@ DECLARE_OPTION_STRUCT(KviStringListOption, QStringList)
 #define KviOption_uintToolBarButtonStyle 79
 #define KviOption_uintMaximumBlowFishKeySize 80
 #define KviOption_uintCustomCursorWidth 81                                    /* Interface */
+#define KviOption_uintUserListMinimumWidth 82
 
-#define KVI_NUM_UINT_OPTIONS 82
+#define KVI_NUM_UINT_OPTIONS 83
 
 namespace KviIdentdOutputMode
 {

--- a/src/kvirc/ui/KviUserListView.cpp
+++ b/src/kvirc/ui/KviUserListView.cpp
@@ -345,6 +345,11 @@ void KviUserListView::applyOptions()
 	m_iFontHeight = fm.lineSpacing();
 	m_pViewArea->m_pScrollBar->setSingleStep(m_iFontHeight);
 
+	if(KVI_OPTION_UINT(KviOption_uintUserListMinimumWidth) < 100)
+		KVI_OPTION_UINT(KviOption_uintUserListMinimumWidth) = 100;
+
+	setMinimumWidth(KVI_OPTION_UINT(KviOption_uintUserListMinimumWidth));
+
 	KviUserListEntry * pEntry = m_pHeadItem;
 
 	//reset scrollarea position and scrollbar position
@@ -361,7 +366,6 @@ void KviUserListView::applyOptions()
 	}
 	updateScrollBarRange();
 	m_pUsersLabel->setFont(KVI_OPTION_FONT(KviOption_fontUserListView));
-	setMinimumWidth(22);
 	resizeEvent(nullptr); // this will call update() too
 	repaint();
 }

--- a/src/kvirc/ui/KviUserListView.h
+++ b/src/kvirc/ui/KviUserListView.h
@@ -136,7 +136,6 @@ class KVIRC_API KviUserListEntry : public QObject
 	Q_OBJECT
 	friend class KviUserListView;
 	friend class KviUserListViewArea;
-
 public:
 	/**
 	* \brief Constructs the user list entry object
@@ -214,6 +213,7 @@ protected:
 	* \return void
 	*/
 	void recalcSize();
+
 private slots:
 	void avatarFrameChanged();
 	void avatarDestroyed();
@@ -802,6 +802,7 @@ protected:
 	void updateScrollBarRange();
 
 	virtual void resizeEvent(QResizeEvent * e);
+
 public slots:
 	/**
 	* \brief Called when an animated avatar is updated (every frame)
@@ -839,6 +840,7 @@ public:
 	* \return int
 	*/
 	int dummyRead() const { return 0; };
+
 protected:
 	KviUserListView * m_pListView;
 	KviUserListEntry * m_pLastEntryUnderMouse;
@@ -857,6 +859,7 @@ protected:
 	virtual void wheelEvent(QWheelEvent * e);
 	virtual void keyPressEvent(QKeyEvent * e);
 protected slots:
+
 	/**
 	* \brief Called when the scrollbar is moved
 	* \param iNewVal The new value of the scrollbar

--- a/src/modules/options/OptionsWidget_userList.cpp
+++ b/src/modules/options/OptionsWidget_userList.cpp
@@ -221,21 +221,33 @@ OptionsWidget_userListFeatures::OptionsWidget_userListFeatures(QWidget * parent)
 {
 	createLayout();
 
-	addBoolSelector(0, 0, 0, 0, __tr2qs_ctx("Show gender icons", "options"), KviOption_boolDrawGenderIcons);
-	addBoolSelector(0, 1, 0, 1, __tr2qs_ctx("Show user rank channel icons", "options"), KviOption_boolShowUserChannelIcons);
-	addBoolSelector(0, 2, 0, 2, __tr2qs_ctx("Show user channel activity indicator", "options"), KviOption_boolShowUserChannelState);
-	addBoolSelector(0, 3, 0, 3, __tr2qs_ctx("Show label with userlist stats", "options"), KviOption_boolShowUserListStatisticLabel);
-	addBoolSelector(0, 4, 0, 4, __tr2qs_ctx("Enable user tooltip", "options"), KviOption_boolShowUserListViewToolTips);
-	addBoolSelector(0, 5, 0, 5, __tr2qs_ctx("Show avatars in userlist", "options"), KviOption_boolShowAvatarsInUserlist);
-	addBoolSelector(0, 6, 0, 6, __tr2qs_ctx("Enable animated avatars", "options"), KviOption_boolEnableAnimatedAvatars);
-	KviBoolSelector * b = addBoolSelector(0, 7, 0, 7, __tr2qs_ctx("Place nicks starting with non-alpha characters (such as _COOL_BOY_) last", "options"), KviOption_boolPlaceNickWithNonAlphaCharsAtEnd);
+	KviUIntSelector * u;
+
+	u = addUIntSelector(0, 0, 0, 0, __tr2qs_ctx("Minimum width:", "options"), KviOption_uintUserListMinimumWidth, 100, 1024, 150);
+	u->setSuffix(__tr2qs_ctx(" pixels", "options"));
+	mergeTip(u, __tr2qs_ctx("Here you can select a desired minimum width for the userlist when visible. "
+	                        "Suggested values range between 120 and 170 pixels. "
+	                        "The value set here, applies to all channels in all networks. "
+	                        "For specific widths for different channels, drag widget to desired width, "
+	                        "right click on channel on Tree Window List and select Save Window Properties As Default.<br>"
+	                        "<b>Please note</b> dragging method may not be as reliable and values set may be lost randomly, "
+	                        "However values will never be less than the width you specified.", "options"));
+
+	addBoolSelector(0, 1, 0, 1, __tr2qs_ctx("Show gender icons", "options"), KviOption_boolDrawGenderIcons);
+	addBoolSelector(0, 2, 0, 2, __tr2qs_ctx("Show user rank channel icons", "options"), KviOption_boolShowUserChannelIcons);
+	addBoolSelector(0, 3, 0, 3, __tr2qs_ctx("Show user channel activity indicator", "options"), KviOption_boolShowUserChannelState);
+	addBoolSelector(0, 4, 0, 4, __tr2qs_ctx("Show label with userlist stats", "options"), KviOption_boolShowUserListStatisticLabel);
+	addBoolSelector(0, 5, 0, 5, __tr2qs_ctx("Enable user tooltip", "options"), KviOption_boolShowUserListViewToolTips);
+	addBoolSelector(0, 6, 0, 6, __tr2qs_ctx("Show avatars in userlist", "options"), KviOption_boolShowAvatarsInUserlist);
+	addBoolSelector(0, 7, 0, 7, __tr2qs_ctx("Enable animated avatars", "options"), KviOption_boolEnableAnimatedAvatars);
+	KviBoolSelector * b = addBoolSelector(0, 8, 0, 8, __tr2qs_ctx("Place nicks starting with non-alpha characters (such as _COOL_BOY_) last", "options"), KviOption_boolPlaceNickWithNonAlphaCharsAtEnd);
 	mergeTip(b, __tr2qs_ctx("All nicknames which include characters such as [ ] ^ _ &lt; &gt; | etc. "
 	                        "will be sorted last in userlist after all regular nicknames.<br>"
 	                        "Select this option if you prefer to see regular nicknames sorted topmost "
 	                        "on userlist.<br><br><b>Note:</b> "
-	                        "Changes to this option requires KVIrc restart.",
-	                "options"));
-	addRowSpacer(0, 8, 0, 8);
+	                        "Changes to this option requires KVIrc restart.", "options"));
+
+	addRowSpacer(0, 9, 0, 9);
 }
 
 OptionsWidget_userListFeatures::~OptionsWidget_userListFeatures()

--- a/src/modules/options/OptionsWidget_userList.h
+++ b/src/modules/options/OptionsWidget_userList.h
@@ -80,7 +80,7 @@ public:
 };
 
 #define KVI_OPTIONS_WIDGET_ICON_OptionsWidget_userListGrid KviIconManager::UserList
-#define KVI_OPTIONS_WIDGET_NAME_OptionsWidget_userListGrid __tr2qs_no_lookup("Nickname Grid")
+#define KVI_OPTIONS_WIDGET_NAME_OptionsWidget_userListGrid __tr2qs_no_lookup("Userlist Grid")
 #define KVI_OPTIONS_WIDGET_KEYWORDS_OptionsWidget_userListGrid __tr2qs_no_lookup("theme,userlist,channel,grid")
 #define KVI_OPTIONS_WIDGET_GROUP_OptionsWidget_userListGrid "theme"
 #define KVI_OPTIONS_WIDGET_PARENT_OptionsWidget_userListGrid OptionsWidget_userList
@@ -102,7 +102,7 @@ public:
 
 #define KVI_OPTIONS_WIDGET_ICON_OptionsWidget_userListFeatures KviIconManager::UserList
 #define KVI_OPTIONS_WIDGET_NAME_OptionsWidget_userListFeatures __tr2qs_no_lookup("Features")
-#define KVI_OPTIONS_WIDGET_KEYWORDS_OptionsWidget_userListFeatures __tr2qs_no_lookup("userlist,channel")
+#define KVI_OPTIONS_WIDGET_KEYWORDS_OptionsWidget_userListFeatures __tr2qs_no_lookup("userlist,channel,width")
 #define KVI_OPTIONS_WIDGET_PARENT_OptionsWidget_userListFeatures OptionsWidget_userList
 #define KVI_OPTIONS_WIDGET_PRIORITY_OptionsWidget_userListFeatures 10
 


### PR DESCRIPTION
#### Changes proposed
- This adds a minimum width configurable value with a minimum of 100 pixels to the **userlist**

This value will be stored along in themes

With some luck this resolves part of https://github.com/kvirc/KVIrc/issues/900

According to tests this seems to interact OK with splitter values stored in winproperties.kvc but at this time is minimal testing thus far and internal themes still havent been updated to reflect these changes, something for another PR.

Works a treat here

Let AV build windows executables from PR to test there also.
