### PR TITLE
CMakeLists: find EXACT python package version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -783,7 +783,7 @@ endif()
 # Check for Python support
 option(WANT_PYTHON "Compile Python support" ON)
 if(WANT_PYTHON)
-	find_package(PythonLibs 2.7)
+	find_package(PythonLibs 2.7 EXACT)
 	if(PYTHONLIBS_FOUND)
 		set(COMPILE_PYTHON_SUPPORT 1)
 		set(CMAKE_STATUS_PYTHON_SUPPORT "Yes")


### PR DESCRIPTION
Im not sure if this will have the desired effect but hers nothing to see what TCI and AV say

Reference to report https://github.com/kvirc/KVIrc/issues/2020
#### Changes proposed
- find exact python package version

fixes #2020 hopefully
