### PR TITLE
Fix double-scrolling in tree-style window list

### DIFF
--- a/src/kvirc/ui/KviTreeWindowList.cpp
+++ b/src/kvirc/ui/KviTreeWindowList.cpp
@@ -492,6 +492,13 @@ void KviTreeWindowList::updateActivityMeter()
 	}
 }
 
+void KviTreeWindowList::wheelEvent(QWheelEvent * e)
+{
+	// Override KviWindowListBase::wheelEvent.
+	// Mouse wheel handling is done in
+	// KviTreeWindowListTreeWidget::wheelEvent.
+}
+
 KviWindowListItem * KviTreeWindowList::firstItem()
 {
 	m_pCurrentItem = (KviTreeWindowListItem *)m_pTreeWidget->topLevelItem(0);

--- a/src/kvirc/ui/KviTreeWindowList.h
+++ b/src/kvirc/ui/KviTreeWindowList.h
@@ -108,6 +108,8 @@ public:
 	virtual void updatePseudoTransparency();
 	virtual void updateActivityMeter();
 
+	virtual void wheelEvent(QWheelEvent * e);
+
 protected:
 	virtual void moveEvent(QMoveEvent *);
 protected slots:


### PR DESCRIPTION
When KviOption_boolWheelScrollsWindowsList was on, scrolling the mouse
wheel over the tree-style window list would skip one item. This was
because the mouse wheel would fire both KviWindowListBase::wheelEvent
and KviTreeWindowListTreeWidget::wheelEvent. We fix this by overriding
KviWindowListBase::wheelEvent in KviTreeWindowList, thus preventing it
from firing.
