### PR TITLE
Fixes keyboard shortcuts in split view IRC channel. Fixes #1319

### DIFF
--- a/src/kvirc/ui/KviChannelWindow.cpp
+++ b/src/kvirc/ui/KviChannelWindow.cpp
@@ -2008,6 +2008,14 @@ void KviChannelWindow::checkChannelSync()
 	}
 }
 
+KviIrcView * KviChannelWindow::lastClickedView() const
+{
+	if(m_pMessageView && m_pIrcView && m_pMessageView->lastMouseClickTime() >= m_pIrcView->lastMouseClickTime())
+			return m_pMessageView;
+
+	return m_pIrcView;
+}
+
 bool KviChannelWindow::eventFilter(QObject * pObject, QEvent * pEvent)
 {
 	if(pEvent->type() == QEvent::FocusOut && pObject == m_pTopicWidget && m_pTopicWidget->isVisible())

--- a/src/kvirc/ui/KviChannelWindow.h
+++ b/src/kvirc/ui/KviChannelWindow.h
@@ -889,6 +889,15 @@ public:
 	*/
 	void checkChannelSync();
 
+	/**
+	* \brief Returns the KviIrcView that was last clicked in this window
+	*
+	* Acts as view() except for split view windows
+	* See also: view()
+	* \return KviIrcView *
+	*/
+	virtual KviIrcView * lastClickedView() const;
+
 protected:
 	/**
 	* \brief Filters the events

--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -1955,23 +1955,20 @@ void KviInputEditor::installShortcuts()
 
 void KviInputEditor::zoomIn()
 {
-	if(m_pKviWindow)
-		if(m_pKviWindow->view())
-			m_pKviWindow->view()->increaseFontSize();
+	if(m_pKviWindow && m_pKviWindow->lastClickedView())
+		m_pKviWindow->lastClickedView()->increaseFontSize();
 }
 
 void KviInputEditor::zoomOut()
 {
-	if(m_pKviWindow)
-		if(m_pKviWindow->view())
-			m_pKviWindow->view()->decreaseFontSize();
+	if(m_pKviWindow && m_pKviWindow->lastClickedView())
+		m_pKviWindow->lastClickedView()->decreaseFontSize();
 }
 
 void KviInputEditor::zoomDefault()
 {
-	if(m_pKviWindow)
-		if(m_pKviWindow->view())
-			m_pKviWindow->view()->resetDefaultFont();
+	if(m_pKviWindow && m_pKviWindow->lastClickedView())
+		m_pKviWindow->lastClickedView()->resetDefaultFont();
 }
 
 void KviInputEditor::keyPressEvent(QKeyEvent * e)
@@ -3083,52 +3080,52 @@ void KviInputEditor::deleteNextWord()
 
 void KviInputEditor::previousLine()
 {
-	if(m_pKviWindow && m_pKviWindow->view())
-		m_pKviWindow->view()->prevLine();
+	if(m_pKviWindow && m_pKviWindow->lastClickedView())
+		m_pKviWindow->lastClickedView()->prevLine();
 	return;
 }
 
 void KviInputEditor::nextLine()
 {
-	if(m_pKviWindow && m_pKviWindow->view())
-		m_pKviWindow->view()->nextLine();
+	if(m_pKviWindow && m_pKviWindow->lastClickedView())
+		m_pKviWindow->lastClickedView()->nextLine();
 	return;
 }
 
 void KviInputEditor::previousPage()
 {
-	if(m_pKviWindow && m_pKviWindow->view())
-		m_pKviWindow->view()->prevPage();
+	if(m_pKviWindow && m_pKviWindow->lastClickedView())
+		m_pKviWindow->lastClickedView()->prevPage();
 }
 
 void KviInputEditor::nextPage()
 {
-	if(m_pKviWindow && m_pKviWindow->view())
-		m_pKviWindow->view()->nextPage();
+	if(m_pKviWindow && m_pKviWindow->lastClickedView())
+		m_pKviWindow->lastClickedView()->nextPage();
 }
 
 void KviInputEditor::scrollTop()
 {
-	if(m_pKviWindow && m_pKviWindow->view())
-		m_pKviWindow->view()->scrollTop();
+	if(m_pKviWindow && m_pKviWindow->lastClickedView())
+		m_pKviWindow->lastClickedView()->scrollTop();
 }
 
 void KviInputEditor::scrollBottom()
 {
-	if(m_pKviWindow && m_pKviWindow->view())
-		m_pKviWindow->view()->scrollBottom();
+	if(m_pKviWindow && m_pKviWindow->lastClickedView())
+		m_pKviWindow->lastClickedView()->scrollBottom();
 }
 
 void KviInputEditor::search()
 {
-	if(m_pKviWindow && m_pKviWindow->view())
-		m_pKviWindow->view()->toggleToolWidget();
+	if(m_pKviWindow && m_pKviWindow->lastClickedView())
+		m_pKviWindow->lastClickedView()->toggleToolWidget();
 }
 
 void KviInputEditor::scrollToLastReadLine()
 {
-	if(m_pKviWindow && m_pKviWindow->view() && m_pKviWindow->view()->hasLineMark())
-		m_pKviWindow->view()->scrollToMarker();
+	if(m_pKviWindow && m_pKviWindow->lastClickedView() && m_pKviWindow->lastClickedView()->hasLineMark())
+		m_pKviWindow->lastClickedView()->scrollToMarker();
 }
 
 void KviInputEditor::sendPlain()

--- a/src/kvirc/ui/KviIrcView.cpp
+++ b/src/kvirc/ui/KviIrcView.cpp
@@ -231,6 +231,8 @@ KviIrcView::KviIrcView(QWidget * parent, KviWindow * pWnd)
 	//m_bShowImages            = KVI_OPTION_BOOL(KviOption_boolIrcViewShowImages);
 
 	m_iMouseTimer = 0;
+	m_pLastEvent = nullptr;
+	m_iLastMouseClickTime = QDateTime::currentMSecsSinceEpoch();
 
 	m_bAcceptDrops = false;
 	m_pPrivateBackgroundPixmap = nullptr;

--- a/src/kvirc/ui/KviIrcView.h
+++ b/src/kvirc/ui/KviIrcView.h
@@ -140,6 +140,7 @@ private:
 	QFontMetrics * m_pFm; // assume this valid only inside a paint event (may be 0 in other circumstances)
 
 	QMouseEvent * m_pLastEvent;
+	qint64 m_iLastMouseClickTime;
 
 	KviIrcViewToolTip * m_pToolTip;
 	bool m_bHaveUnreadedHighlightedMessages;
@@ -190,6 +191,8 @@ public:
 	void splitMessagesTo(KviIrcView * v);
 	void joinMessagesFrom(KviIrcView * v);
 	void appendMessagesFrom(KviIrcView * v);
+
+	qint64 lastMouseClickTime() const { return m_iLastMouseClickTime; }
 
 	// Return true if the specified message type should be "split" to the user message specific view.
 	bool messageShouldGoToMessageView(int iMsgType);

--- a/src/kvirc/ui/KviIrcView_events.cpp
+++ b/src/kvirc/ui/KviIrcView_events.cpp
@@ -245,6 +245,8 @@ void KviIrcView::mousePressEvent(QMouseEvent * e)
 	if(m_pKviWindow->input())
 		m_pKviWindow->input()->setFocus();
 
+	m_iLastMouseClickTime = QDateTime::currentMSecsSinceEpoch();
+
 	if(!(e->button() & Qt::LeftButton))
 	{
 		triggerMouseRelatedKvsEvents(e);

--- a/src/kvirc/ui/KviWindow.h
+++ b/src/kvirc/ui/KviWindow.h
@@ -282,6 +282,15 @@ public:
 	inline KviIrcView * view() const { return m_pIrcView; };
 
 	/**
+	* \brief Returns the KviIrcView that was last clicked in this window
+	*
+	* Acts as view() except for split view windows
+	* See also: view()
+	* \return KviIrcView *
+	*/
+	virtual KviIrcView * lastClickedView() const { return m_pIrcView; };
+
+	/**
 	* \brief Returns the console that this window belongs to
 	*
 	* May be null for windows that aren't bound to irc contexts


### PR DESCRIPTION
By clicking inside one of the two views in a split view IRC channel, keyboard shortcuts now apply to the last clicked view.
