### PR TITLE
Use real bold when it is safe to do so

### DIFF
--- a/src/kvirc/ui/KviIrcView.h
+++ b/src/kvirc/ui/KviIrcView.h
@@ -106,6 +106,7 @@ private:
 	int m_iFontLineWidth;
 	int m_iFontDescent;
 	int m_iFontCharacterWidth[256]; //1024 bytes fixed
+	bool m_bUseRealBold;
 
 	int m_iWrapMargin;
 	int m_iMinimumPaintWidth;
@@ -233,7 +234,7 @@ private:
 	void fastScroll(int lines = 1);
 	const kvi_wchar_t * getTextLine(int msg_type, const kvi_wchar_t * data_ptr, KviIrcViewLine * line_ptr, bool bEnableTimeStamp = true, const QDateTime & datetime = QDateTime());
 	void calculateLineWraps(KviIrcViewLine * ptr, int maxWidth);
-	void recalcFontVariables(const QFontMetrics & fm, const QFontInfo & fi);
+	void recalcFontVariables(const QFont & font, const QFontInfo & fi);
 	bool checkSelectionBlock(KviIrcViewLine * line, int bufIndex);
 	KviIrcViewWrappedBlock * getLinkUnderMouse(int xPos, int yPos, QRect * pRect = 0, QString * linkCmd = 0, QString * linkText = 0);
 	void doLinkToolTip(const QRect & rct, QString & linkCmd, QString & linkText);


### PR DESCRIPTION
Revive b612e36ce2581fdf1f0df5e4bee99bcc70cc548c, but only enable it when
the metrics of printable ASCII characters match between bold and non-bold.

Fixes #2022.

CC @wodim, @Dessa 
