### PR TITLE
Fix string concatenation with macro in KviInputEditor

### DIFF
--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -1032,7 +1032,7 @@ void KviInputEditor::showContextPopup(const QPoint & pos)
 	QString szClip;
 
 	static QString ths = "<html><body><table width=\"100%\">" START_TABLE_BOLD_ROW;
-	static QString the = "</table></body></html>"; END_TABLE_BOLD_ROW;
+	static QString the = "</table></body></html>" END_TABLE_BOLD_ROW;
 
 	QClipboard * pClip = QApplication::clipboard();
 	if(pClip)


### PR DESCRIPTION
There was an extra ; added in commit 8a99f27 that messed up the string concatenation after macro expansion.
