### PR TITLE
Fix undefined behavior when trying to find an invalid window id

### DIFF
--- a/src/kvirc/kernel/KviApplication.cpp
+++ b/src/kvirc/kernel/KviApplication.cpp
@@ -1741,7 +1741,8 @@ KviConsoleWindow * KviApplication::topmostConnectedConsole()
 
 KviWindow * KviApplication::findWindow(const QString & szWindowId)
 {
-	return g_pGlobalWindowDict.find(szWindowId)->second;
+	auto search = g_pGlobalWindowDict.find(szWindowId);
+	return search != g_pGlobalWindowDict.end() ? search->second : nullptr;
 }
 
 KviWindow * KviApplication::findWindowByCaption(const QString & szWindowCaption, int iContextId)


### PR DESCRIPTION
When trying to find a window via an invalid id (ex: `/echo $window.type(0)`) will result in undefined behavior when returning from the `std::map.find()` and calling `second`.

Edit: Wording clarification.
