### PR TITLE
Make channel list dialogs more consistent; fix #1790

### DIFF
--- a/src/kvirc/ui/KviSelectors.cpp
+++ b/src/kvirc/ui/KviSelectors.cpp
@@ -34,6 +34,7 @@
 #include <QPainter>
 #include <QLayout>
 #include <QColorDialog>
+#include <QGroupBox>
 #include <QPalette>
 #include <QFontDialog>
 #include <QAbstractItemView>
@@ -845,18 +846,31 @@ KviChannelListSelector::KviChannelListSelector(QWidget * par, const QString & tx
 	m_pTreeWidget->setHeaderLabels(columnLabels);
 	m_pTreeWidget->setColumnWidth(0, 200);
 	m_pTreeWidget->setColumnWidth(1, 200);
-	KviTalHBox * pEditsHBox = new KviTalHBox(this);
 
-	m_pChanLineEdit = new QLineEdit(pEditsHBox);
-	m_pChanLineEdit->setPlaceholderText(__tr2qs("Channel name")); // setPlaceHolderText() is not the correct and consistent way to fix this, this is the easy way out adding more inconsistency across dialogs.
+	QGroupBox * pEditsGroupBox = new QGroupBox(__tr2qs("Add channel"), this);
+	QGridLayout * pChannelLayout = new QGridLayout(pEditsGroupBox);
+
+	QString szMsg = __tr2qs("Name");
+	szMsg.append(":");
+
+	QLabel * pNameLabel = new QLabel(szMsg, pEditsGroupBox);
+	pChannelLayout->addWidget(pNameLabel, 1, 0);
+
+	m_pChanLineEdit = new QLineEdit(pEditsGroupBox);
 	connect(m_pChanLineEdit, SIGNAL(textChanged(const QString &)), this, SLOT(textChanged(const QString &)));
 	connect(m_pChanLineEdit, SIGNAL(returnPressed()), this, SLOT(addClicked()));
+	pChannelLayout->addWidget(m_pChanLineEdit, 1, 1);
 
-	m_pPassLineEdit = new QLineEdit(pEditsHBox);
+	szMsg = __tr2qs("Password");
+	szMsg.append(":");
+
+	QLabel * pPasswordLabel = new QLabel(szMsg, pEditsGroupBox);
+	pChannelLayout->addWidget(pPasswordLabel, 2, 0);
+
+	m_pPassLineEdit = new QLineEdit(pEditsGroupBox);
 	m_pPassLineEdit->setEchoMode(QLineEdit::Password);
-	m_pPassLineEdit->setPlaceholderText(__tr2qs("Channel password")); //setPlaceHolderText() is not the correct and consistent way to fix this, this is the easy way out adding more inconsistency across dialogs.
-	connect(m_pPassLineEdit, SIGNAL(textChanged(const QString &)), this, SLOT(textChanged(const QString &)));
 	connect(m_pPassLineEdit, SIGNAL(returnPressed()), this, SLOT(addClicked()));
+	pChannelLayout->addWidget(m_pPassLineEdit, 2, 1);
 
 	KviTalHBox * hBox = new KviTalHBox(this);
 
@@ -875,6 +889,10 @@ KviChannelListSelector::KviChannelListSelector(QWidget * par, const QString & tx
 	setSpacing(4);
 	setStretchFactor(m_pTreeWidget, 1);
 	setEnabled(bEnabled);
+
+	// Default disable the add and remove buttons
+	m_pAddButton->setEnabled(false);
+	m_pRemoveButton->setEnabled(false);
 }
 
 KviChannelListSelector::~KviChannelListSelector()
@@ -908,6 +926,7 @@ void KviChannelListSelector::textChanged(const QString &)
 
 void KviChannelListSelector::itemSelectionChanged()
 {
+	m_pRemoveButton->setEnabled(m_pTreeWidget->selectedItems().size() > 0);
 }
 
 void KviChannelListSelector::addClicked()

--- a/src/modules/channelsjoin/ChannelsJoinDialog.cpp
+++ b/src/modules/channelsjoin/ChannelsJoinDialog.cpp
@@ -35,12 +35,12 @@
 #include "KviRegisteredChannel.h"
 #include "KviRegisteredChannelDataBase.h"
 #include "KviSelectors.h"
-#include "KviTalGroupBox.h"
 
 #include <QCheckBox>
 #include <QCloseEvent>
 #include <QDesktopWidget>
 #include <QEvent>
+#include <QGroupBox>
 #include <QHeaderView>
 #include <QLabel>
 #include <QLayout>
@@ -71,23 +71,29 @@ ChannelsJoinDialog::ChannelsJoinDialog(const char * name)
 	m_pTreeWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 	g->addWidget(m_pTreeWidget, 0, 0, 1, 2);
 
-	m_pGroupBox = new KviTalGroupBox(Qt::Horizontal, __tr2qs("Channel"), this);
+	m_pGroupBox = new QGroupBox(__tr2qs("Channel"), this);
+	QGridLayout * pChannelLayout = new QGridLayout(m_pGroupBox);
+
 	QString szMsg = __tr2qs("Name");
 	szMsg.append(":");
 
-	new QLabel(szMsg, m_pGroupBox);
+	QLabel * pNameLabel = new QLabel(szMsg, m_pGroupBox);
+	pChannelLayout->addWidget(pNameLabel, 1, 0);
 
 	m_pChannelEdit = new QLineEdit(m_pGroupBox);
 	connect(m_pChannelEdit, SIGNAL(returnPressed()), this, SLOT(editReturnPressed()));
 	connect(m_pChannelEdit, SIGNAL(textChanged(const QString &)), this, SLOT(editTextChanged(const QString &)));
+	pChannelLayout->addWidget(m_pChannelEdit, 1, 1);
 
 	szMsg = __tr2qs("Password");
 	szMsg.append(":");
 
-	new QLabel(szMsg, m_pGroupBox);
+	QLabel * pPasswordLabel = new QLabel(szMsg, m_pGroupBox);
+	pChannelLayout->addWidget(pPasswordLabel, 2, 0);
 
 	m_pPass = new QLineEdit(m_pGroupBox);
 	m_pPass->setEchoMode(QLineEdit::Password);
+	pChannelLayout->addWidget(m_pPass, 2, 1);
 
 	g->addWidget(m_pGroupBox, 1, 0, 1, 2);
 

--- a/src/modules/channelsjoin/ChannelsJoinDialog.h
+++ b/src/modules/channelsjoin/ChannelsJoinDialog.h
@@ -37,7 +37,7 @@
 #include <QTreeWidget>
 
 class KviConsoleWindow;
-class KviTalGroupBox;
+class QGroupBox;
 class QCheckBox;
 class QLineEdit;
 class QPushButton;
@@ -102,7 +102,7 @@ protected:
 	};
 	QLineEdit * m_pChannelEdit;
 	ChannelsJoinDialogTreeWidget * m_pTreeWidget;
-	KviTalGroupBox * m_pGroupBox;
+	QGroupBox * m_pGroupBox;
 	QLineEdit * m_pPass;
 	QCheckBox * m_pShowAtStartupCheck;
 	QCheckBox * m_pCloseAfterJoinCheck;


### PR DESCRIPTION
The "join channels" dialog and the "auto join channel list" settings dialog both presented a list of channels and some fields to add/remove channels from the list.
They were quite inconsistent as stated in#1790.
This PR tries to make them more consistent.
As a bonus, the "add" and "remove" buttons are now correctly enabled/disabled when they are useful.

![schermata 2017-01-28 alle 18 28 19](https://cloud.githubusercontent.com/assets/1631111/22398406/32c16dac-e588-11e6-8e4e-670a44d99c05.png)
![schermata 2017-01-28 alle 18 28 52](https://cloud.githubusercontent.com/assets/1631111/22398407/32c3bb5c-e588-11e6-9156-7e34aeff133f.png)
