### PR TITLE
Shut up VC++

### DIFF
--- a/cmake/KVIrc.nsi.cmake
+++ b/cmake/KVIrc.nsi.cmake
@@ -111,12 +111,12 @@ Section !$(KVIrc) KVIrc_IDX
 
 	IfFileExists "$INSTDIR\vcredist_x86.exe" VcRedist86Exists PastVcRedist86Check
 	VcRedist86Exists:
-		ExecWait '"$INSTDIR\vcredist_x86.exe"  /passive /norestart'
+		ExecWait '"$INSTDIR\vcredist_x86.exe"  /quiet /norestart'
 	PastVcRedist86Check:
 
 	IfFileExists "$INSTDIR\vcredist_x64.exe" VcRedist64Exists PastVcRedist64Check
 	VcRedist64Exists:
-		ExecWait '"$INSTDIR\vcredist_x64.exe"  /passive /norestart'
+		ExecWait '"$INSTDIR\vcredist_x64.exe"  /quiet /norestart'
 	PastVcRedist64Check:
 
 SectionEnd


### PR DESCRIPTION
Make the MS VC++ redist installer run silently, it's just an unnecessary popup.

This is https://github.com/kvirc/KVIrc/pull/2147 without the other change since @Dessa didn't want that (?) just yet?