### PR TITLE
Implement `znc.in/self-message` IRCv3 capability

### DIFF
--- a/src/kvirc/kernel/KviIrcConnection.cpp
+++ b/src/kvirc/kernel/KviIrcConnection.cpp
@@ -456,6 +456,7 @@ void KviIrcConnection::handleInitialCapLs()
 	cap_add("extended-join");
 	cap_add("userhost-in-names");
 	cap_add("chghost");
+	cap_add("znc.in/self-message");
 
 	if(szRequests.isEmpty())
 	{

--- a/src/kvirc/sparser/KviIrcServerParser_ctcp.cpp
+++ b/src/kvirc/sparser/KviIrcServerParser_ctcp.cpp
@@ -54,6 +54,7 @@
 #include "kvi_sourcesdate.h"
 #include "KviRegisteredUserDataBase.h"
 #include "KviBuildInfo.h"
+#include "KviIrcConnectionServerInfo.h"
 
 #include <stdlib.h>
 
@@ -1433,13 +1434,16 @@ void KviIrcServerParser::parseCtcpRequestAction(KviCtcpMessage * msg)
 	szData8 = msg->pData;
 
 	KviWindow * pOut = nullptr;
-	bool bIsChannel = !IS_ME(msg->msg, msg->szTarget);
+	bool bIsChannel = msg->msg->connection()->serverInfo()->supportedChannelTypes().indexOf(msg->szTarget[0]) != -1;
+	// "znc.in/self-message" capability: Handle a replayed message from ourselves to someone else.
+	bool bSelfMessage = IS_ME(msg->msg, msg->pSource->nick());
+	QString szWindow = bIsChannel || bSelfMessage ? msg->szTarget : msg->pSource->nick();
 
 	QString szData;
 
 	if(bIsChannel)
 	{
-		pOut = (KviWindow *)msg->msg->connection()->findChannel(msg->szTarget);
+		pOut = (KviWindow *)msg->msg->connection()->findChannel(szWindow);
 		if(pOut)
 			szData = pOut->decodeText(szData8.ptr());
 		else
@@ -1447,7 +1451,7 @@ void KviIrcServerParser::parseCtcpRequestAction(KviCtcpMessage * msg)
 	}
 	else
 	{
-		KviQueryWindow * query = msg->msg->connection()->findQuery(msg->pSource->nick());
+		KviQueryWindow * query = msg->msg->connection()->findQuery(szWindow);
 		if(!query)
 		{
 			szData = msg->msg->connection()->decodeText(szData8.ptr());
@@ -1464,14 +1468,15 @@ void KviIrcServerParser::parseCtcpRequestAction(KviCtcpMessage * msg)
 				       szData))
 				{
 					// check if the scripter hasn't created it
-					query = msg->msg->connection()->findQuery(msg->pSource->nick());
+					query = msg->msg->connection()->findQuery(szWindow);
 				}
 				else
 				{
 					// no query yet, create it!
 					// this will trigger OnQueryWindowCreated
-					query = msg->msg->console()->connection()->createQuery(msg->pSource->nick());
-					query->setTarget(msg->pSource->nick(), msg->pSource->user(), msg->pSource->host());
+					query = msg->msg->console()->connection()->createQuery(szWindow);
+					if (!bSelfMessage)
+						query->setTarget(msg->pSource->nick(), msg->pSource->user(), msg->pSource->host());
 				}
 				if(!KVI_OPTION_STRING(KviOption_stringOnNewQueryOpenedSound).isEmpty())
 					KviKvsScript::run("snd.play $0", nullptr, new KviKvsVariantList(new KviKvsVariant(KVI_OPTION_STRING(KviOption_stringOnNewQueryOpenedSound))));


### PR DESCRIPTION
This capability is used to indicate that the client supports receiving
messages previously sent by the user. In ZNC, it is required for proper
playback of private message conversations.

More information: http://wiki.znc.in/Query_buffers#Self_messages

The implementation is fairly straight-forward. In the relevant places,
we switch the method used to identify if a message is a private message
or belongs in a channel - instead of comparing the target to our
nickname, we check if it starts with one of the server-announced
CHANTYPES characters, which has the additional benefit of avoiding a
race condition when changing nicknames.

Possible forward improvements:
- Currently, if the first message received for a window is a
  self-message, we do not call setTarget. As far as I've seen, the
  effect is purely cosmetic (the target is not added to the member list,
  which is hidden by default anyway).
- CTCP code for each CTCP message type needs to be manually updated to
  handle self-messages. This patch only addresses ACTION CTCPs.
