### PR TITLE
Fix local variable shadowing. Fixes #2126.

### DIFF
--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -2290,7 +2290,7 @@ void KviInputEditor::completion(bool bShift)
 		else
 		{
 			QString szAll;
-			QString szMatch = tmp.front();
+			szMatch = tmp.front();
 			int iWLen = szWord.length();
 			if(szMatch.left(1) == '$')
 				szMatch.remove(0, 1);


### PR DESCRIPTION
Fixes local variable shadowing of `szMatch` introduced in 7d08b0c3.
