### PR TITLE
Add /away -d for GUI actions to override the boolUseAwayMessage option. Fixes #2101 and fixes #2102.

### DIFF
--- a/src/kvirc/kernel/KviCoreActions.cpp
+++ b/src/kvirc/kernel/KviCoreActions.cpp
@@ -1053,7 +1053,7 @@ KviGoAwayAction::KviGoAwayAction(QObject * pParent)
     : KviKvsAction(
           pParent,
           QString(KVI_COREACTION_AWAYBACK),
-          QString("if($away())back; else away;"),
+          QString("if($away())back; else away -d;"),
           __tr2qs("Away/Back"),
           __tr2qs("Allows entering and leaving away state"),
           KviActionManager::categoryIrc(),

--- a/src/kvirc/kvs/KviKvsCoreSimpleCommands_af.cpp
+++ b/src/kvirc/kvs/KviKvsCoreSimpleCommands_af.cpp
@@ -84,12 +84,15 @@ namespace KviKvsCoreSimpleCommands
 		@title:
 			away
 		@syntax:
-			away [-a | --all-networks] [<reason:string>]
+			away [-a | --all-networks] [-d | --default-message] [<reason:string>]
 		@short:
 			Puts you into 'away' state
 		@switches:
 			!sw: -a | --all-networks
 			Set away on all networks
+			!sw: -d | --default-message
+			If you do not specify a message, this switch overrides the boolUseAwayMessage option
+			and sets you away with the default message.
 		@description:
 			Puts you into 'away' state in the connection associated to the
 			current [b]IRC context[/b].[br] This command is "server based";
@@ -120,7 +123,7 @@ namespace KviKvsCoreSimpleCommands
 
 		if(szReason.isEmpty())
 		{
-			if(KVI_OPTION_BOOL(KviOption_boolUseAwayMessage))
+			if(KVI_OPTION_BOOL(KviOption_boolUseAwayMessage) || KVSCSC_pSwitches->find('d', "default-message"))
 			{
 				//user want to use its default away message
 				szReason = KVI_OPTION_STRING(KviOption_stringAwayMessage);

--- a/src/kvirc/ui/KviStatusBarApplet.cpp
+++ b/src/kvirc/ui/KviStatusBarApplet.cpp
@@ -206,9 +206,9 @@ void KviStatusBarAwayIndicator::mouseDoubleClickEvent(QMouseEvent * e)
 		return;
 	QString command;
 	if(m_bAwayOnAllContexts)
-		command = "if($away)back -a; else away -a";
+		command = "if($away)back -a; else away -a -d";
 	else
-		command = "if($away)back; else away";
+		command = "if($away)back; else away -d";
 	KviKvsScript::run(command, c->console());
 }
 

--- a/src/modules/trayicon/libkvitrayicon.cpp
+++ b/src/modules/trayicon/libkvitrayicon.cpp
@@ -239,6 +239,7 @@ void KviTrayIconWidget::doAway(bool)
 {
 	int id;
 	bool ok;
+	QString szReason;
 	QAction * act = dynamic_cast<QAction *>(QObject::sender());
 
 	if(act != nullptr)
@@ -265,8 +266,11 @@ void KviTrayIconWidget::doAway(bool)
 				}
 				else
 				{
+					szReason = KVI_OPTION_STRING(KviOption_stringAwayMessage);
+					if(szReason.isEmpty())
+						szReason = __tr2qs("Away from keyboard.");
 					pConsole->connection()->sendFmtData("AWAY :%s",
-					    pConsole->connection()->encodeText(KVI_OPTION_STRING(KviOption_stringAwayMessage)).data());
+					    pConsole->connection()->encodeText(szReason).data());
 				}
 			}
 		}
@@ -284,8 +288,11 @@ void KviTrayIconWidget::doAway(bool)
 				}
 				else
 				{
+					szReason = KVI_OPTION_STRING(KviOption_stringAwayMessage);
+					if(szReason.isEmpty())
+						szReason = __tr2qs("Away from keyboard.");
 					pConsole->connection()->sendFmtData("AWAY :%s",
-					    pConsole->connection()->encodeText(KVI_OPTION_STRING(KviOption_stringAwayMessage)).data());
+					    pConsole->connection()->encodeText(szReason).data());
 				}
 			}
 		}


### PR DESCRIPTION
#### Changes proposed

This commit adds a `-d`/`--default-message` switch to the `/away` command. If used, it overrides the `boolUseAwayMessage` option and uses the default away message if no message is specified.
The toolbar away button and the status bar widget now also use this switch.
