### PR TITLE
Add Ctrl+Home/End to scroll to top/bottom

### DIFF
--- a/src/kvilib/config/kvi_shortcuts.h
+++ b/src/kvilib/config/kvi_shortcuts.h
@@ -122,6 +122,8 @@
 * \def KVI_SHORTCUTS_WIN_PREV_HIGHLIGHT Previous highlighted window
 * \def KVI_SHORTCUTS_WIN_PREV_LINE Scroll the output window up one line
 * \def KVI_SHORTCUTS_WIN_PREV_PAGE Scroll the output window up one page
+* \def KVI_SHORTCUTS_WIN_HOME Scroll the output window to the top
+* \def KVI_SHORTCUTS_WIN_END Scroll the output window to the bottom
 * \def KVI_SHORTCUTS_WIN_SCROLL_TO_LAST_READ_LINE Scroll to the last read line
 * \def KVI_SHORTCUTS_WIN_SEARCH Open "Find Text" dialog
 * \def KVI_SHORTCUTS_WIN_ZOOM_IN Increase font size
@@ -195,6 +197,8 @@
 #define KVI_SHORTCUTS_WIN_NEXT_HIGHLIGHT Qt::AltModifier + Qt::Key_PageDown               // Qt::AltModifier + Qt::Key_PageDown
 #define KVI_SHORTCUTS_WIN_PREV_PAGE QKeySequence::MoveToPreviousPage                      // Qt::Key_PageUp
 #define KVI_SHORTCUTS_WIN_NEXT_PAGE QKeySequence::MoveToNextPage                          // Qt::Key_PageDown
+#define KVI_SHORTCUTS_WIN_HOME QKeySequence::MoveToStartOfDocument                        // Qt::ControlModifier + Qt::Key_Home
+#define KVI_SHORTCUTS_WIN_END QKeySequence::MoveToEndOfDocument                           // Qt::ControlModifier + Qt::Key_End
 #define KVI_SHORTCUTS_WIN_PREV_LINE Qt::ShiftModifier + Qt::Key_PageUp                    // Qt::ShiftModifier + Qt::Key_PageUp
 #define KVI_SHORTCUTS_WIN_NEXT_LINE Qt::ShiftModifier + Qt::Key_PageDown                  // Qt::ShiftModifier + Qt::Key_PageDown
 #define KVI_SHORTCUTS_INPUT_PREV_WORD QKeySequence::MoveToPreviousWord                    // Qt::ControlModifier + Qt::Key_Left

--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -1945,6 +1945,8 @@ void KviInputEditor::installShortcuts()
 	KviShortcut::create(KVI_SHORTCUTS_WIN_NEXT_LINE, this, SLOT(nextLine()), nullptr, Qt::WidgetShortcut);
 	KviShortcut::create(KVI_SHORTCUTS_WIN_PREV_PAGE, this, SLOT(previousPage()), nullptr, Qt::WidgetShortcut);
 	KviShortcut::create(KVI_SHORTCUTS_WIN_NEXT_PAGE, this, SLOT(nextPage()), nullptr, Qt::WidgetShortcut);
+	KviShortcut::create(KVI_SHORTCUTS_WIN_HOME, this, SLOT(scrollTop()), nullptr, Qt::WidgetShortcut);
+	KviShortcut::create(KVI_SHORTCUTS_WIN_END, this, SLOT(scrollBottom()), nullptr, Qt::WidgetShortcut);
 	KviShortcut::create(KVI_SHORTCUTS_WIN_SEARCH, this, SLOT(search()), nullptr, Qt::WidgetShortcut);
 	KviShortcut::create(KVI_SHORTCUTS_WIN_SCROLL_TO_LAST_READ_LINE, this, SLOT(scrollToLastReadLine()), nullptr, Qt::WidgetShortcut);
 	KviShortcut::create(KVI_SHORTCUTS_INPUT_SEND_PLAIN, this, SLOT(sendPlain()), nullptr, Qt::WidgetShortcut);
@@ -3152,6 +3154,18 @@ void KviInputEditor::nextPage()
 {
 	if(m_pKviWindow && m_pKviWindow->view())
 		m_pKviWindow->view()->nextPage();
+}
+
+void KviInputEditor::scrollTop()
+{
+	if(m_pKviWindow && m_pKviWindow->view())
+		m_pKviWindow->view()->scrollTop();
+}
+
+void KviInputEditor::scrollBottom()
+{
+	if(m_pKviWindow && m_pKviWindow->view())
+		m_pKviWindow->view()->scrollBottom();
 }
 
 void KviInputEditor::search()

--- a/src/kvirc/ui/KviInputEditor.h
+++ b/src/kvirc/ui/KviInputEditor.h
@@ -786,6 +786,18 @@ private slots:
 	void nextPage();
 
 	/**
+	* \brief Scrolls the output window to the top
+	* \return void
+	*/
+	void scrollTop();
+
+	/**
+	* \brief Scrolls the output window to the bottom
+	* \return void
+	*/
+	void scrollBottom();
+
+	/**
 	* \brief Opens the search window
 	* \return void
 	*/

--- a/src/kvirc/ui/KviIrcView.cpp
+++ b/src/kvirc/ui/KviIrcView.cpp
@@ -453,6 +453,8 @@ void KviIrcView::prevLine() { m_pScrollBar->triggerAction(QAbstractSlider::Slide
 void KviIrcView::nextLine() { m_pScrollBar->triggerAction(QAbstractSlider::SliderSingleStepAdd); }
 void KviIrcView::prevPage() { m_pScrollBar->triggerAction(QAbstractSlider::SliderPageStepSub); }
 void KviIrcView::nextPage() { m_pScrollBar->triggerAction(QAbstractSlider::SliderPageStepAdd); }
+void KviIrcView::scrollTop() { m_pScrollBar->triggerAction(QAbstractSlider::SliderToMinimum); }
+void KviIrcView::scrollBottom() { m_pScrollBar->triggerAction(QAbstractSlider::SliderToMaximum); }
 
 void KviIrcView::setPrivateBackgroundPixmap(const QPixmap & pixmap, bool bRepaint)
 {

--- a/src/kvirc/ui/KviIrcView.h
+++ b/src/kvirc/ui/KviIrcView.h
@@ -199,6 +199,8 @@ public:
 	void nextLine();
 	void nextPage();
 	void prevPage();
+	void scrollTop();
+	void scrollBottom();
 	virtual QSize sizeHint() const;
 	const QString & lastLineOfText();
 	const QString & lastMessageText();


### PR DESCRIPTION
Consistent with other apps, where Ctrl+Home/End jumps to the top/bottom
of the document.

This is mainly useful to quickly jump to the very bottom of a buffer
after a search, as well as UX parity with other clients.
