### PR TITLE
Disable old broken OnURLLinkPopupRequest when restoring default script; fix #2140

### DIFF
--- a/data/defscript/events.kvs
+++ b/data/defscript/events.kvs
@@ -163,6 +163,10 @@ event(OnURLLinkClick,default)
 	openurl $0
 }
 
+# Fix bug https://github.com/kvirc/KVIrc/issues/2140
+eventctl -d -q OnURLLinkPopupRequest "URL popup"
+eventctl -d -q OnURLLinkPopupRequest "URLpopup"
+
 event(OnURLLinkPopupRequest,default)
 {
 	popup.show urlpopup $0

--- a/src/kvirc/kvs/KviKvsCoreCallbackCommands.cpp
+++ b/src/kvirc/kvs/KviKvsCoreCallbackCommands.cpp
@@ -532,7 +532,7 @@ namespace KviKvsCoreCallbackCommands
 			or a numeric code (from 0 to 999) of a RAW server message.[br]
 			If the -q switch is specified then the command runs in quiet mode.
 		@seealso:
-			[cmd]eventctl[/cmd]
+			[cmd]eventctl[/cmd] [fnc]$iseventenabled[/fnc]
 	*/
 
 	KVSCCC(event)

--- a/src/kvirc/kvs/KviKvsCoreFunctions_gl.cpp
+++ b/src/kvirc/kvs/KviKvsCoreFunctions_gl.cpp
@@ -693,6 +693,8 @@ namespace KviKvsCoreFunctions
 			<boolean> $isEventEnabled(<event_name:string>,<handler_name:string>)
 		@description:
 			Returns [b]1[/b] if the event handler is enabled.
+		@seealso:
+			[cmd]event[/cmd] [cmd]eventctl[/cmd]
 	*/
 
 	KVSCF(isEventEnabled)

--- a/src/kvirc/kvs/KviKvsCoreSimpleCommands_af.cpp
+++ b/src/kvirc/kvs/KviKvsCoreSimpleCommands_af.cpp
@@ -1469,7 +1469,7 @@ namespace KviKvsCoreSimpleCommands
 			The <event_name> may be one of the kvirc-builtin event names
 			or a numeric code (from 0 to 999) of a raw server message.[br]
 		@seealso:
-			[cmd]event[/cmd]
+			[cmd]event[/cmd] [fnc]$iseventenabled[/fnc]
 	*/
 	KVSCSC(eventctl)
 	{


### PR DESCRIPTION
In order to fix #2140, the default event handler for the `OnURLLinkPopupRequest` event has been renamed in f8f50bd6a787fdae7ce03cc36f97068399700d66.
This PR adds some code in the default KVS events script that disables any leftover from the old event handler, to avoid duplicate event handlers and the problem described in #2140.
As a bonus, the documentation for event-related methods has been crosslinked.