### PR TITLE
Minor refactor of KviAction.{cpp,h}

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,4 +16,6 @@ DerivePointerAlignment: false
 PointerAlignment: Middle
 
 SortIncludes: false
+
+AccessModifierOffset: -4
 ...

--- a/src/kvirc/kernel/KviAction.cpp
+++ b/src/kvirc/kernel/KviAction.cpp
@@ -35,14 +35,6 @@
 #include <QAction>
 #include <QMenu>
 
-KviActionCategory::KviActionCategory(const QString & szName, const QString & szVisibleName, const QString & szDescription)
-    : m_szName(szName), m_szVisibleName(szVisibleName), m_szDescription(szDescription)
-{
-}
-
-KviActionCategory::~KviActionCategory()
-    = default;
-
 KviAction::KviAction(QObject * pParent, const QString & szName, const QString & szVisibleName, const QString & szDescription, KviActionCategory * pCategory, const QString & szBigIconId, const QString & szSmallIconId, unsigned int uFlags, const QString & szKeySequence)
     : QObject(pParent),
       m_szName(szName),

--- a/src/kvirc/kernel/KviAction.cpp
+++ b/src/kvirc/kernel/KviAction.cpp
@@ -35,34 +35,34 @@
 #include <QAction>
 #include <QMenu>
 
-KviAction::KviAction(QObject * pParent, const QString & szName, const QString & szVisibleName, const QString & szDescription, KviActionCategory * pCategory, const QString & szBigIconId, const QString & szSmallIconId, unsigned int uFlags, const QString & szKeySequence)
+KviAction::KviAction(QObject * pParent, QString szName, QString szVisibleName, QString szDescription, KviActionCategory * pCategory, QString szBigIconId, QString szSmallIconId, unsigned int uFlags, QString szKeySequence)
     : QObject(pParent),
-      m_szName(szName),
-      m_szVisibleName(szVisibleName),
-      m_szDescription(szDescription),
+      m_szName(std::move(szName)),
+      m_szVisibleName(std::move(szVisibleName)),
+      m_szDescription(std::move(szDescription)),
       m_pCategory(pCategory),
-      m_szBigIconId(szBigIconId),
-      m_szSmallIconId(szSmallIconId),
+      m_szBigIconId(std::move(szBigIconId)),
+      m_szSmallIconId(std::move(szSmallIconId)),
       m_eSmallIcon(KviIconManager::None),
       m_uInternalFlags(KviAction::Enabled),
       m_uFlags(uFlags),
-      m_szKeySequence(szKeySequence),
-      m_pAccel(nullptr)
+      m_szKeySequence(std::move(szKeySequence)),
+      m_pAccel()
 {
 }
 
-KviAction::KviAction(QObject * pParent, const QString & szName, const QString & szVisibleName, const QString & szDescription, KviActionCategory * pCategory, const QString & szBigIconId, KviIconManager::SmallIcon eSmallIcon, unsigned int uFlags, const QString & szKeySequence)
+KviAction::KviAction(QObject * pParent, QString szName, QString szVisibleName, QString szDescription, KviActionCategory * pCategory, QString szBigIconId, KviIconManager::SmallIcon eSmallIcon, unsigned int uFlags, QString szKeySequence)
     : QObject(pParent),
-      m_szName(szName),
-      m_szVisibleName(szVisibleName),
-      m_szDescription(szDescription),
+      m_szName(std::move(szName)),
+      m_szVisibleName(std::move(szVisibleName)),
+      m_szDescription(std::move(szDescription)),
       m_pCategory(pCategory),
-      m_szBigIconId(szBigIconId),
-      m_eSmallIcon(eSmallIcon),
+      m_szBigIconId(std::move(szBigIconId)),
+      m_eSmallIcon(std::move(eSmallIcon)),
       m_uInternalFlags(KviAction::Enabled),
       m_uFlags(uFlags),
-      m_szKeySequence(szKeySequence),
-      m_pAccel(nullptr)
+      m_szKeySequence(std::move(szKeySequence)),
+      m_pAccel()
 {
 }
 

--- a/src/kvirc/kernel/KviAction.cpp
+++ b/src/kvirc/kernel/KviAction.cpp
@@ -71,8 +71,7 @@ KviAction::~KviAction()
 	for(auto & pAction : m_pActionList)
 		disconnect(pAction, SIGNAL(destroyed()), this, SLOT(actionDestroyed()));
 
-	if(m_pAccel)
-		unregisterAccelerator();
+	this->unregisterAccelerator();
 }
 
 const QString & KviAction::visibleName()
@@ -92,9 +91,7 @@ bool KviAction::isKviUserActionNeverOverrideThis()
 
 void KviAction::registerAccelerator()
 {
-	if(m_pAccel)
-		delete m_pAccel;
-
+	this->unregisterAccelerator();
 	if(!m_szKeySequence.isEmpty())
 	{
 		g_pMainWindow->freeAccelleratorKeySequence(m_szKeySequence);
@@ -103,10 +100,6 @@ void KviAction::registerAccelerator()
 		connect(m_pAccel, SIGNAL(activated()), this, SLOT(activate()));
 		//no way to have Ctrl+Alt+Key events fired as no-ambiguous, probably qt bug
 		connect(m_pAccel, SIGNAL(activatedAmbiguously()), this, SLOT(activate()));
-	}
-	else
-	{
-		m_pAccel = nullptr;
 	}
 }
 

--- a/src/kvirc/kernel/KviAction.h
+++ b/src/kvirc/kernel/KviAction.h
@@ -39,6 +39,7 @@
 
 #include <memory>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 class QShortcut;
@@ -69,10 +70,12 @@ public:
 	* \param szDescription Description of the category
 	* \return KviActionCategory
 	*/
-	KviActionCategory(const QString & szName, const QString & szVisibleName, const QString & szDescription)
-        : m_szName(szName), m_szVisibleName(szVisibleName), m_szDescription(szDescription)
-        {
-        }
+	KviActionCategory(QString szName, QString szVisibleName, QString szDescription)
+	    : m_szName(std::move(szName)),
+	      m_szVisibleName(std::move(szVisibleName)),
+	      m_szDescription(std::move(szDescription))
+	{
+	}
 
 public:
 	/**

--- a/src/kvirc/kernel/KviAction.h
+++ b/src/kvirc/kernel/KviAction.h
@@ -153,14 +153,14 @@ public:
 	*/
 	KviAction(
 	    QObject * pParent,
-	    const QString & szName,
-	    const QString & szVisibleName,
-	    const QString & szDescription,
-	    KviActionCategory * pCategory = NULL,
-	    const QString & szBigIconId = QString(),
-	    const QString & szSmallIconId = QString(),
+	    QString szName,
+	    QString szVisibleName,
+	    QString szDescription,
+	    KviActionCategory * pCategory = nullptr,
+	    QString szBigIconId = QString(),
+	    QString szSmallIconId = QString(),
 	    unsigned int uFlags = 0,
-	    const QString & szKeySequence = QString());
+	    QString szKeySequence = QString());
 
 	/**
 	* \brief Constructs the action object
@@ -182,14 +182,14 @@ public:
 	*/
 	KviAction(
 	    QObject * pParent,
-	    const QString & szName,
-	    const QString & szVisibleName,
-	    const QString & szDescription,
-	    KviActionCategory * pCategory = NULL,
-	    const QString & szBigIconId = QString(),
+	    QString szName,
+	    QString szVisibleName,
+	    QString szDescription,
+	    KviActionCategory * pCategory = nullptr,
+	    QString szBigIconId = QString(),
 	    KviIconManager::SmallIcon eSmallIcon = KviIconManager::None,
 	    unsigned int uFlags = 0,
-	    const QString & szKeySequence = QString());
+	    QString szKeySequence = QString());
 
 	/**
 	* \brief Destroys the action object

--- a/src/kvirc/kernel/KviAction.h
+++ b/src/kvirc/kernel/KviAction.h
@@ -69,12 +69,10 @@ public:
 	* \param szDescription Description of the category
 	* \return KviActionCategory
 	*/
-	KviActionCategory(const QString & szName, const QString & szVisibleName, const QString & szDescription);
-
-	/**
-	* \brief Destroys an action category object
-	*/
-	~KviActionCategory();
+	KviActionCategory(const QString & szName, const QString & szVisibleName, const QString & szDescription)
+        : m_szName(szName), m_szVisibleName(szVisibleName), m_szDescription(szDescription)
+        {
+        }
 
 public:
 	/**


### PR DESCRIPTION
#### Changes proposed
- Simplify `KviActionCategory`
- `.clang-format`: set `AccessModifierOffset` to `-4` to match existing code
- Use move semantics in `KviActionCategory` and `KviAction` constructors
- Re-use `KviAction::unregisterAccelerator` when possible
