### PR TITLE
Don't split selection on UTF-16 surrogate pairs

### DIFF
--- a/src/kvirc/ui/KviIrcView.cpp
+++ b/src/kvirc/ui/KviIrcView.cpp
@@ -2618,8 +2618,16 @@ int KviIrcView::getVisibleCharIndexAt(KviIrcViewLine *, int xPos, int yPos)
 				while(iLeft < xPos && retValue < l->pBlocks[i].block_len)
 				{
 					curChar = l->szText.at(l->pBlocks[i].block_start + retValue);
-					iLeft += (curChar < 0xff) ? m_iFontCharacterWidth[curChar.unicode()] : m_pFm->width(curChar);
-					retValue++;
+					if (curChar >= 0xD800 && curChar <= 0xDC00) // Surrogate pair
+					{
+						iLeft += m_pFm->width(l->szText.mid(retValue), 2);
+						retValue+=2;
+					}
+					else
+					{
+						iLeft += (curChar < 0xff) ? m_iFontCharacterWidth[curChar.unicode()] : m_pFm->width(curChar);
+						retValue++;
+					}
 				}
 				//printf("%d\n",l->pBlocks[i].block_start+retValue);
 				return l->pBlocks[i].block_start + retValue;

--- a/src/kvirc/ui/KviIrcView.h
+++ b/src/kvirc/ui/KviIrcView.h
@@ -113,9 +113,6 @@ private:
 	int m_iIconWidth;
 	int m_iIconSideSpacing;
 
-	QPoint m_mousePressPos;
-	QPoint m_mouseCurrentPos;
-
 	// Selection
 	KviIrcViewLine * m_pSelectionInitLine;
 	KviIrcViewLine * m_pSelectionEndLine;

--- a/src/kvirc/ui/KviIrcView_events.cpp
+++ b/src/kvirc/ui/KviIrcView_events.cpp
@@ -269,9 +269,6 @@ void KviIrcView::mousePressEvent(QMouseEvent * e)
 		repaint();
 	}
 
-	m_mousePressPos = e->pos();
-	m_mouseCurrentPos = e->pos();
-
 	m_bMouseIsDown = true;
 
 	m_bShiftPressed = (e->modifiers() & Qt::ShiftModifier);
@@ -803,8 +800,6 @@ void KviIrcView::leaveEvent(QEvent *)
 
 void KviIrcView::timerEvent(QTimerEvent * e)
 {
-	m_mouseCurrentPos = mapFromGlobal(QCursor::pos());
-
 	if(e->timerId() == m_iSelectTimer)
 	{
 		repaint();


### PR DESCRIPTION
E.g. `[01:52:57] <LooX> 𝖜𝖍𝖞 𝖎 𝖉𝖔𝖓𝖙 𝖇𝖊𝖑𝖎𝖛𝖊 𝖎𝖙`

Just a hack to fix this particular instance. There are still some artifacts when selecting this text, w.r.t. horizontal position.
