### PR TITLE
add only a direct shortcut to kvirc in the windows start menu

### DIFF
--- a/cmake/KVIrc.nsi.cmake
+++ b/cmake/KVIrc.nsi.cmake
@@ -124,10 +124,7 @@ SectionEnd
 ; Optional section (can be disabled by the user)
 Section $(StartMenuSection) StartMenuSection_IDX
   SetShellVarContext all
-  CreateDirectory "$SMPROGRAMS\KVIrc"
-  CreateShortCut "$SMPROGRAMS\KVIrc\Uninstall.lnk" "$INSTDIR\uninstall.exe" "" "$INSTDIR\uninstall.exe" 0
-  CreateShortCut "$SMPROGRAMS\KVIrc\KVIrc.lnk" "$INSTDIR\@KVIRC_BINARYNAME@.exe" "" "$INSTDIR\@KVIRC_BINARYNAME@.exe" 0 "" "" $(ProgramDescription)
-
+  CreateShortCut "$SMPROGRAMS\KVIrc.lnk" "$INSTDIR\@KVIRC_BINARYNAME@.exe" "" "$INSTDIR\@KVIRC_BINARYNAME@.exe" 0 "" "" $(ProgramDescription)
 SectionEnd
 
 Section $(DesktopSection) DesktopSection_IDX
@@ -231,8 +228,7 @@ Section !un.$(UnGeneralFiles)
     DeleteRegKey HKLM SOFTWARE\KVIrc
 
     ; Remove shortcuts, if any
-    Delete "$SMPROGRAMS\KVIrc\*.*"
-    RMDir "$SMPROGRAMS\KVIrc"
+    Delete "$SMPROGRAMS\KVIrc.lnk"
     Delete "$DESKTOP\KVIrc.lnk"
     Delete "$QUICKLAUNCH\KVIrc.lnk"
 


### PR DESCRIPTION
Microsoft guidelines say that only shortcuts to the application itself should be shown in the start menu.

http://web.archive.org/web/20120305022332/http://msdn.microsoft.com/en-us/library/aa511447.aspx

>Put only program shortcuts on the Start menu. Don't put shortcuts to the following items on the Start menu:
>Program uninstallers. Users access uninstallers through the Programs control panel item.

Everybody ok?