### PR TITLE
Remove \r chop when pasting last log

### DIFF
--- a/src/kvirc/ui/KviWindow.cpp
+++ b/src/kvirc/ui/KviWindow.cpp
@@ -1496,12 +1496,6 @@ enough:
 			}
 		}
 
-		if (szLine.endsWith("\r"))
-		{
-			// Remove the \r char at the szEnd of line
-			szLine.chop(1);
-		}
-
 		if (szLine.isEmpty())
 			continue;
 


### PR DESCRIPTION
Removing the last \r on the line messes up KVIrc link recognition since that \r is the termination of the KVIrc link.

fixes #2167