### PR TITLE
Respect bold and italic font settings. Fixes kvirc/KVIrc#2017.

### DIFF
--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -853,6 +853,8 @@ void KviInputEditor::drawContents(QPainter * p)
 
 	int iTextBaseline = iBottom - fm->descent();
 
+	QFont::Style normalFontStyle = p->font().style();
+
 	// When m_bIMComposing is true, the text between m_iIMStart and m_iIMStart+m_iIMLength should be highlighted to show that this is the active
 	// preedit area for the input method, and the text outside cannot be edited while
 	// composing. Maybe this can be implemented similarly as painting the selection?
@@ -912,10 +914,11 @@ void KviInputEditor::drawContents(QPainter * p)
 						p->fillRect(QRectF(fCurX, iTop, pBlock->fWidth, iBottom - iTop), KVI_OPTION_MIRCCOLOR(pBlock->uBackground));
 				}
 
+
 				if (pBlock->uFlags & KviInputEditorTextBlock::IsItalic)
 				{
 					QFont newFont = p->font();
-					newFont.setStyle(QFont::StyleItalic);
+					newFont.setStyle(normalFontStyle == QFont::StyleNormal ? QFont::StyleItalic : QFont::StyleNormal);
 					p->setFont(newFont);
 				}
 
@@ -938,7 +941,7 @@ void KviInputEditor::drawContents(QPainter * p)
 				if (pBlock->uFlags & KviInputEditorTextBlock::IsItalic)
 				{
 					QFont newFont = p->font();
-					newFont.setStyle(QFont::StyleNormal);
+					newFont.setStyle(normalFontStyle);
 					p->setFont(newFont);
 				}
 			}

--- a/src/kvirc/ui/KviIrcView.cpp
+++ b/src/kvirc/ui/KviIrcView.cpp
@@ -1065,6 +1065,8 @@ void KviIrcView::paintEvent(QPaintEvent * p)
 	SET_ANTI_ALIASING(pa);
 
 	pa.setFont(font());
+	QFont::Style normalFontStyle = pa.font().style();
+
 	if(!m_pFm)
 	{
 		// note that QFontMetrics(pa.font()) may be not the same as QFontMetrics(font())
@@ -1355,9 +1357,9 @@ void KviIrcView::paintEvent(QPaintEvent * p)
 			theWdth = width() - (curLeftCoord + KVI_IRCVIEW_HORIZONTAL_BORDER + scrollbarWidth);                                                                    \
 		pa.fillRect(curLeftCoord, curBottomCoord - m_iFontLineSpacing + m_iFontDescent, theWdth, m_iFontLineSpacing, KVI_OPTION_MIRCCOLOR((unsigned char)curBack)); \
 	}                                                                                                                                                               \
-	newFont = pa.font();                                                                                                                                               \
-	newFont.setStyle(curItalic ? QFont::StyleItalic : QFont::StyleNormal);                                                                                             \
-	pa.setFont(newFont);                                                                                                                                               \
+	newFont = pa.font();                                                                                                                                            \
+	newFont.setStyle(curItalic ^ normalFontStyle != QFont::StyleNormal ? QFont::StyleItalic : QFont::StyleNormal);                                                  \
+	pa.setFont(newFont);                                                                                                                                            \
 	pa.drawText(curLeftCoord, curBottomCoord, _text_str.mid(_text_idx, _text_len));                                                                                 \
 	if(curBold)                                                                                                                                                     \
 		pa.drawText(curLeftCoord + 1, curBottomCoord, _text_str.mid(_text_idx, _text_len));                                                                         \
@@ -1502,7 +1504,7 @@ void KviIrcView::paintEvent(QPaintEvent * p)
 					}
 
 					newFont = pa.font();
-					newFont.setStyle(curItalic ? QFont::StyleItalic : QFont::StyleNormal);
+					newFont.setStyle(curItalic ^ normalFontStyle != QFont::StyleNormal ? QFont::StyleItalic : QFont::StyleNormal);
 					pa.setFont(newFont);
 
 					if(curLink)

--- a/src/kvirc/ui/KviTopicWidget.cpp
+++ b/src/kvirc/ui/KviTopicWidget.cpp
@@ -200,6 +200,8 @@ void KviTopicWidget::paintColoredText(QPainter * p, QString text, const QPalette
 	int maxX = rect.width() - 2; // 2 is 1*margin
 	unsigned int idx = 0;
 
+	QFont::Style normalFontStyle = p->font().style();
+
 	while((idx < (unsigned int)text.length()) && (curX < maxX))
 	{
 		unsigned short c = text[(int)idx].unicode();
@@ -247,13 +249,14 @@ void KviTopicWidget::paintColoredText(QPainter * p, QString text, const QPalette
 				}
 			}
 
+			QFont newFont = p->font();
+			newFont.setStyle((curItalic ^ (normalFontStyle != QFont::StyleNormal)) ? QFont::StyleItalic : QFont::StyleNormal);
+			p->setFont(newFont);
+
 			p->drawText(curX, baseline, szText.left(len));
 
 			if(curBold)
 				p->drawText(curX + 1, baseline, szText.left(len));
-			QFont newFont = p->font();
-			newFont.setStyle(curItalic ? QFont::StyleItalic : QFont::StyleNormal);
-			p->setFont(newFont);
 			if(curUnderline)
 			{
 				p->drawLine(curX, baseline + 1, curX + wdth, baseline + 1);


### PR DESCRIPTION
#### Changes proposed

This commit changes the way italic codes are handled to respect an italic font setting. If the normal font is italic, italic codes will make the text normal style, which is the formatting style seen in literature when emphasis occurs in a quote which is written in italic.
Bold and underline codes stack with font settings.
### Known issues
- The XOR behaviour of italic codes and stacking of bold codes don't seem to work as intended in the topic widget.
- Italic codes may fail to render if you change to an italic font, until KVIrc is restarted.
