### PR TITLE
Add compatibilty to fish10 and mircryption keyx cbc mode.

### DIFF
--- a/src/modules/fish/libkvifish.cpp
+++ b/src/modules/fish/libkvifish.cpp
@@ -160,9 +160,15 @@ bool fish_event_onQueryNotice(KviKvsModuleEventCall * c)
 		}
 		else
 		{
-			c->window()->console()->connection()->sendFmtData("NOTICE %s :DH1080_FINISH %sA",
-			    c->window()->console()->connection()->encodeText(szNick).data(),
-			    szTmp.data());
+			// for compatibility with fish10
+			if(szMessage.endsWith(" CBC", Qt::CaseSensitive))
+				c->window()->console()->connection()->sendFmtData("NOTICE %s :DH1080_FINISH %sA CBC",
+					c->window()->console()->connection()->encodeText(szNick).data(),
+					szTmp.data());
+			else
+				c->window()->console()->connection()->sendFmtData("NOTICE %s :DH1080_FINISH %sA",
+					c->window()->console()->connection()->encodeText(szNick).data(),
+					szTmp.data());
 		}
 	}
 


### PR DESCRIPTION
Mimics fish10 when getting a DH1080_INIT from a fish10 user so the other party will use CBC mode as well.
Also adds support for DH1080_FINISH_cbc being received from Mircryption or other clients.