### PR TITLE
actions/popups/events: add option controller dialog for CTCP ignore and joins/parts/quits

### DIFF
--- a/data/defscript/actions.kvs
+++ b/data/defscript/actions.kvs
@@ -1,0 +1,392 @@
+# Default actions file
+#
+# Coding style/curly brackets: Allman style
+
+action.create -w=xcqd -t=tools ("optionctrlr",$tr("Option controller"),$tr("Opens a control dialog for easy CTCP ignore and joins/parts/quits management."),"kvi_bigicon_settings.png",$icon(options))
+{
+	#################################################################
+	#                                                               #
+	#   File : actions.kvs (optionctrlr) v4.1.1.6810                #
+	#   Creation date : Fri Jul 22 16:57:41 2016 UTC by un1versal   #
+	#                                                               #
+	#################################################################
+
+	# Prevent dialog from opening multiple times
+	if(%PDisplay)
+		halt;
+	else
+		%PDisplay = $true;
+
+	# This prologue houses the variables for the option controller dialog
+	# Add CTCP Protection Variables
+	%ProtectPing = $option(boolIgnoreCTCPPing)
+	%ProtectFinger = $option(boolIgnoreCTCPFinger)
+	%ProtectVersion = $option(boolIgnoreCTCPVersion)
+	%ProtectUserinfo = $option(boolIgnoreCTCPUserinfo)
+	%ProtectClientinfo = $option(boolIgnoreCTCPClientinfo)
+	%ProtectSource = $option(boolIgnoreCTCPSource)
+	%ProtectTime = $option(boolIgnoreCTCPTime)
+	%ProtectPage = $option(boolIgnoreCTCPPage)
+	%ProtectAvatar = $option(boolIgnoreCTCPAvatar)
+	%ProtectDCC = $option(boolIgnoreCTCPDCC)
+
+	# Add Join Suppression Variables
+	%IsJoinEnabled = $isEventEnabled(OnJoin, suppressJoinMsgs)
+	%IsPartEnabled = $isEventEnabled(OnPart, suppressPartMsgs)
+	%IsQuitEnabled = $isEventEnabled(OnQuit, suppressQuitMsgs)
+
+	# Create the main widget as a dialog
+	%widget = $new(dialog)
+	%layout = $new(layout,%widget)
+	%widget->$setWindowTitle($tr("Option Controllers - KVIrc"))
+
+	# Add dialog geometry restrictions.
+	# Prevent dialog from looking nasty when resized!
+	# Maximum width accounts for translations
+	%widget->$setWFlags(dialog)
+	%widget->$setMinimumHeight(450)
+	%widget->$setMaximumHeight(450)
+	%widget->$setMinimumWidth(330)
+	%widget->$setMaximumWidth(555)
+	%widget->$resize(330,450)
+	# Make sure dialog is ontop and can be navigated by keyboard
+	%widget->$raise()
+	%widget->$setfocus()
+
+	# Create the CTCP controlled groupbox
+	%groupbox = $new(groupbox,%widget)
+	%groupbox->$setTitle($tr("CTCP Ignore Controllers"))
+	%groupbox->$setAlignment("left")
+
+	# Add groupbox to main layout
+	%layout->$addWidget(%groupbox,0,0)
+
+	# Create checkboxes + labels
+	%vbox = $new(vbox,%groupbox)
+
+	%checkboxping = $new(checkbox,%vbox)
+	%checkboxping->$setText($tr("Enable ignore for CTCP PING"))
+	%checkboxping->$setToolTip($tr("When checked, all CTCP PING requests are ignored."))
+	%checkboxping->$setchecked(%ProtectPing)
+
+	# Here comes the magic
+	privateimpl(%checkboxping,checkbox)
+	{
+		if(%ProtectPing)
+		{
+			option boolIgnoreCTCPPing 0
+			echo -i = $msgtype(GenericStatus) $tr("Disabled ignore for CTCP PING")
+		}
+		else
+		{
+			option boolIgnoreCTCPPing 1
+			echo -i = $msgtype(GenericStatus) $tr("Enabled ignore for CTCP PING")
+		}
+		%ProtectPing = $option(boolIgnoreCTCPPing)
+	}
+	objects.connect %checkboxping clicked %checkboxping checkbox
+
+	%checkboxfinger = $new(checkbox,%vbox)
+	%checkboxfinger->$setText($tr("Enable ignore for CTCP FINGER"))
+	%checkboxfinger->$setToolTip($tr("When checked, all CTCP FINGER requests are ignored."))
+	%checkboxfinger->$setchecked(%ProtectFinger)
+
+	# Here comes the magic
+	privateimpl(%checkboxfinger,checkbox)
+	{
+		if(%ProtectFinger)
+		{
+			option boolIgnoreCTCPFinger 0
+			echo -i = $msgtype(GenericStatus) $tr("Disabled ignore for CTCP FINGER")
+		}
+		else
+		{
+			option boolIgnoreCTCPFinger 1
+			echo -i = $msgtype(GenericStatus) $tr("Enabled ignore for CTCP FINGER")
+		}
+		%ProtectFinger = $option(boolIgnoreCTCPFinger)
+	}
+	objects.connect %checkboxfinger clicked %checkboxfinger checkbox
+
+	%checkboxversion = $new(checkbox,%vbox)
+	%checkboxversion->$setText($tr("Enable ignore for CTCP VERSION"))
+	%checkboxversion->$setToolTip($tr("When checked, all CTCP VERSION requests are ignored."))
+	%checkboxversion->$setchecked(%ProtectVersion)
+
+	# Here comes the magic
+	privateimpl(%checkboxversion,checkbox)
+	{
+		if(%ProtectVersion)
+		{
+			option boolIgnoreCTCPVersion 0
+			echo -i = $msgtype(GenericStatus) $tr("Disabled ignore for CTCP VERSION")
+		}
+		else
+		{
+			option boolIgnoreCTCPVersion 1
+			echo -i = $msgtype(GenericStatus) $tr("Enabled ignore for CTCP VERSION")
+		}
+		%ProtectVersion = $option(boolIgnoreCTCPVersion)
+	}
+	objects.connect %checkboxversion clicked %checkboxversion checkbox
+
+	%checkboxuserinfo = $new(checkbox,%vbox)
+	%checkboxuserinfo->$setText($tr("Enable ignore for CTCP USERINFO"))
+	%checkboxuserinfo->$setToolTip($tr("When checked, all CTCP USERINFO requests are ignored."))
+	%checkboxuserinfo->$setchecked(%ProtectUserinfo)
+
+	# Here comes the magic
+	privateimpl(%checkboxuserinfo,checkbox)
+	{
+		if(%ProtectUserinfo)
+		{
+			option boolIgnoreCTCPUserinfo 0
+			echo -i = $msgtype(GenericStatus) $tr("Disabled ignore for CTCP USERINFO")
+		}
+		else
+		{
+			option boolIgnoreCTCPUserinfo 1
+			echo -i = $msgtype(GenericStatus) $tr("Enabled ignore for CTCP USERINFO")
+		}
+		%ProtectUserinfo = $option(boolIgnoreCTCPUserinfo)
+	}
+	objects.connect %checkboxuserinfo clicked %checkboxuserinfo checkbox
+
+	%checkboxclientinfo = $new(checkbox,%vbox)
+	%checkboxclientinfo->$setText($tr("Enable ignore for CTCP CLIENTINFO"))
+	%checkboxclientinfo->$setToolTip($tr("When checked, all CTCP CLIENTINFO requests are ignored."))
+	%checkboxclientinfo->$setchecked(%ProtectClientInfo)
+
+	# Here comes the magic
+	privateimpl(%checkboxclientinfo,checkbox)
+	{
+		if(%ProtectClientInfo)
+		{
+			option boolIgnoreCTCPClientinfo 0
+			echo -i = $msgtype(GenericStatus) $tr("Disabled ignore for CTCP CLIENTINFO")
+		}
+		else
+		{
+			option boolIgnoreCTCPClientinfo 1
+			echo -i = $msgtype(GenericStatus) $tr("Enabled ignore for CTCP CLIENTINFO")
+		}
+		%ProtectClientInfo = $option(boolIgnoreCTCPClientinfo)
+	}
+	objects.connect %checkboxclientinfo clicked %checkboxclientinfo checkbox
+
+	%checkboxsource = $new(checkbox,%vbox)
+	%checkboxsource->$setText($tr("Enable ignore for CTCP SOURCE"))
+	%checkboxsource->$setToolTip($tr("When checked, all CTCP SOURCE requests are ignored."))
+	%checkboxsource->$setchecked(%ProtectSource)
+
+	# Here comes the magic
+	privateimpl(%checkboxsource,checkbox)
+	{
+		if(%ProtectSource)
+		{
+			option boolIgnoreCTCPSource 0
+			echo -i = $msgtype(GenericStatus) $tr("Disabled ignore for CTCP SOURCE")
+		}
+		else
+		{
+			option boolIgnoreCTCPSource 1
+			echo -i = $msgtype(GenericStatus) $tr("Enabled ignore for CTCP SOURCE")
+		}
+		%ProtectSource = $option(boolIgnoreCTCPSource)
+	}
+	objects.connect %checkboxsource clicked %checkboxsource checkbox
+
+	%checkboxtime = $new(checkbox,%vbox)
+	%checkboxtime->$setText($tr("Enable ignore for CTCP TIME"))
+	%checkboxtime->$setToolTip($tr("When checked, all CTCP TIME requests are ignored."))
+	%checkboxtime->$setchecked(%ProtectTime)
+
+	# Here comes the magic
+	privateimpl(%checkboxtime,checkbox)
+	{
+		if(%ProtectTime)
+		{
+			option boolIgnoreCTCPTime 0
+			echo -i = $msgtype(GenericStatus) $tr("Disabled ignore for CTCP TIME")
+		}
+		else
+		{
+			option boolIgnoreCTCPTime 1
+			echo -i = $msgtype(GenericStatus) $tr("Enabled ignore for CTCP TIME")
+		}
+		%ProtectTime = $option(boolIgnoreCTCPTime)
+	}
+	objects.connect %checkboxtime clicked %checkboxtime checkbox
+
+	%checkboxpage = $new(checkbox,%vbox)
+	%checkboxpage->$setText($tr("Enable ignore for CTCP PAGE"))
+	%checkboxpage->$setToolTip($tr("When checked, all CTCP PAGE requests are ignored."))
+	%checkboxpage->$setchecked(%ProtectPage)
+
+	# Here comes the magic
+	privateimpl(%checkboxpage,checkbox)
+	{
+		if(%ProtectPage)
+		{
+			option boolIgnoreCTCPPage 0
+			echo -i = $msgtype(GenericStatus) $tr("Disabled ignore for CTCP PAGE")
+		}
+		else
+		{
+			option boolIgnoreCTCPPage 1
+			echo -i = $msgtype(GenericStatus) $tr("Enabled ignore for CTCP PAGE")
+		}
+		%ProtectPage = $option(boolIgnoreCTCPPage)
+	}
+	objects.connect %checkboxpage clicked %checkboxpage checkbox
+
+	%checkboxavatar = $new(checkbox,%vbox)
+	%checkboxavatar->$setText($tr("Enable ignore for CTCP AVATAR"))
+	%checkboxavatar->$setToolTip($tr("When checked, all CTCP AVATAR requests are ignored."))
+	%checkboxavatar->$setchecked(%ProtectAvatar)
+
+	# Here comes the magic
+	privateimpl(%checkboxavatar,checkbox)
+	{
+		if(%ProtectAvatar)
+		{
+			option boolIgnoreCTCPAvatar 0
+			echo -i = $msgtype(GenericStatus) $tr("Disabled ignore for CTCP AVATAR")
+		}
+		else
+		{
+			option boolIgnoreCTCPAvatar 1
+			echo -i = $msgtype(GenericStatus) $tr("Enabled ignore for CTCP AVATAR")
+		}
+		%ProtectAvatar = $option(boolIgnoreCTCPAvatar)
+	}
+	objects.connect %checkboxavatar clicked %checkboxavatar checkbox
+
+	%checkboxdcc = $new(checkbox,%vbox)
+	%checkboxdcc->$setText($tr("Enable ignore for CTCP DCC"))
+	%checkboxdcc->$setToolTip($tr("When checked, all CTCP DCC requests are ignored."))
+	%checkboxdcc->$setchecked(%ProtectDCC)
+
+	# Here comes the magic
+	privateimpl(%checkboxdcc,checkbox)
+	{
+		if(%ProtectDCC)
+		{
+			option boolIgnoreCTCPDCC 0
+			echo -i = $msgtype(GenericStatus) $tr("Disabled ignore for CTCP DCC")
+		}
+		else
+		{
+			option boolIgnoreCTCPDCC 1
+			echo -i = $msgtype(GenericStatus) $tr("Enabled ignore for CTCP DCC")
+		}
+		%ProtectDCC = $option(boolIgnoreCTCPDCC)
+	}
+	objects.connect %checkboxdcc clicked %checkboxdcc checkbox
+
+	# Then the groupbox
+	%groupbox = $new(groupbox,%widget)
+	%groupbox->$setTitle($tr("Message Suppression Controllers"))
+	%groupbox->$setAlignment("left")
+
+	# Add the groupbox to the main layout
+	%layout->$addWidget(%groupbox,1,0)
+
+	# Now we create checkboxes + labels
+	%vbox = $new(vbox,%groupbox)
+
+	%checkboxjoin = $new(checkbox,%vbox)
+	%checkboxjoin->$setText($tr("Enable join message suppression"))
+	%checkboxjoin->$setToolTip($tr("When checked, all join messages are hidden."))
+	%checkboxjoin->$setchecked(%IsJoinEnabled)
+
+	# Here comes the magic
+	privateimpl(%checkboxjoin,checkbox)
+	{
+		if($isEventEnabled(OnJoin, suppressJoinMsgs))
+		{
+			eventctl -d OnJoin suppressJoinMsgs
+			echo -i = $msgtype(GenericStatus) $tr("Disabled join message suppression")
+		}
+		else
+		{
+			eventctl -e OnJoin suppressJoinMsgs
+			echo -i = $msgtype(GenericStatus) $tr("Enabled join message suppression")
+		}
+		%IsJoinEnabled = $isEventEnabled(OnJoin, suppressJoinMsgs)
+	}
+	objects.connect %checkboxjoin clicked %checkboxjoin checkbox
+
+	# Here comes the magic
+	%checkboxpart = $new(checkbox,%vbox)
+	%checkboxpart->$setText($tr("Enable part message suppression"))
+	%checkboxpart->$setToolTip($tr("When checked, all part messages are hidden."))
+	%checkboxpart->$setchecked(%IsPartEnabled)
+
+	privateimpl(%checkboxpart,checkbox)
+	{
+		if($isEventEnabled(OnPart, suppressPartMsgs))
+		{
+			eventctl -d OnPart suppressPartMsgs
+			echo -i = $msgtype(GenericStatus) $tr("Disabled part message suppression")
+		}
+		else
+		{
+			eventctl -e OnPart suppressPartMsgs
+			echo -i = $msgtype(GenericStatus) $tr("Enabled part message suppression")
+		}
+		%IsPartEnabled = $isEventEnabled(OnPart, suppressPartMsgs)
+	}
+	objects.connect %checkboxpart clicked %checkboxpart checkbox
+
+	%checkboxquit = $new(checkbox,%vbox)
+	%checkboxquit->$setText($tr("Enable quit message suppression"))
+	%checkboxquit->$setToolTip($tr("When checked, all part messages are hidden."))
+	%checkboxquit->$setchecked(%IsQuitEnabled)
+
+	# Here comes the magic
+	privateimpl(%checkboxquit,checkbox)
+	{
+		if($isEventEnabled(OnQuit, suppressQuitMsgs))
+		{
+			eventctl -d OnQuit suppressQuitMsgs
+			echo -i = $msgtype(GenericStatus) $tr("Disabled quit message suppression")
+		}
+		else
+		{
+			eventctl -e OnQuit suppressQuitMsgs
+			echo -i = $msgtype(GenericStatus) $tr("Enabled quit message suppression")
+		}
+		%IsQuitEnabled = $isEventEnabled(OnQuit, suppressQuitMsgs)
+	}
+	objects.connect %checkboxquit clicked %checkboxquit checkbox
+
+	# Now add the Close button
+	%grouphbox = $new(groupbox,%widget)
+	%hrzbox = $new(hbox,%grouphbox)
+	%layout->$addWidget(%grouphbox,2,0)
+
+	%closebutton = $new(button,%hrzbox)
+	%closebutton->$settext($tr("Close"))
+
+	%grouphbox->$isFlat($true)
+	%grouphbox->$setInsideMargin(0)
+	%grouphbox->$setAlignment(right)
+
+	# Here comes the magic
+	privateimpl(%widget,closeEvent)
+	{
+		## And kill dialog on close
+		delete -q $$
+
+		# Unset all the variables: after delete so %Pdisplay is definitely unset 
+		unset %PDisplay, %ProtectPing, %ProtectFinger, %ProtectVersion, %ProtectUserinfo \
+		%ProtectClientinfo, %ProtectSource, %ProtectTime, %ProtectPage, %ProtectAvatar   \
+		%ProtectDCC, %IsJoinEnabled, %IsPartEnabled, %IsQuitEnabled
+	}
+	objects.connect %closebutton clicked %widget closeEvent
+
+	# Let's show this sexy dialog
+	%widget->$show()
+}
+

--- a/data/defscript/default.kvc
+++ b/data/defscript/default.kvc
@@ -1,12 +1,12 @@
 # KVIrc configuration file
 [KVIrc]
 Version=4.1.1
-Date=2016-06-16
-ActionVersion=4.1.1
+Date=2016-07-20
+ActionVersion=4.1.1.6810
 AddonVersion=4.1.1
 AliasVersion=4.1.1.6732
 ClassVersion=4.1.1
-EventVersion=4.1.1.6732
-PopupVersion=4.1.1.6772
+EventVersion=4.1.1.6810
+PopupVersion=4.1.1.6810
 RawVersion=4.1.1
-ToolbarVersion=4.1.1
+ToolbarVersion=4.1.1.6732

--- a/data/defscript/default.kvs
+++ b/data/defscript/default.kvs
@@ -12,6 +12,7 @@
 %mypath = "$file.extractpath($0)$file.ps"
 
 # Fetch default scripts data
+include "actions.kvs" %mypath
 include "aliases.kvs" %mypath
 include "events.kvs" %mypath
 include "popups.kvs" %mypath

--- a/data/defscript/events.kvs
+++ b/data/defscript/events.kvs
@@ -88,6 +88,11 @@ event(OnChannelWindowCreated,default)
 	{
 		popup.show -p=$0,$1 logging;
 	}
+
+	button(w,Controllers,$icon("options"),$tr("Option controllers","defscript"))
+	{
+		action.trigger optionctrlr;
+	}
 }
 
 event(OnQueryWindowCreated,default)
@@ -96,7 +101,33 @@ event(OnQueryWindowCreated,default)
 	{
 		popup.show -p=$0,$1 logging;
 	}
+
+	button(w,Controllers,$icon("options"),$tr("Option controllers","defscript"))
+	{
+		action.trigger optionctrlr;
+	}
 }
+
+event(OnJoin,suppressJoinMsgs)
+{
+	halt;
+}
+
+eventctl -d OnJoin suppressJoinMsgs
+
+event(OnPart,suppressPartMsgs)
+{
+	halt;
+}
+
+eventctl -d OnPart suppressPartMsgs
+
+event(OnQuit,suppressQuitMsgs)
+{
+	halt;
+}
+
+eventctl -d OnQuit suppressQuitMsgs
 
 event(OnDCCChatWindowCreated,default)
 {

--- a/data/defscript/popups.kvs
+++ b/data/defscript/popups.kvs
@@ -261,20 +261,6 @@ defpopup(channelpopup)
 
 defpopup(ctcp)
 {
-	prologue
-	{
-		%:ProtectPing = $option(boolIgnoreCTCPPing)
-		%:ProtectFinger = $option(boolIgnoreCTCPFinger)
-		%:ProtectVersion = $option(boolIgnoreCTCPVersion)
-		%:ProtectUserinfo = $option(boolIgnoreCTCPUserinfo)
-		%:ProtectClientinfo = $option(boolIgnoreCTCPClientinfo)
-		%:ProtectSource = $option(boolIgnoreCTCPSource)
-		%:ProtectTime = $option(boolIgnoreCTCPTime)
-		%:ProtectPage = $option(boolIgnoreCTCPPage)
-		%:ProtectAvatar = $option(boolIgnoreCTCPAvatar)
-		%:ProtectDCC = $option(boolIgnoreCTCPDCC)
-	}
-
 	item(PING,$icon("serverping"))
 	{
 		ctcp $0 PING
@@ -323,111 +309,6 @@ defpopup(ctcp)
 	item(AVATAR,$icon("avatar"))
 	{
 		ctcp $0 AVATAR
-	}
-
-	separator
-
-	popup($tr("CTCP Protection","defscript"),$icon("options"))
-	{
-		item(PING - $tr("Disable Ignore","defscript"),$icon("serverping")) (%:ProtectPing)
-		{
-			option boolIgnoreCTCPPing 0
-		}
-
-		item(PING - $tr("Enable Ignore","defscript"),$icon("serverping")) (!%:ProtectPing)
-		{
-			option boolIgnoreCTCPPing 1
-		}
-
-		item(FINGER - $tr("Disable Ignore","defscript"),$icon("finger")) (%:ProtectFinger)
-		{
-			option boolIgnoreCTCPFinger 0
-		}
-
-		item(FINGER - $tr("Enable Ignore","defscript"),$icon("finger")) (!%:ProtectFinger)
-		{
-			option boolIgnoreCTCPFinger 1
-		}
-
-		item(VERSION - $tr("Disable Ignore","defscript"),$icon("kvirc")) (%:ProtectVersion)
-		{
-			option boolIgnoreCTCPVersion 0
-		}
-
-		item(VERSION - $tr("Enable Ignore","defscript"),$icon("kvirc")) (!%:ProtectVersion)
-		{
-			option boolIgnoreCTCPVersion 1
-		}
-
-		item(USERINFO - $tr("Disable Ignore","defscript"),$icon("user")) (%:ProtectUserinfo)
-		{
-			option boolIgnoreCTCPUserinfo 0
-		}
-
-		item(USERINFO - $tr("Enable Ignore","defscript"),$icon("user")) (!%:ProtectUserinfo)
-		{
-			option boolIgnoreCTCPUserinfo 1
-		}
-
-		item(CLIENTINFO - $tr("Disable Ignore","defscript"),$icon("serverinfo")) (%:ProtectClientinfo)
-		{
-			option boolIgnoreCTCPClientinfo 0
-		}
-
-		item(CLIENTINFO - $tr("Enable Ignore","defscript"),$icon("serverinfo")) (!%:ProtectClientinfo)
-		{
-			option boolIgnoreCTCPClientinfo 1
-		}
-
-		item(SOURCE - $tr("Disable Ignore","defscript"),$icon("ctcprequestunknown")) (%:ProtectSource)
-		{
-			option boolIgnoreCTCPSource 0
-		}
-
-		item(SOURCE - $tr("Enable Ignore","defscript"),$icon("ctcprequestunknown")) (!%:ProtectSource)
-		{
-			option boolIgnoreCTCPSource 1
-		}
-
-		item(TIME - $tr("Disable Ignore","defscript"),$icon("time")) (%:ProtectTime)
-		{
-			option boolIgnoreCTCPTime 0
-		}
-
-		item(TIME - $tr("Enable Ignore","defscript"),$icon("time")) (!%:ProtectTime)
-		{
-			option boolIgnoreCTCPTime 1
-		}
-
-		item(PAGE - $tr("Disable Ignore","defscript"),$icon("messages")) (%:ProtectPage)
-		{
-			option boolIgnoreCTCPPage 0
-		}
-
-		item(PAGE - $tr("Enable Ignore","defscript"),$icon("messages")) (!%:ProtectPage)
-		{
-			option boolIgnoreCTCPPage 1
-		}
-
-		item(AVATAR - $tr("Disable Ignore","defscript"),$icon("avatar")) (%:ProtectAvatar)
-		{
-			option boolIgnoreCTCPAvatar 0
-		}
-
-		item(AVATAR - $tr("Enable Ignore","defscript"),$icon("avatar")) (!%:ProtectAvatar)
-		{
-			option boolIgnoreCTCPAvatar 1
-		}
-
-		item(DCC - $tr("Disable Ignore","defscript"),$icon("dcc")) (%:ProtectDCC)
-		{
-			option boolIgnoreCTCPDCC 0
-		}
-
-		item(DCC - $tr("Enable Ignore","defscript"),$icon("dcc")) (!%:ProtectDCC)
-		{
-			option boolIgnoreCTCPDCC 1
-		}
 	}
 }
 
@@ -853,7 +734,14 @@ defpopup(windowpopup)
 			window.close %x
 	}
 
-	separator(%:bIsConnectedConsole)
+	separator
+
+	item($tr("&Option Controllers","defscript"),$icon("options"))
+	{
+		action.trigger optionctrlr;
+	}
+
+	separator
 
 	item($tr("Unhighlight All Windows" ,"defscript")) (%:bIsConnectedConsole)
 	{

--- a/src/kvirc/kernel/KviDefaultScript.cpp
+++ b/src/kvirc/kernel/KviDefaultScript.cpp
@@ -153,7 +153,7 @@ void KviDefaultScriptManager::restoreInternal()
 	{
 		if(m_pDialog->m_pData->isChecked())
 			KviActionManager::instance()->killAllKvsUserActions();
-		// No need to load here since we haven't a default actions script yet
+		g_pApp->loadDefaultScript("actions");
 		m_szAction = oConfig.readEntry("ActionVersion");
 	}
 


### PR DESCRIPTION
### please do not squash Ill merge this in properly

> ### NOTE Illustrations below are meant to show how options are layed out ONLY. The State of the Options in illustrations does not reflect defaults. I.E its for illustration purposes only.
#### Changes proposed

**popups**
- optionctrlrs ( this is used to control both of the above so its easily
  added anywhere and easily expanded )
- this adds suppress on join/part/quit control menus actions
- this now houses previous CTCP Protection control actions

**events**
- add default events for Joins / Parts / Quits
- add button for accessing Option Controllers from main UI ( similar to logging )

These events are disabled by default meaning you see joins parts and quits per default.

**Note** Whenever something is Enabled or Disabled there's textual feedback

![demo](https://cloud.githubusercontent.com/assets/3521959/17066343/8b5739cc-503e-11e6-9075-836d14fa1377.gif)
## Known Issues
- [x] Dialog can be opened multiple times
- [x] If user closes dialog via title bar close button (%PDisplay is not unset and dialog cant be reopened until unsetting this global) Feature requests allow close button on title bar to be disabled/removed?
- [ ] Dialog can be open in as panel but only left hand side, this looks awful
- [ ] When opening Dialog as in panel Window title in treeview is invisible until selected. (bug!!)
