### PR TITLE
fix: hide comments in issues in new posts

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@
 ### Actual behavior
 
 
-[//]: # (Besides the text description, include any screenshot(s) that help us visualize the issue you're facing)
+[//]:# (Besides the text description, include any screenshots that help us visualize the issue you're facing)
 
 ### Steps to reproduce the issue
 1.
@@ -12,10 +12,10 @@
 3.
 
 ### System information
-[//]: # (Type "/about.kvirc" (or click "Help → About KVIrc") and copy&paste the details from the "Executable Information" tab below between ``` marks)
-[//]: # (Also Enter any OS information the "Executable Information" tab doesn't contain, e.g. KDE, Gentoo, Linux Mint, etc.)
+[//]:# (Type ```/about.kvirc``` or click "Help → About KVIrc" and copy & paste the details from the "Executable Information" tab below between ``` marks)  
+[//]:# (Also Enter any OS information the "Executable Information" tab doesn't contain, e.g. KDE, Gentoo, Linux Mint, etc.)
 
 ```
 
 ```
-[//]: # (If you experienced crashes, segfaults please also include a stacktrace below, For how-to read: https://github.com/kvirc/KVIrc/wiki/Grabbing-a-useful-backtrace.)
+[//]:# (If you experienced crashes or segfaults please also include a stacktrace below, For how-to read: https://github.com/kvirc/KVIrc/wiki/Grabbing-a-useful-backtrace.)


### PR DESCRIPTION
The _issue_ happens because comments can only have one ( open and ) close bracket. so ``` [//]:# (this is a comment (and it) shouldn't show up)``` shows up unless the inner brackets are escaped like ```[//]:# (this is a comment \(and it\) shouldn't show up)``` or there's no inner brackets or ```<!-- xml comments -->``` is used.

This is probably a regression introduced by GitHub

this should fix the issue that comments show up in tickets like #2211

[//]: # (If your pull request is a fix to an open issue please add fixes #9999 to the commit comments.)
[//]: # (If your proposal involves GUI improvements, add screenshots of before and after to help visualise the proposal on the fly.)
#### Changes proposed
- remove inner brackets from comments
-
-

[//]: # (If you have write privileges to repository, do label your pull request, else you could insert a mention prefixed with @GitHub-Username below.)

