### PR TITLE
Fix string type in ShellExecute for URL handlers on Windows

### DIFF
--- a/src/kvirc/kvs/KviKvsCoreSimpleCommands_mr.cpp
+++ b/src/kvirc/kvs/KviKvsCoreSimpleCommands_mr.cpp
@@ -415,7 +415,7 @@ namespace KviKvsCoreSimpleCommands
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
 		if(KVI_OPTION_BOOL(KviOption_boolUseSystemUrlHandlers))
 		{
-			intptr_t iRet = (intptr_t)::ShellExecute(NULL, "open", szUrl.toLocal8Bit().data(), NULL, NULL, SW_SHOWNORMAL);
+			intptr_t iRet = (intptr_t)::ShellExecute(NULL, "open", szUrl.toStdWString().data(), NULL, NULL, SW_SHOWNORMAL);
 			if(iRet <= 32)
 			{
 				/*


### PR DESCRIPTION
An attempt at fixing opening of utf-8 links when opened with setting "Use system URL handlers" enabled on Windows builds.