### PR TITLE
Esc saves and clears input line

### DIFF
--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -1692,7 +1692,7 @@ void KviInputEditor::handleDragSelection()
 	repaintWithCursorOn();
 }
 
-void KviInputEditor::returnPressed(bool)
+void KviInputEditor::finishInput()
 {
 	if(!m_szTextBuffer.isEmpty() /* && (!m_pHistory->current() || m_szTextBuffer.compare(*(m_pHistory->current())))*/)
 	{
@@ -1712,6 +1712,11 @@ void KviInputEditor::returnPressed(bool)
 		m_pHistory->removeLast();
 
 	m_iCurHistoryIdx = -1;
+}
+
+void KviInputEditor::returnPressed(bool)
+{
+	finishInput();
 
 	emit enterPressed();
 }
@@ -3419,6 +3424,8 @@ void KviInputEditor::deleteHit()
 
 void KviInputEditor::escapeHit()
 {
+	finishInput();
+	setText("");
 	emit escapePressed();
 }
 

--- a/src/kvirc/ui/KviInputEditor.h
+++ b/src/kvirc/ui/KviInputEditor.h
@@ -435,13 +435,24 @@ private:
 	void moveCursorTo(int iIdx, bool bRepaint = true);
 
 	/**
-	* \brief Adds the text to the history
+	* \brief Submits input
 	*
 	* Triggered when the user press return
 	* \param bRepaint Whether to repain the input line
 	* \return void
 	*/
 	void returnPressed(bool bRepaint = true);
+
+	/**
+	* \brief Adds the text to the history
+	*
+	* Called when the user is done editing the current
+	* input line (either by submitting or clearing it).
+	* Adds the content (if any) to the history,
+	* and hides helper windows.
+	* \return void
+	*/
+	void finishInput();
 
 	/**
 	* \brief Autocompletion function


### PR DESCRIPTION
This implements a useful feature from mIRC: the ability to save the
currently typed line to the history, without actually sending it. This
can be occasionally very useful in situations such as when you're typing
a long reply, and in the middle of that you need to stop and send a
short reply to a question that appeared meanwhile.

Regardless, using Esc to clear the current input is a common pattern we
should follow anyway.
