### PR TITLE
KviInputEditor cleanup

### DIFF
--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -68,6 +68,7 @@
 #include <QMenu>
 #include <QWidgetAction>
 #include <QTextBoundaryFinder>
+#include <QRegExp>
 
 #include <qdrawutil.h> // qDrawShadePanel
 
@@ -1042,6 +1043,9 @@ void KviInputEditor::showContextPopup(const QPoint & pos)
 
 		if(!szClip.isEmpty())
 		{
+			// Prevent too many newlines from spamming the context menu
+			szClip.replace(QRegExp("^((?:[^\n]*\n){6}).*"), "\\1...");
+
 			if(szClip.length() > 60)
 			{
 				szClip.truncate(60);

--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -2300,9 +2300,11 @@ void KviInputEditor::completion(bool bShift)
 		{
 			QString szAll;
 			szMatch = tmp.front();
-			auto predicate = bIsDir
-				? std::function<bool(const QChar &, const QChar &)>([](const QChar & a, const QChar & b) { return a.unicode() == b.unicode(); })
-				: std::function<bool(const QChar &, const QChar &)>([](const QChar & a, const QChar & b) { return a.toLower().unicode() == b.toLower().unicode(); });
+			auto predicate =
+				[bIsDir](const QChar & a, const QChar & b)
+				{
+					return bIsDir ? (a.unicode() == b.unicode()) : (a.toLower().unicode() == b.toLower().unicode());
+				};
 
 			for(auto szTmp : tmp)
 			{

--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -2278,7 +2278,7 @@ void KviInputEditor::completion(bool bShift)
 		if(tmp.size() == 1)
 		{
 			szMatch = tmp.front();
-			if(szMatch.left(1) == '$')
+			if(szMatch.left(1) == '$' && szMatch != '$')
 				szMatch.remove(0, 1);
 			if(bIsCommand && !iOffset && szMatch.right(1) != '.')
 				szMatch.append(' ');
@@ -2293,7 +2293,7 @@ void KviInputEditor::completion(bool bShift)
 				}
 			}
 
-			if(bInCommand && !bIsCommand)
+			if(bInCommand && !bIsCommand && !bIsFunction)
 				completionEscapeUnsafeToken(szMatch); // escape crazy things like Nick\nquit
 		}
 		else

--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -171,6 +171,7 @@ KviInputEditor::KviInputEditor(QWidget * pPar, KviWindow * pWnd, KviUserListView
 	m_pKviWindow = pWnd;
 	m_pUserListView = pView;
 	m_bReadOnly = false;
+	m_bSpSlowFlag = false;       //Slow paste status flag
 
 	setAttribute(Qt::WA_InputMethodEnabled, true);
 

--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -73,6 +73,7 @@
 #include <qdrawutil.h> // qDrawShadePanel
 
 #include <algorithm>
+#include <functional>
 
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
 #include <windows.h>

--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -2280,9 +2280,9 @@ void KviInputEditor::completion(bool bShift)
 			szMatch = tmp.front();
 			if(szMatch.left(1) == '$')
 				szMatch.remove(0, 1);
-			if(bIsCommand && szMatch.right(1) != '.')
+			if(bIsCommand && !iOffset && szMatch.right(1) != '.')
 				szMatch.append(' ');
-			else if(bIsFunction && szMatch.right(1) != '.')
+			else if(bIsFunction && !iOffset && szMatch.right(1) != '.')
 				szMatch.append('(');
 			else if(bIsNick)
 			{

--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -1033,9 +1033,6 @@ void KviInputEditor::showContextPopup(const QPoint & pos)
 
 	QString szClip;
 
-	static QString ths = "<html><body><table width=\"100%\">" START_TABLE_BOLD_ROW;
-	static QString the = END_TABLE_BOLD_ROW "</table></body></html>";
-
 	QClipboard * pClip = QApplication::clipboard();
 	if(pClip)
 	{
@@ -1056,21 +1053,28 @@ void KviInputEditor::showContextPopup(const QPoint & pos)
 			szClip.replace(QChar('>'), "&gt;");
 			szClip.replace(QChar('\n'), "<br>");
 
-			QString szLabel = ths;
+			QString szLabel = "<html><body>";
+
+			// Title
+			szLabel += "<table width=\"100%\">";
+			szLabel += START_TABLE_BOLD_ROW;
 			szLabel += "<center><b>";
 			szLabel += __tr2qs("Clipboard");
 			szLabel += "</b></center>";
-			szLabel += the;
+			szLabel += END_TABLE_BOLD_ROW;
+			szLabel += "</table>";
+
+			// Clipboard contents (truncated for display)
 			szLabel += szClip;
+
+			// Line breaks count
 			szLabel += "<br><b><center>";
-
-			QString szNum;
-			szNum.setNum(iOcc);
-
-			szLabel += szNum;
+			szLabel += QString::number(iOcc);
 			szLabel += QChar(' ');
 			szLabel += (iOcc == 1) ? __tr2qs("line break") : __tr2qs("line breaks");
 			szLabel += "</b></center>";
+
+			szLabel += "</body></html>";
 
 			QLabel * pLabel = new QLabel(szLabel, g_pInputPopup);
 			pLabel->setFrameStyle(QFrame::Raised | QFrame::StyledPanel);

--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -1317,7 +1317,7 @@ void KviInputEditor::mousePressEvent(QMouseEvent * e)
 {
 	if(e->button() & Qt::LeftButton)
 	{
-		m_iCursorPosition = charIndexFromXPosition(e->pos().x());
+		m_iCursorPosition = std::min(charIndexFromXPosition(e->pos().x()), m_szTextBuffer.length());
 		m_iSelectionAnchorChar = m_iCursorPosition;
 		clearSelection();
 		repaintWithCursorOn();

--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -1691,9 +1691,8 @@ void KviInputEditor::finishInput()
 	}
 
 	//ensure the color window is hidden (bug #835)
-	if(g_pColorWindow)
-		if(g_pColorWindow->isVisible())
-			g_pColorWindow->hide();
+	if(g_pColorWindow && g_pColorWindow->isVisible())
+		g_pColorWindow->hide();
 
 	KVI_ASSERT(KVI_INPUT_MAX_LOCAL_HISTORY_ENTRIES > 1); //ABSOLUTELY NEEDED, if not, pHist will be destroyed...
 	if(m_History.size() > KVI_INPUT_MAX_LOCAL_HISTORY_ENTRIES)
@@ -2150,7 +2149,7 @@ void KviInputEditor::completion(bool bShift)
 	}
 
 	int iOffset;
-	if(KviQString::equalCI(m_szTextBuffer.left(5), "/help") || KviQString::equalCI(m_szTextBuffer.left(5), "/help.open"))
+	if(KviQString::equalCI(m_szTextBuffer.left(5), "/help"))
 		iOffset = 1;
 	else
 		iOffset = 0;
@@ -2218,11 +2217,11 @@ void KviInputEditor::completion(bool bShift)
 			if(m_pKviWindow->console())
 				m_pKviWindow->console()->completeChannel(szWord, tmp);
 		}
-
-		//FIXME: Complete also on irc:// starting strings, not only irc.?
 	}
 	else if(KviQString::equalCIN(szWord, "irc.", 4))
 	{
+		//FIXME: Complete also on irc:// starting strings, not only irc.?
+
 		// irc server name
 		if(m_pKviWindow)
 			if(m_pKviWindow->console())
@@ -2285,9 +2284,7 @@ void KviInputEditor::completion(bool bShift)
 			}
 
 			if(bInCommand && !bIsCommand)
-			{
 				completionEscapeUnsafeToken(szMatch); // escape crazy things like Nick\nquit
-			}
 		}
 		else
 		{
@@ -2313,12 +2310,7 @@ void KviInputEditor::completion(bool bShift)
 		m_pKviWindow->outputNoFmt(KVI_OUT_SYSTEMMESSAGE, __tr2qs("No matches"));
 
 	if(!szMatch.isEmpty())
-	{
-		//if(!bIsDir && !bIsNick)match = match.toLower(); <-- why? It is nice to have
-		//						 $module.someFunctionName instad
-		//						 of unreadable $module.somefunctionfame
 		replaceWordBeforeCursor(szWord, szMatch, false);
-	}
 
 	repaintWithCursorOn();
 }
@@ -2478,7 +2470,6 @@ void KviInputEditor::insertChar(QChar c)
 
 void KviInputEditor::repaintWithCursorOn()
 {
-	// :)
 	if(!m_bUpdatesEnabled)
 		return;
 
@@ -2516,7 +2507,7 @@ int KviInputEditor::charIndexFromXPosition(qreal fXPos)
 	if(!pBlock)
 		return iCurChar;
 
-	// This is very tricky. Qt does not provide a simple mean to figure out the cursor position
+	// This is very tricky. Qt does not provide a simple means to figure out the cursor position
 	// from an x position on the text. We use QFontMetrics::elidedText() to guess it.
 
 	// Additionally Qt::ElideNone does not work as expected (see QTBUG-40315): it just ignores clipping altogether.

--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -2299,8 +2299,9 @@ void KviInputEditor::completion(bool bShift)
 		{
 			QString szAll;
 			szMatch = tmp.front();
-			auto predicate = bIsDir ? [](const QChar& a, const QChar& b) { return a.unicode() == b.unicode(); }
-				: [](const QChar& a, const QChar& b) { return a.toLower().unicode() == b.toLower().unicode(); };
+			auto predicate = bIsDir
+				? std::function<bool(const QChar &, const QChar &)>([](const QChar & a, const QChar & b) { return a.unicode() == b.unicode(); })
+				: std::function<bool(const QChar &, const QChar &)>([](const QChar & a, const QChar & b) { return a.toLower().unicode() == b.toLower().unicode(); });
 
 			for(auto szTmp : tmp)
 			{

--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -2315,6 +2315,9 @@ void KviInputEditor::completion(bool bShift)
 
 			if(m_pKviWindow)
 				m_pKviWindow->output(KVI_OUT_SYSTEMMESSAGE, __tr2qs("%d matches: %Q"), tmp.size(), &szAll);
+
+			if(szMatch.left(1) == '$')
+				szMatch.remove(0, 1);
 		}
 	}
 	else if(m_pKviWindow)

--- a/src/kvirc/ui/KviInputEditor.h
+++ b/src/kvirc/ui/KviInputEditor.h
@@ -117,7 +117,7 @@ protected:
 	int m_iSelectionBegin;
 	int m_iSelectionEnd;
 	int m_iMaxBufferSize;
-	bool m_bSpSlowFlag; // <-- what is this ?
+	bool m_bSpSlowFlag; // Slow paste status flag
 	int m_iCursorWidth;
 
 	// members for supporting input methods


### PR DESCRIPTION
- Updates the partial string matching for tab completion to use modern c++
- Cleanup on comments and code style
- Fixes HTML code in the context menu for clipboard preview
- Fixes issue of having too many newlines before the 60 character truncation which would spam the context menu potentially causing it to go to 2 or more columns
- Fixes uninitialized Slow Paste status flag that would randomly cause it to show in context menu depending on what was in that memory location previously
- Fixes issue of not properly removing $ prefix on kvs functions in tab completion causing an extra $ to be inserted before functions
- Disables auto appending of ' ' and '(' when in `/help` mode since you wouldn't want it in this context
- Fixes tab completion for kvs function $$
- Fixes #2065
