### PR TITLE
Fix using multiple keys in one join command with alias j

### DIFF
--- a/data/defscript/aliases.kvs
+++ b/data/defscript/aliases.kvs
@@ -219,7 +219,7 @@ alias(j)
 	}
 	else
 	{
-		join $0-
+		join $0 $1
 	}
 }
 


### PR DESCRIPTION
With it being `$0-` then running `/j #chan1,#chan2,#chan3 key1,key2` results in `JOIN #chan1,#chan2,#chan3 key1,#key2` treating it as a channel with a space in it.  This update fixes this issue.
