### PR TITLE
Add a line highlighter for the current line in the script editor widget.

### DIFF
--- a/src/modules/editor/ScriptEditorImplementation.cpp
+++ b/src/modules/editor/ScriptEditorImplementation.cpp
@@ -67,6 +67,7 @@ extern std::set<ScriptEditorImplementation *> g_pScriptEditorWindowList;
 extern KviModule * g_pEditorModulePointer;
 
 static QColor g_clrBackground(0, 0, 0);
+static QColor g_clrBackgroundHighlight(50, 50, 50);
 static QColor g_clrNormalText(100, 255, 0);
 static QColor g_clrBracket(255, 0, 0);
 static QColor g_clrComment(0, 120, 0);
@@ -130,6 +131,8 @@ ScriptEditorWidget::ScriptEditorWidget(QWidget * pParent)
 	}
 	else
 		loadCompleterFromFile();
+
+	connect(this, &ScriptEditorWidget::cursorPositionChanged, this, &ScriptEditorWidget::highlightCurrentLine);
 }
 
 ScriptEditorWidget::~ScriptEditorWidget()
@@ -214,6 +217,24 @@ void ScriptEditorWidget::asyncCompleterCreation()
 		delete m_pListCompletition;
 		delete m_pListModulesNames;
 	}
+}
+
+void ScriptEditorWidget::highlightCurrentLine()
+{
+	if(isReadOnly())
+	{
+		setExtraSelections(QList<QTextEdit::ExtraSelection>());
+		return;
+	}
+
+	QTextEdit::ExtraSelection selection;
+
+	selection.cursor = textCursor();
+	selection.cursor.clearSelection();
+	selection.format.setBackground(g_clrBackgroundHighlight);
+	selection.format.setProperty(QTextFormat::FullWidthSelection, true);
+
+	setExtraSelections(QList<QTextEdit::ExtraSelection>({ selection }));
 }
 
 void ScriptEditorWidget::loadCompleterFromFile()
@@ -475,6 +496,7 @@ ScriptEditorWidgetColorOptions::ScriptEditorWidgetColorOptions(QWidget * pParent
 	gbox->setInsideSpacing(0);
 
 	addColorSelector(gbox, __tr2qs_ctx("Background:", "editor"), &g_clrBackground, true);
+	addColorSelector(gbox, __tr2qs_ctx("Background Highlight:", "editor"), &g_clrBackgroundHighlight, true);
 	addColorSelector(gbox, __tr2qs_ctx("Normal text:", "editor"), &g_clrNormalText, true);
 	addColorSelector(gbox, __tr2qs_ctx("Brackets:", "editor"), &g_clrBracket, true);
 	addColorSelector(gbox, __tr2qs_ctx("Comments:", "editor"), &g_clrComment, true);
@@ -784,6 +806,7 @@ void ScriptEditorImplementation::loadOptions()
 
 	KviConfigurationFile cfg(szTmp, KviConfigurationFile::Read);
 	g_clrBackground = cfg.readColorEntry("Background", QColor(0, 0, 0));
+	g_clrBackgroundHighlight = cfg.readColorEntry("BackgroundHighlight", QColor(50, 50, 50));
 	g_clrNormalText = cfg.readColorEntry("NormalText", QColor(100, 255, 0));
 	g_clrBracket = cfg.readColorEntry("Bracket", QColor(255, 0, 0));
 	g_clrComment = cfg.readColorEntry("Comment", QColor(0, 120, 0));
@@ -830,6 +853,7 @@ void ScriptEditorImplementation::saveOptions()
 
 	KviConfigurationFile cfg(szTmp, KviConfigurationFile::Write);
 	cfg.writeEntry("Background", g_clrBackground);
+	cfg.writeEntry("BackgroundHighlight", g_clrBackgroundHighlight);
 	cfg.writeEntry("NormalText", g_clrNormalText);
 	cfg.writeEntry("Bracket", g_clrBracket);
 	cfg.writeEntry("Comment", g_clrComment);

--- a/src/modules/editor/ScriptEditorImplementation.h
+++ b/src/modules/editor/ScriptEditorImplementation.h
@@ -84,6 +84,7 @@ public slots:
 	void slotReplace();
 protected slots:
 	void asyncCompleterCreation();
+	void highlightCurrentLine();
 signals:
 	void keyPressed();
 


### PR DESCRIPTION
When using the `ScriptEditorWidget` in any of the instances in KVIrc, it now includes a line highlight for the current line containing the cursor.  If you want to disable it, just set "Background Highlight" color to match the "Background" color in the Configure Editor dialog.
