### PR TITLE
CMakeLists.txt: Prefer Python 2.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,9 @@ set(CMAKE_KVIRC_BUILD_CPU ${CMAKE_SYSTEM_PROCESSOR})
 set(CMAKE_KVIRC_BUILD_COMPILER ${CMAKE_CXX_COMPILER})
 set(CMAKE_KVIRC_BUILD_COMPILER_FLAGS ${CMAKE_CXX_FLAGS})
 
+# Prefer Python 2.7 over 3.x (which is currently incompatible) - GitHub issue #2020
+set(Python_ADDITIONAL_VERSIONS "2.7")
+
 # Allow the use of the LOCATION property
 cmake_policy(SET CMP0026 OLD)
 


### PR DESCRIPTION
Fixes #2020.

Now it configures as follows:

```
-- Found PythonInterp: /usr/bin/python2.7 (found version "2.7.11") 
-- Found PythonLibs: /usr/lib64/libpython2.7.so (found suitable version "2.7.11", minimum required is "2.7") 
--    Python support              : Yes
```
