### PR TITLE
AV: try to improve openssl logic

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,12 +43,13 @@ install:
     - c:\cygwin\bin\find /cygdrive/c/deps "-type" f
     - ps: |
         if (-Not (Test-Path "c:\OpenSSL-$env:ssl_arch")) {
-            echo "no openssl found, this is pretty sad."
-        } else {
-            echo "downloading openssl"
+            echo "preinstalled openssl not found, this is pretty sad."
+            echo "downloading openssl 1.0.2h package, don't worry, be happy!"
             Invoke-WebRequest "https://slproweb.com/download/$($env:ssl_arch)OpenSSL-1_0_2h.exe" -OutFile c:\openssl-setup.exe
             echo "installing openssl"
             Start-Process -Wait -FilePath c:\openssl-setup.exe -ArgumentList "/silent /verysilent /sp- /suppressmsgboxes"
+        } else {
+            echo "using preinstalled openssl"
         }
     - c:\cygwin\bin\find /cygdrive/c/OpenSSL-%ssl_arch% "-type" f
     - ps: |


### PR DESCRIPTION
#### Changes proposed
- try and see if this logic works better for openssl

The problem before https://github.com/kvirc/KVIrc/blob/f246144866e7435ef9255fc2daec8a70ed033146/.appveyor.yml#L45-L53 that logic when openssl failed the else statement wasnt processed...

with the introduction of if (-Not) the else statement is processed but the buildworkers openssl build isnt found (**even though it now contains the full version** not the light.)  

So this is here to see what happens in this situation just for kicks atm.
