### PR TITLE
Row/Col: Rename row to line and dont use 0 base for first line/col

### DIFF
--- a/src/modules/editor/ScriptEditorImplementation.cpp
+++ b/src/modules/editor/ScriptEditorImplementation.cpp
@@ -762,7 +762,7 @@ ScriptEditorImplementation::ScriptEditorImplementation(QWidget * par)
 	pLab->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
 	g->addWidget(pLab, 1, 1);
 
-	m_pRowColLabel = new QLabel(QString(__tr2qs_ctx("Line: %1 Col: %2", "editor")).arg(0).arg(0), this);
+	m_pRowColLabel = new QLabel(QString(__tr2qs_ctx("Line: %1 Col: %2", "editor")).arg(1).arg(1), this);
 	m_pRowColLabel->setFrameStyle(QFrame::Sunken | QFrame::Panel);
 	m_pRowColLabel->setMinimumWidth(80);
 	g->addWidget(m_pRowColLabel, 1, 3);
@@ -937,8 +937,8 @@ void ScriptEditorImplementation::updateRowColLabel()
 {
 	if(m_lastCursorPos == m_pEditor->textCursor().position())
 		return;
-	int iRow = m_pEditor->textCursor().blockNumber();
-	int iCol = m_pEditor->textCursor().columnNumber();
+	int iRow = m_pEditor->textCursor().blockNumber() + 1; 
+	int iCol = m_pEditor->textCursor().columnNumber() + 1;
 	QString szTmp = QString(__tr2qs_ctx("Line: %1 Col: %2", "editor")).arg(iRow).arg(iCol);
 	m_pRowColLabel->setText(szTmp);
 	m_lastCursorPos = m_pEditor->textCursor().position();


### PR DESCRIPTION
This works fine @ Try 2

Noticed something weird going on with Event Editor, probably unrelated.
Open event editor and you can type into the editor area and even type into the event name field
The problem is there's no actual event selected so this should be possible :/

Reference https://github.com/kvirc/KVIrc/issues/1950 the feature request uncovered an issue

There's a inconsistency between row/col numbers in reference to errors printed and names used
Row and Column counter position starts at 0 while if there's an error it references line/col starts at 1
Also The errors mention lines not rows

e.g.

```
[02:33:46] [KVS] Compilation error: Unexpected end of line in string constant (missing " character or unescaped newline)
[02:33:46] [KVS]   In script context "sys", line 163, near character 22
[02:33:46] [KVS] Code listing:
[02:33:46] [KVS]   161 ...
[02:33:46] [KVS]   162  {
[02:33:46] [KVS]   163      echo $tr("Usage:")"
[02:33:46] [KVS]   164      echo "      "/%aliasname <cpu> %S $tr("Output CPU information.")
[02:33:46] [KVS]   165 ...
```

![capture](https://cloud.githubusercontent.com/assets/3521959/16605921/5b1d7e08-432b-11e6-8077-242868557401.PNG)

However when you opened the script and goto line 8 you were actually in line 9 since counter is 0 based.

~~The counter also actually showed Row, not line as the error suggests.~~
~~so we try to make this consistent by using more common place terminology.~~
#### Changes proposed
-  ~~Rename Row -> Line on counter~~ fixed
-  Make Line and Column count start at 1

Let AV build and maybe with some luck get some feedback
