### PR TITLE
fix empty tooltip  glitch when not connected to a server.

### DIFF
--- a/src/kvirc/ui/KviIrcView_events.cpp
+++ b/src/kvirc/ui/KviIrcView_events.cpp
@@ -1121,6 +1121,8 @@ void KviIrcView::doLinkToolTip(const QRect & rct, QString & linkCmd, QString & l
 
 				tip += "</table></body></html>";
 			}
+			else
+				tip = __tr2qs("You're not connected to a server");
 		}
 		break;
 		default:


### PR DESCRIPTION
this is here so I can get a testbuild for Windows from AV before merging.

![](https://cloud.githubusercontent.com/assets/3521959/17648920/ef6c8534-621d-11e6-8f47-6da5fea09e4d.gif)

noticed this when parting a channel then hovering over the channel name on the part message, but I imagine this willbe a problem with all channel links tooltips in other areas.
#### Changes proposed
- fix empty tooltip on channel name hover when not connected to a server
