### PR TITLE
Row/Col: Rename row to line and dont use 0 base for first line

### DIFF
--- a/src/modules/editor/ScriptEditorImplementation.cpp
+++ b/src/modules/editor/ScriptEditorImplementation.cpp
@@ -762,7 +762,7 @@ ScriptEditorImplementation::ScriptEditorImplementation(QWidget * par)
 	pLab->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
 	g->addWidget(pLab, 1, 1);
 
-	m_pRowColLabel = new QLabel(QString(__tr2qs_ctx("Line: %1 Col: %2", "editor")).arg(0).arg(0), this);
+	m_pRowColLabel = new QLabel(QString(__tr2qs_ctx("Line: %1 Col: %2", "editor")).arg(1).arg(1), this);
 	m_pRowColLabel->setFrameStyle(QFrame::Sunken | QFrame::Panel);
 	m_pRowColLabel->setMinimumWidth(80);
 	g->addWidget(m_pRowColLabel, 1, 3);
@@ -937,8 +937,8 @@ void ScriptEditorImplementation::updateRowColLabel()
 {
 	if(m_lastCursorPos == m_pEditor->textCursor().position())
 		return;
-	int iRow = m_pEditor->textCursor().blockNumber() + 1; 
-	int iCol = m_pEditor->textCursor().columnNumber() + 1;
+	int iRow = m_pEditor->textCursor().blockNumber(); 
+	int iCol = m_pEditor->textCursor().columnNumber();
 	QString szTmp = QString(__tr2qs_ctx("Line: %1 Col: %2", "editor")).arg(iRow).arg(iCol);
 	m_pRowColLabel->setText(szTmp);
 	m_lastCursorPos = m_pEditor->textCursor().position();

--- a/src/modules/editor/ScriptEditorImplementation.cpp
+++ b/src/modules/editor/ScriptEditorImplementation.cpp
@@ -762,7 +762,7 @@ ScriptEditorImplementation::ScriptEditorImplementation(QWidget * par)
 	pLab->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
 	g->addWidget(pLab, 1, 1);
 
-	m_pRowColLabel = new QLabel(QString(__tr2qs_ctx("Row: %1 Col: %2", "editor")).arg(0).arg(0), this);
+	m_pRowColLabel = new QLabel(QString(__tr2qs_ctx("Line: %1 Col: %2", "editor")).arg(0).arg(0), this);
 	m_pRowColLabel->setFrameStyle(QFrame::Sunken | QFrame::Panel);
 	m_pRowColLabel->setMinimumWidth(80);
 	g->addWidget(m_pRowColLabel, 1, 3);
@@ -937,9 +937,9 @@ void ScriptEditorImplementation::updateRowColLabel()
 {
 	if(m_lastCursorPos == m_pEditor->textCursor().position())
 		return;
-	int iRow = m_pEditor->textCursor().blockNumber();
-	int iCol = m_pEditor->textCursor().columnNumber();
-	QString szTmp = QString(__tr2qs_ctx("Row: %1 Col: %2", "editor")).arg(iRow).arg(iCol);
+	int iRow = m_pEditor->textCursor().blockNumber() + 1; 
+	int iCol = m_pEditor->textCursor().columnNumber() + 1;
+	QString szTmp = QString(__tr2qs_ctx("Line: %1 Col: %2", "editor")).arg(iRow).arg(iCol);
 	m_pRowColLabel->setText(szTmp);
 	m_lastCursorPos = m_pEditor->textCursor().position();
 }

--- a/src/modules/objects/KvsObject_multiLineEdit.cpp
+++ b/src/modules/objects/KvsObject_multiLineEdit.cpp
@@ -306,8 +306,8 @@ bool KvsObject_textedit::functionCursorPosition(KviKvsObjectFunctionCall * c)
 {
 	if(!widget())
 		return true;
-	int iRow = ((QTextEdit *)widget())->textCursor().blockNumber();
-	int iCol = ((QTextEdit *)widget())->textCursor().columnNumber();
+	int iRow = ((QTextEdit *)widget())->textCursor().blockNumber() + 1;
+	int iCol = ((QTextEdit *)widget())->textCursor().columnNumber() + 1;
 
 	KviKvsArray * a = new KviKvsArray();
 	a->set(0, new KviKvsVariant((kvs_int_t)iRow));

--- a/src/modules/objects/KvsObject_multiLineEdit.cpp
+++ b/src/modules/objects/KvsObject_multiLineEdit.cpp
@@ -306,8 +306,8 @@ bool KvsObject_textedit::functionCursorPosition(KviKvsObjectFunctionCall * c)
 {
 	if(!widget())
 		return true;
-	int iRow = ((QTextEdit *)widget())->textCursor().blockNumber() + 1;
-	int iCol = ((QTextEdit *)widget())->textCursor().columnNumber() + 1;
+	int iRow = ((QTextEdit *)widget())->textCursor().blockNumber();
+	int iCol = ((QTextEdit *)widget())->textCursor().columnNumber();
 
 	KviKvsArray * a = new KviKvsArray();
 	a->set(0, new KviKvsVariant((kvs_int_t)iRow));


### PR DESCRIPTION
Reference https://github.com/kvirc/KVIrc/issues/1950 the feature request uncovered an issue

There's a inconsistency between row/col numbers in reference to errors printed and names used
Row and Column counter position starts at 0 while if there's an error it references line/col starts at 1
Also The errors mention lines not rows

This fixes that 
#### Changes proposed
-  Rename Row -> Line on counter
-  Make Line and Column count start at 1

Let AV build and maybe with some luck get some feedback
