### PR TITLE
Give better names to console log files

### DIFF
--- a/src/kvirc/ui/KviConsoleWindow.cpp
+++ b/src/kvirc/ui/KviConsoleWindow.cpp
@@ -143,9 +143,6 @@ KviConsoleWindow::KviConsoleWindow(int iFlags)
 
 	m_pTmpHighLightedChannels = new QStringList;
 
-	if(KVI_OPTION_BOOL(KviOption_boolAutoLogConsole))
-		m_pIrcView->startLogging();
-
 	applyOptions();
 }
 
@@ -396,7 +393,10 @@ void KviConsoleWindow::saveProperties(KviConfigurationFile * cfg)
 
 void KviConsoleWindow::getBaseLogFileName(QString & buffer)
 {
-	buffer = QString("CONSOLE_%1").arg(context()->id());
+	if(context()->connection())
+		buffer = context()->connection()->target()->network()->name();
+	else
+		buffer = context()->id();
 }
 
 void KviConsoleWindow::showNotifyList(bool bShow, bool bIgnoreSizeChange)
@@ -504,6 +504,14 @@ void KviConsoleWindow::connectionAttached()
 	connect(m_pContext->connection(), SIGNAL(chanListChanged()), this, SLOT(updateUri()));
 	updateUri();
 	m_pNotifyListView->setUserDataBase(connection()->userDataBase());
+
+	// Update log file name
+	if(KVI_OPTION_BOOL(KviOption_boolAutoLogConsole))
+	{
+		if (m_pIrcView->isLogging())
+			m_pIrcView->stopLogging();
+		m_pIrcView->startLogging();
+	}
 }
 
 void KviConsoleWindow::connectionDetached()


### PR DESCRIPTION
This patch names console log files after the IRC network.

Note that the console windows are created without a connection
initially. To avoid creating mostly-empty indexed log files, we do not
begin logging until a connection is created.

Fixes #1710.

CC @un1versal @staticfox 
