### PR TITLE
Add missing channel mode descriptions for Criten IRCD. Fixes #2122

### DIFF
--- a/src/kvirc/kernel/KviIrcConnectionServerInfo.cpp
+++ b/src/kvirc/kernel/KviIrcConnectionServerInfo.cpp
@@ -1982,6 +1982,12 @@ const QString & KviCritenIrcServerInfo::getChannelModeDescription(char mode)
 		case 'c':
 			return __tr2qs("No control codes (colors, bold, ..)");
 			break;
+		case 'f':
+			return __tr2qs("Flood limit");
+			break;
+		case 'r':
+			return __tr2qs("Registered Channel");
+			break;
 	}
 	return KviBasicIrcServerInfo::getChannelModeDescription(mode);
 }


### PR DESCRIPTION
Adds missing `f` and `r` channel modes.  Please note that on the IRCD in #2122, mode `q` has been removed, but still exists in the ISUPPORT message for some reason, so leaving it as Unknown is probably best, since it isn't our responsibility to fix their mistake.
