### PR TITLE
Make Windows code Unicode-aware

### DIFF
--- a/src/kvilib/config/kvi_settings.h
+++ b/src/kvilib/config/kvi_settings.h
@@ -193,4 +193,9 @@
 #endif
 #endif
 
+#if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
+#define UNICODE
+#define _UNICODE
+#endif
+
 #endif //_KVI_SETTINGS_H_

--- a/src/kvilib/ext/KviRuntimeInfo.cpp
+++ b/src/kvilib/ext/KviRuntimeInfo.cpp
@@ -613,7 +613,7 @@ static QString queryWinInfo(QueryInfo info)
 					}
 			}
 			// Display service pack (if any) and build number.
-			szVersion += QString("%1 (Build %2)").arg(osvi.szCSDVersion).arg(osvi.dwBuildNumber & 0xFFFF);
+			szVersion += QString("%1 (Build %2)").arg(QString::fromWCharArray(osvi.szCSDVersion)).arg(osvi.dwBuildNumber & 0xFFFF);
 	}
 	if(info == Os_Release)
 	{

--- a/src/kvilib/locale/KviLocale.cpp
+++ b/src/kvilib/locale/KviLocale.cpp
@@ -479,15 +479,15 @@ KviLocale::KviLocale(QApplication * pApp, const QString & szLocaleDir, const QSt
 	if(KviFileUtils::fileExists(szLangFile))
 		KviFileUtils::readFile(szLangFile, g_szLang);
 	if(g_szLang.isEmpty())
-		g_szLang = KviEnvironment::getVariable(QString("KVIRC_LANG"));
+		g_szLang = KviEnvironment::getVariable("KVIRC_LANG");
 #ifdef COMPILE_KDE_SUPPORT
 	if(g_szLang.isEmpty())
-		g_szLang = KviEnvironment::getVariable(QString("KDE_LANG"));
+		g_szLang = KviEnvironment::getVariable("KDE_LANG");
 #endif //COMPILE_KDE_SUPPORT
 	if(g_szLang.isEmpty())
-		g_szLang = KviEnvironment::getVariable(QString("LC_MESSAGES"));
+		g_szLang = KviEnvironment::getVariable("LC_MESSAGES");
 	if(g_szLang.isEmpty())
-		g_szLang = KviEnvironment::getVariable(QString("LANG"));
+		g_szLang = KviEnvironment::getVariable("LANG");
 	if(g_szLang.isEmpty())
 		g_szLang = QLocale::system().name();
 	if(g_szLang.isEmpty())

--- a/src/kvilib/locale/KviLocale.cpp
+++ b/src/kvilib/locale/KviLocale.cpp
@@ -467,7 +467,7 @@ static KviLocale::EncodingDescription supported_encodings[] = {
 
 KviLocale * KviLocale::m_pSelf = nullptr;
 unsigned int KviLocale::m_uCount = 0;
-KviCString KviLocale::g_szLang = "";
+QString KviLocale::g_szLang = "";
 
 KviLocale::KviLocale(QApplication * pApp, const QString & szLocaleDir, const QString & szForceLocaleDir)
 {
@@ -477,26 +477,22 @@ KviLocale::KviLocale(QApplication * pApp, const QString & szLocaleDir, const QSt
 	QString szLangFile = QString("%1/%2").arg(szForceLocaleDir, KVI_FORCE_LOCALE_FILE_NAME);
 
 	if(KviFileUtils::fileExists(szLangFile))
-	{
-		QString szTmp;
-		KviFileUtils::readFile(szLangFile, szTmp);
-		g_szLang = szTmp;
-	}
+		KviFileUtils::readFile(szLangFile, g_szLang);
 	if(g_szLang.isEmpty())
-		g_szLang = KviEnvironment::getVariable("KVIRC_LANG");
+		g_szLang = KviEnvironment::getVariable(QString("KVIRC_LANG"));
 #ifdef COMPILE_KDE_SUPPORT
 	if(g_szLang.isEmpty())
-		g_szLang = KviEnvironment::getVariable("KDE_LANG");
+		g_szLang = KviEnvironment::getVariable(QString("KDE_LANG"));
 #endif //COMPILE_KDE_SUPPORT
 	if(g_szLang.isEmpty())
-		g_szLang = KviEnvironment::getVariable("LC_MESSAGES");
+		g_szLang = KviEnvironment::getVariable(QString("LC_MESSAGES"));
 	if(g_szLang.isEmpty())
-		g_szLang = KviEnvironment::getVariable("LANG");
+		g_szLang = KviEnvironment::getVariable(QString("LANG"));
 	if(g_szLang.isEmpty())
 		g_szLang = QLocale::system().name();
 	if(g_szLang.isEmpty())
 		g_szLang = "en";
-	g_szLang.trim();
+	g_szLang = g_szLang.trimmed();
 
 	g_szDefaultLocalePath = szLocaleDir;
 
@@ -512,12 +508,12 @@ KviLocale::KviLocale(QApplication * pApp, const QString & szLocaleDir, const QSt
 	// the codecs by ourselves...
 	g_pSmartCodecDict->setAutoDelete(false);
 
-	if(g_szLang.hasData())
+	if(!g_szLang.isEmpty())
 	{
 		// ensure Qt will use the right locale when formatting dates, numbers, ..
 		// Note: Qt will use the system() locale anyway, we need to construct an empty QLocale()
 		// to get it use our specified locale.
-		QLocale::setDefault(QLocale(QString::fromLatin1(g_szLang.ptr(), g_szLang.len())));
+		QLocale::setDefault(QLocale(g_szLang));
 
 		QString szBuffer;
 		if(findCatalogue(szBuffer, "kvirc", szLocaleDir))
@@ -536,7 +532,7 @@ KviLocale::KviLocale(QApplication * pApp, const QString & szLocaleDir, const QSt
 			if(!(kvi_strEqualCI(szTmp.ptr(), "en") || kvi_strEqualCI(szTmp.ptr(), "c") || kvi_strEqualCI(szTmp.ptr(), "us") || kvi_strEqualCI(szTmp.ptr(), "gb") || kvi_strEqualCI(szTmp.ptr(), "posix")))
 			{
 				// FIXME: THIS IS NO LONGER VALID!!!
-				qDebug("Can't find the catalogue for locale \"%s\" (%s)", g_szLang.ptr(), szTmp.ptr());
+				qDebug("Can't find the catalogue for locale \"%s\" (%s)", g_szLang.toUtf8().data(), szTmp.ptr());
 				qDebug("There is no such translation or the $LANG variable was incorrectly set");
 				qDebug("You can use $KVIRC_LANG to override the catalogue name");
 				qDebug("For example you can set KVIRC_LANG to it_IT to force usage of the it.mo catalogue");

--- a/src/kvilib/locale/KviLocale.h
+++ b/src/kvilib/locale/KviLocale.h
@@ -90,7 +90,7 @@ protected:
 	~KviLocale();
 
 public:
-	static KviCString g_szLang;
+	static QString g_szLang;
 
 protected:
 	QApplication * m_pApp;
@@ -150,7 +150,7 @@ public:
 	* \brief Returns the language code of the localization
 	* \return const KviCString &
 	*/
-	const KviCString & localeName() { return g_szLang; }
+	const QString & localeName() { return g_szLang; }
 
 	/**
 	* \brief Returns the codec associated to the given translation

--- a/src/kvilib/locale/KviLocale.h
+++ b/src/kvilib/locale/KviLocale.h
@@ -148,9 +148,9 @@ public:
 
 	/**
 	* \brief Returns the language code of the localization
-	* \return const KviCString &
+	* \return const QString &
 	*/
-	const QString & localeName() { return g_szLang; }
+	const QString & localeName() const { return g_szLang; }
 
 	/**
 	* \brief Returns the codec associated to the given translation

--- a/src/kvilib/system/KviEnvironment.cpp
+++ b/src/kvilib/system/KviEnvironment.cpp
@@ -33,7 +33,7 @@ namespace KviEnvironment
 
 #if !defined(COMPILE_ON_WINDOWS) && !defined(COMPILE_ON_MINGW)
 
-	bool setVariable(const QString & szName, QString & szValue)
+	bool setVariable(const QString & szName, const QString & szValue)
 	{
 		auto name = szName.toLocal8Bit();
 		auto value = szValue.toLocal8Bit();

--- a/src/kvilib/system/KviEnvironment.cpp
+++ b/src/kvilib/system/KviEnvironment.cpp
@@ -33,14 +33,14 @@ namespace KviEnvironment
 
 #if !defined(COMPILE_ON_WINDOWS) && !defined(COMPILE_ON_MINGW)
 
-#ifdef HAVE_SETENV
-	bool setVariable(const char * name, const char * value)
+	bool setVariable(QString szName, QString szValue)
 	{
+		const char * name = szName.toLocal8Bit().data();
+		const char * value = szValue.toLocal8Bit().data();
+#ifdef HAVE_SETENV
 		return (setenv(name, value, 1) == 0);
 #else
 #ifdef HAVE_PUTENV
-	bool setVariable(const char * name, const char * value)
-	{
 		int iLen1 = kvi_strLen(name);
 		int iLen2 = kvi_strLen(value);
 		char * buf = (char *)KviMemory::allocate(iLen1 + iLen2 + 2);
@@ -56,22 +56,19 @@ namespace KviEnvironment
 		}
 		return true;
 #else
-	bool setVariable(const char *, const char *)
-	{
 		// no setenv, no putenv.. what the hell of system is this ?
 		return false;
 #endif
 #endif
 	}
 
-#ifdef HAVE_UNSETENV
-	void unsetVariable(const char * name)
+	void unsetVariable(QString szName)
 	{
+		const char * name = szName.toLocal8Bit().data();
+#ifdef HAVE_UNSETENV
 		unsetenv(name);
 #else
 #ifdef HAVE_PUTENV
-	void unsetVariable(const char * name)
-	{
 		int iLen1 = kvi_strLen(name);
 		char * buf = (char *)KviMemory::allocate(iLen1 + 1);
 		KviMemory::move(buf, name, iLen1);
@@ -92,8 +89,6 @@ namespace KviEnvironment
 			} // else this system sux
 		}
 #else
-	void unsetVariable(const char *)
-	{
 // no setenv, no putenv.. what the hell of system is this ?
 #endif
 #endif

--- a/src/kvilib/system/KviEnvironment.cpp
+++ b/src/kvilib/system/KviEnvironment.cpp
@@ -38,11 +38,11 @@ namespace KviEnvironment
 		auto name = szName.toLocal8Bit();
 		auto value = szValue.toLocal8Bit();
 #ifdef HAVE_SETENV
-		return (setenv(name, value, 1) == 0);
+		return (setenv(name.data(), value.data(), 1) == 0);
 #else
 #ifdef HAVE_PUTENV
-		int iLen1 = kvi_strLen(name.data());
-		int iLen2 = kvi_strLen(value.data());
+		int iLen1 = name.length()
+		int iLen2 = value.length();
 		char * buf = (char *)KviMemory::allocate(iLen1 + iLen2 + 2);
 		KviMemory::move(buf, name.data(), iLen1);
 		*(buf + iLen1) = '=';
@@ -66,10 +66,10 @@ namespace KviEnvironment
 	{
 		auto name = szName.toLocal8Bit();
 #ifdef HAVE_UNSETENV
-		unsetenv(name);
+		unsetenv(name.data());
 #else
 #ifdef HAVE_PUTENV
-		int iLen1 = kvi_strLen(name.data());
+		int iLen1 = name.length();
 		char * buf = (char *)KviMemory::allocate(iLen1 + 1);
 		KviMemory::move(buf, name.data(), iLen1);
 		*(buf + iLen1) = '\0';

--- a/src/kvilib/system/KviEnvironment.cpp
+++ b/src/kvilib/system/KviEnvironment.cpp
@@ -33,20 +33,20 @@ namespace KviEnvironment
 
 #if !defined(COMPILE_ON_WINDOWS) && !defined(COMPILE_ON_MINGW)
 
-	bool setVariable(QString szName, QString szValue)
+	bool setVariable(const QString & szName, QString & szValue)
 	{
-		const char * name = szName.toLocal8Bit().data();
-		const char * value = szValue.toLocal8Bit().data();
+		auto name = szName.toLocal8Bit();
+		auto value = szValue.toLocal8Bit();
 #ifdef HAVE_SETENV
 		return (setenv(name, value, 1) == 0);
 #else
 #ifdef HAVE_PUTENV
-		int iLen1 = kvi_strLen(name);
-		int iLen2 = kvi_strLen(value);
+		int iLen1 = kvi_strLen(name.data());
+		int iLen2 = kvi_strLen(value.data());
 		char * buf = (char *)KviMemory::allocate(iLen1 + iLen2 + 2);
-		KviMemory::move(buf, name, iLen1);
+		KviMemory::move(buf, name.data(), iLen1);
 		*(buf + iLen1) = '=';
-		KviMemory::move(buf + iLen1 + 1, value, iLen2);
+		KviMemory::move(buf + iLen1 + 1, value.data(), iLen2);
 		*(buf + iLen1 + iLen2 + 1) = '\0';
 		int iRet = putenv(buf);
 		if(iRet != 0)
@@ -62,16 +62,16 @@ namespace KviEnvironment
 #endif
 	}
 
-	void unsetVariable(QString szName)
+	void unsetVariable(const QString & szName)
 	{
-		const char * name = szName.toLocal8Bit().data();
+		auto name = szName.toLocal8Bit();
 #ifdef HAVE_UNSETENV
 		unsetenv(name);
 #else
 #ifdef HAVE_PUTENV
-		int iLen1 = kvi_strLen(name);
+		int iLen1 = kvi_strLen(name.data());
 		char * buf = (char *)KviMemory::allocate(iLen1 + 1);
-		KviMemory::move(buf, name, iLen1);
+		KviMemory::move(buf, name.data(), iLen1);
 		*(buf + iLen1) = '\0';
 		int iRet = putenv(buf);
 		if(iRet != 0)
@@ -81,7 +81,7 @@ namespace KviEnvironment
 		else
 		{
 			// hmmm
-			if(getVariable(name) == nullptr)
+			if(getVariable(name.data()) == nullptr)
 			{
 				// ok, the string is not in the environment
 				// we can free it

--- a/src/kvilib/system/KviEnvironment.h
+++ b/src/kvilib/system/KviEnvironment.h
@@ -45,25 +45,23 @@ namespace KviEnvironment
 {
 
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
-	inline QString getVariable(QString szName)
+	inline QString getVariable(const QString & szName)
 	{
 		LPTSTR szRet = (LPTSTR)::malloc(MAX_ENV_SIZE * sizeof(TCHAR));
 		QString szValue;
 		if (GetEnvironmentVariable(szName.toStdWString().c_str(), szRet, MAX_ENV_SIZE))
 			szValue = QString::fromStdWString(szRet);
-		else
-			szValue = QString();
 		::free(szRet);
 		return szValue;
 	}
 
-	inline void setVariable(QString szName, QString szValue)
+	inline void setVariable(const QString & szName, const QString & szValue)
 	{
 		SetEnvironmentVariable(szName.toStdWString().c_str(),
 			szValue.toStdWString().c_str());
 	}
 
-	inline void unsetVariable(QString szName)
+	inline void unsetVariable(const QString & szName)
 	{
 		SetEnvironmentVariable(szName.toStdWString().c_str(), NULL);
 	}
@@ -73,7 +71,7 @@ namespace KviEnvironment
 	* \param name The name of the variable to get
 	* \return char *
 	*/
-	inline QString getVariable(QString szName)
+	inline QString getVariable(const QString & szName)
 	{
 		const char * name = szName.toLocal8Bit().data();
 		return QString::fromLocal8Bit(getenv(name));
@@ -85,14 +83,14 @@ namespace KviEnvironment
 	* \param value The value of the variable
 	* \return bool
 	*/
-	KVILIB_API bool setVariable(QString szName, QString szValue);
+	KVILIB_API bool setVariable(const QString & szName, QString & szValue);
 
 	/**
 	* \brief Unsets environment variable
 	* \param name The name of the variable to set
 	* \return void
 	*/
-	KVILIB_API void unsetVariable(QString szName);
+	KVILIB_API void unsetVariable(const QString & szName);
 #endif
 }
 

--- a/src/kvilib/system/KviEnvironment.h
+++ b/src/kvilib/system/KviEnvironment.h
@@ -73,8 +73,8 @@ namespace KviEnvironment
 	*/
 	inline QString getVariable(const QString & szName)
 	{
-		const char * name = szName.toLocal8Bit().data();
-		return QString::fromLocal8Bit(getenv(name));
+		auto name = szName.toLocal8Bit();
+		return QString::fromLocal8Bit(getenv(name.data()));
 	}
 
 	/**

--- a/src/kvilib/system/KviEnvironment.h
+++ b/src/kvilib/system/KviEnvironment.h
@@ -83,7 +83,7 @@ namespace KviEnvironment
 	* \param value The value of the variable
 	* \return bool
 	*/
-	KVILIB_API bool setVariable(const QString & szName, QString & szValue);
+	KVILIB_API bool setVariable(const QString & szName, const QString & szValue);
 
 	/**
 	* \brief Unsets environment variable

--- a/src/kvirc/kernel/KviApplication.cpp
+++ b/src/kvirc/kernel/KviApplication.cpp
@@ -1277,7 +1277,7 @@ void KviApplication::updatePseudoTransparency()
 		{
 			QSize size = g_pApp->desktop()->screenGeometry(g_pApp->desktop()->primaryScreen()).size();
 			// get the Program Manager
-			HWND hWnd = FindWindow("Progman", "Program Manager");
+			HWND hWnd = FindWindow(TEXT("Progman"), TEXT("Program Manager"));
 			// Create and setup bitmap
 			const HDC displayDc = GetDC(0);
 			HDC bitmap_dc = CreateCompatibleDC(displayDc);

--- a/src/kvirc/kernel/KviApplication_filesystem.cpp
+++ b/src/kvirc/kernel/KviApplication_filesystem.cpp
@@ -74,7 +74,7 @@ void KviApplication::getGlobalKvircDirectory(QString & szData, KvircSubdir dir, 
 			szData.append("help");
 			{
 				// Localized help
-				QString tmp(KviLocale::instance()->localeName().ptr());
+				QString tmp = KviLocale::instance()->localeName();
 				tmp.prepend(KVI_PATH_SEPARATOR_CHAR);
 				tmp.prepend(szData);
 				if(KviFileUtils::directoryExists(tmp))
@@ -227,7 +227,7 @@ void KviApplication::getLocalKvircDirectory(QString & szData, KvircSubdir dir, c
 			szData.append("help");
 			{
 				// Localized help
-				QString tmp = KviLocale::instance()->localeName().ptr();
+				QString tmp = KviLocale::instance()->localeName();
 				tmp.prepend(KVI_PATH_SEPARATOR_CHAR);
 				tmp.prepend(szData);
 				if(KviFileUtils::directoryExists(tmp))

--- a/src/kvirc/kernel/KviApplication_setup.cpp
+++ b/src/kvirc/kernel/KviApplication_setup.cpp
@@ -117,7 +117,7 @@ bool KviApplication::checkFileAssociations()
 	pcBuffer = (char *)malloc(len * sizeof(char));
 	HKEY hKey;
 
-	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, ".kvs", 0, KEY_READ, &hKey) != ERROR_SUCCESS)
+	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, TEXT(".kvs"), 0, KEY_READ, &hKey) != ERROR_SUCCESS)
 	{
 		free(pcBuffer);
 		return false;
@@ -138,7 +138,7 @@ bool KviApplication::checkFileAssociations()
 	}
 
 	len = QUERY_BUFFER;
-	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, "KVIrcScript", 0, KEY_READ, &hKey) != ERROR_SUCCESS)
+	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, TEXT("KVIrcScript"), 0, KEY_READ, &hKey) != ERROR_SUCCESS)
 	{
 		free(pcBuffer);
 		return false;
@@ -159,7 +159,7 @@ bool KviApplication::checkFileAssociations()
 	}
 
 	len = QUERY_BUFFER;
-	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, "KVIrcScript\\DefaultIcon", 0, KEY_READ, &hKey) != ERROR_SUCCESS)
+	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, TEXT("KVIrcScript\\DefaultIcon"), 0, KEY_READ, &hKey) != ERROR_SUCCESS)
 	{
 		free(pcBuffer);
 		return false;
@@ -182,7 +182,7 @@ bool KviApplication::checkFileAssociations()
 	}
 
 	len = QUERY_BUFFER;
-	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, "KVIrcScript\\Shell\\Parse", 0, KEY_READ, &hKey) != ERROR_SUCCESS)
+	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, TEXT("KVIrcScript\\Shell\\Parse"), 0, KEY_READ, &hKey) != ERROR_SUCCESS)
 	{
 		free(pcBuffer);
 		return false;
@@ -203,7 +203,7 @@ bool KviApplication::checkFileAssociations()
 	}
 
 	len = QUERY_BUFFER;
-	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, "KVIrcScript\\Shell\\Parse\\command", 0, KEY_READ, &hKey) != ERROR_SUCCESS)
+	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, TEXT("KVIrcScript\\Shell\\Parse\\command"), 0, KEY_READ, &hKey) != ERROR_SUCCESS)
 	{
 		free(pcBuffer);
 		return false;
@@ -226,7 +226,7 @@ bool KviApplication::checkFileAssociations()
 	}
 
 	//Config
-	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, ".kvc", 0, KEY_READ, &hKey) != ERROR_SUCCESS)
+	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, TEXT(".kvc"), 0, KEY_READ, &hKey) != ERROR_SUCCESS)
 	{
 		free(pcBuffer);
 		return false;
@@ -247,14 +247,14 @@ bool KviApplication::checkFileAssociations()
 	}
 
 	len = QUERY_BUFFER;
-	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, "KVIrcConfig", 0, KEY_READ, &hKey) != ERROR_SUCCESS)
+	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, TEXT("KVIrcConfig"), 0, KEY_READ, &hKey) != ERROR_SUCCESS)
 	{
 		free(pcBuffer);
 		return false;
 	}
 
 	//Addon
-	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, ".kva", 0, KEY_READ, &hKey) != ERROR_SUCCESS)
+	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, TEXT(".kva"), 0, KEY_READ, &hKey) != ERROR_SUCCESS)
 	{
 		free(pcBuffer);
 		return false;
@@ -275,14 +275,14 @@ bool KviApplication::checkFileAssociations()
 	}
 
 	len = QUERY_BUFFER;
-	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, "KVIrcAddon", 0, KEY_READ, &hKey) != ERROR_SUCCESS)
+	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, TEXT("KVIrcAddon"), 0, KEY_READ, &hKey) != ERROR_SUCCESS)
 	{
 		free(pcBuffer);
 		return false;
 	}
 
 	//Theme
-	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, ".kvt", 0, KEY_READ, &hKey) != ERROR_SUCCESS)
+	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, TEXT(".kvt"), 0, KEY_READ, &hKey) != ERROR_SUCCESS)
 	{
 		free(pcBuffer);
 		return false;
@@ -303,7 +303,7 @@ bool KviApplication::checkFileAssociations()
 	}
 
 	len = QUERY_BUFFER;
-	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, "KVIrcTheme", 0, KEY_READ, &hKey) != ERROR_SUCCESS)
+	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, TEXT("KVIrcTheme"), 0, KEY_READ, &hKey) != ERROR_SUCCESS)
 	{
 		free(pcBuffer);
 		return false;
@@ -324,11 +324,11 @@ bool KviApplication::checkUriAssociations(const char * pcProto)
 	pcBuffer = (char *)malloc(len * sizeof(char));
 	HKEY hKey;
 
-	KviCString szStoredKey = pcProto;
-	KviCString szKey = szStoredKey;
+	QString szStoredKey = pcProto;
+	QString szKey = szStoredKey;
 
 	len = QUERY_BUFFER;
-	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, szKey, 0, KEY_READ, &hKey) != ERROR_SUCCESS)
+	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, szKey.toStdWString().c_str(), 0, KEY_READ, &hKey) != ERROR_SUCCESS)
 	{
 		free(pcBuffer);
 		return false;
@@ -349,7 +349,7 @@ bool KviApplication::checkUriAssociations(const char * pcProto)
 	}
 
 	len = QUERY_BUFFER;
-	if((err = RegQueryValueEx(hKey, "URL Protocol", 0, 0, (LPBYTE)pcBuffer, &len)) != ERROR_SUCCESS)
+	if((err = RegQueryValueEx(hKey, TEXT("URL Protocol"), 0, 0, (LPBYTE)pcBuffer, &len)) != ERROR_SUCCESS)
 	{
 		free(pcBuffer);
 		return false;
@@ -357,7 +357,7 @@ bool KviApplication::checkUriAssociations(const char * pcProto)
 
 	szKey = szStoredKey + "\\DefaultIcon";
 	len = QUERY_BUFFER;
-	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, szKey, 0, KEY_READ, &hKey) != ERROR_SUCCESS)
+	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, szKey.toStdWString().c_str(), 0, KEY_READ, &hKey) != ERROR_SUCCESS)
 	{
 		free(pcBuffer);
 		return false;
@@ -381,7 +381,7 @@ bool KviApplication::checkUriAssociations(const char * pcProto)
 
 	len = QUERY_BUFFER;
 	szKey = szStoredKey + "\\Shell\\open";
-	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, szKey, 0, KEY_READ, &hKey) != ERROR_SUCCESS)
+	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, szKey.toStdWString().c_str(), 0, KEY_READ, &hKey) != ERROR_SUCCESS)
 	{
 		free(pcBuffer);
 		return false;
@@ -403,7 +403,7 @@ bool KviApplication::checkUriAssociations(const char * pcProto)
 
 	len = QUERY_BUFFER;
 	szKey = szStoredKey + "\\Shell\\open\\command";
-	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, szKey, 0, KEY_READ, &hKey) != ERROR_SUCCESS)
+	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, szKey.toStdWString().c_str(), 0, KEY_READ, &hKey) != ERROR_SUCCESS)
 	{
 		free(pcBuffer);
 		return false;
@@ -439,31 +439,31 @@ void KviApplication::setupUriAssociations(const char * pcProto)
 	HKEY hKey;
 	DWORD err;
 
-	KviCString szStoredKey = pcProto;
-	KviCString szKey = szStoredKey;
+	QString szStoredKey = pcProto;
+	QString szKey = szStoredKey;
 
 	QByteArray tmp;
 	QString szAppPath = applicationFilePath();
 	szAppPath.replace('/', "\\");
 
-	SHDeleteKey(HKEY_CLASSES_ROOT, szKey);
+	SHDeleteKey(HKEY_CLASSES_ROOT, szKey.toStdWString().c_str());
 
-	err = RegCreateKeyEx(HKEY_CLASSES_ROOT, szKey, 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	err = RegCreateKeyEx(HKEY_CLASSES_ROOT, szKey.toStdWString().c_str(), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE) "URL:IRC Protocol", 16);
-	RegSetValueEx(hKey, "URL Protocol", 0, REG_SZ, (LPBYTE) "", 0);
+	RegSetValueEx(hKey, TEXT("URL Protocol"), 0, REG_SZ, (LPBYTE) "", 0);
 
 	szKey = szStoredKey + "\\DefaultIcon";
-	RegCreateKeyEx(HKEY_CLASSES_ROOT, szKey, 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	RegCreateKeyEx(HKEY_CLASSES_ROOT, szKey.toStdWString().c_str(), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	tmp = QString(szAppPath + ",0").toLocal8Bit();
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE)tmp.data(), tmp.length());
 
 	szKey = szStoredKey + "\\Shell\\open";
-	RegCreateKeyEx(HKEY_CLASSES_ROOT, szKey, 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	RegCreateKeyEx(HKEY_CLASSES_ROOT, szKey.toStdWString().c_str(), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	tmp = __tr2qs("Open with KVIrc").toLocal8Bit();
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE)tmp.data(), tmp.length());
 
 	szKey = szStoredKey + "\\Shell\\open\\command";
-	RegCreateKeyEx(HKEY_CLASSES_ROOT, szKey, 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	RegCreateKeyEx(HKEY_CLASSES_ROOT, szKey.toStdWString().c_str(), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	tmp = QString(szAppPath + " --external \"%1\"").toLocal8Bit();
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE)tmp.data(), tmp.length());
 #else
@@ -482,86 +482,86 @@ void KviApplication::setupFileAssociations()
 	QString szAppPath = applicationFilePath();
 	szAppPath.replace('/', "\\");
 
-	SHDeleteKey(HKEY_CLASSES_ROOT, ".kvs");
+	SHDeleteKey(HKEY_CLASSES_ROOT, TEXT(".kvs"));
 
-	err = RegCreateKeyEx(HKEY_CLASSES_ROOT, ".kvs", 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	err = RegCreateKeyEx(HKEY_CLASSES_ROOT, TEXT(".kvs"), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE) "KVIrcScript", 11);
 
-	SHDeleteKey(HKEY_CLASSES_ROOT, "KVIrcScript");
-	RegCreateKeyEx(HKEY_CLASSES_ROOT, "KVIrcScript", 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	SHDeleteKey(HKEY_CLASSES_ROOT, TEXT("KVIrcScript"));
+	RegCreateKeyEx(HKEY_CLASSES_ROOT, TEXT("KVIrcScript"), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	tmp = __tr2qs("KVIrc KVS Script").toLocal8Bit();
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE)tmp.data(), tmp.length());
 
-	RegCreateKeyEx(HKEY_CLASSES_ROOT, "KVIrcScript\\DefaultIcon", 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	RegCreateKeyEx(HKEY_CLASSES_ROOT, TEXT("KVIrcScript\\DefaultIcon"), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	tmp = QString(szAppPath + ",1").toLocal8Bit();
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE)tmp.data(), tmp.length());
 
-	RegCreateKeyEx(HKEY_CLASSES_ROOT, "KVIrcScript\\Shell\\Parse", 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	RegCreateKeyEx(HKEY_CLASSES_ROOT, TEXT("KVIrcScript\\Shell\\Parse"), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	tmp = __tr2qs("Run KVS Script").toLocal8Bit();
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE)tmp.data(), tmp.length());
 
-	RegCreateKeyEx(HKEY_CLASSES_ROOT, "KVIrcScript\\Shell\\Parse\\command", 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	RegCreateKeyEx(HKEY_CLASSES_ROOT, TEXT("KVIrcScript\\Shell\\Parse\\command"), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	tmp = QString(szAppPath + " \"%1\"").toLocal8Bit();
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE)tmp.data(), tmp.length());
 
 	//Configs
-	SHDeleteKey(HKEY_CLASSES_ROOT, ".kvc");
+	SHDeleteKey(HKEY_CLASSES_ROOT, TEXT(".kvc"));
 
-	err = RegCreateKeyEx(HKEY_CLASSES_ROOT, ".kvc", 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	err = RegCreateKeyEx(HKEY_CLASSES_ROOT, TEXT(".kvc"), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE) "KVIrcConfig", 11);
 
-	SHDeleteKey(HKEY_CLASSES_ROOT, "KVIrcConfig");
-	RegCreateKeyEx(HKEY_CLASSES_ROOT, "KVIrcConfig", 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	SHDeleteKey(HKEY_CLASSES_ROOT, TEXT("KVIrcConfig"));
+	RegCreateKeyEx(HKEY_CLASSES_ROOT, TEXT("KVIrcConfig"), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	tmp = __tr2qs("KVIrc Configuration File").toLocal8Bit();
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE)tmp.data(), tmp.length());
 
-	RegCreateKeyEx(HKEY_CLASSES_ROOT, "KVIrcConfig\\DefaultIcon", 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	RegCreateKeyEx(HKEY_CLASSES_ROOT, TEXT("KVIrcConfig\\DefaultIcon"), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	tmp = QString(szAppPath + ",2").toLocal8Bit();
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE)tmp.data(), tmp.length());
 
 	// Themes
-	SHDeleteKey(HKEY_CLASSES_ROOT, ".kvt");
+	SHDeleteKey(HKEY_CLASSES_ROOT, TEXT(".kvt"));
 
-	err = RegCreateKeyEx(HKEY_CLASSES_ROOT, ".kvt", 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	err = RegCreateKeyEx(HKEY_CLASSES_ROOT, TEXT(".kvt"), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE) "KVIrcTheme", 11);
 
-	SHDeleteKey(HKEY_CLASSES_ROOT, "KVIrcTheme");
-	RegCreateKeyEx(HKEY_CLASSES_ROOT, "KVIrcTheme", 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	SHDeleteKey(HKEY_CLASSES_ROOT, TEXT("KVIrcTheme"));
+	RegCreateKeyEx(HKEY_CLASSES_ROOT, TEXT("KVIrcTheme"), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	tmp = __tr2qs("KVIrc Theme Package").toLocal8Bit();
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE)tmp.data(), tmp.length());
 
-	RegCreateKeyEx(HKEY_CLASSES_ROOT, "KVIrcTheme\\DefaultIcon", 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	RegCreateKeyEx(HKEY_CLASSES_ROOT, TEXT("KVIrcTheme\\DefaultIcon"), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	tmp = QString(szAppPath + ",3").toLocal8Bit();
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE)tmp.data(), tmp.length());
 
-	RegCreateKeyEx(HKEY_CLASSES_ROOT, "KVIrcTheme\\Shell\\Install", 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	RegCreateKeyEx(HKEY_CLASSES_ROOT, TEXT("KVIrcTheme\\Shell\\Install"), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	tmp = __tr2qs("Install Theme Package").toLocal8Bit();
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE)tmp.data(), tmp.length());
 
-	RegCreateKeyEx(HKEY_CLASSES_ROOT, "KVIrcTheme\\Shell\\Install\\command", 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	RegCreateKeyEx(HKEY_CLASSES_ROOT, TEXT("KVIrcTheme\\Shell\\Install\\command"), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	tmp = QString(szAppPath + " \"%1\"").toLocal8Bit();
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE)tmp.data(), tmp.length());
 
 	//Addons
-	SHDeleteKey(HKEY_CLASSES_ROOT, ".kva");
+	SHDeleteKey(HKEY_CLASSES_ROOT, TEXT(".kva"));
 
-	err = RegCreateKeyEx(HKEY_CLASSES_ROOT, ".kva", 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	err = RegCreateKeyEx(HKEY_CLASSES_ROOT, TEXT(".kva"), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE) "KVIrcAddon", 11);
 
-	SHDeleteKey(HKEY_CLASSES_ROOT, "KVIrcAddon");
-	RegCreateKeyEx(HKEY_CLASSES_ROOT, "KVIrcAddon", 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	SHDeleteKey(HKEY_CLASSES_ROOT, TEXT("KVIrcAddon"));
+	RegCreateKeyEx(HKEY_CLASSES_ROOT, TEXT("KVIrcAddon"), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	tmp = __tr2qs("KVIrc Addon Package").toLocal8Bit();
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE)tmp.data(), tmp.length());
 
-	RegCreateKeyEx(HKEY_CLASSES_ROOT, "KVIrcAddon\\DefaultIcon", 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	RegCreateKeyEx(HKEY_CLASSES_ROOT, TEXT("KVIrcAddon\\DefaultIcon"), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	tmp = QString(szAppPath + ",4").toLocal8Bit();
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE)tmp.data(), tmp.length());
 
-	RegCreateKeyEx(HKEY_CLASSES_ROOT, "KVIrcAddon\\Shell\\Install", 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	RegCreateKeyEx(HKEY_CLASSES_ROOT, TEXT("KVIrcAddon\\Shell\\Install"), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	tmp = __tr2qs("Install Package").toLocal8Bit();
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE)tmp.data(), tmp.length());
 
-	RegCreateKeyEx(HKEY_CLASSES_ROOT, "KVIrcAddon\\Shell\\Install\\command", 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
+	RegCreateKeyEx(HKEY_CLASSES_ROOT, TEXT("KVIrcAddon\\Shell\\Install\\command"), 0, 0, 0, KEY_WRITE, 0, &hKey, 0);
 	tmp = QString(szAppPath + " \"%1\"").toLocal8Bit();
 	RegSetValueEx(hKey, 0, 0, REG_SZ, (LPBYTE)tmp.data(), tmp.length());
 

--- a/src/kvirc/kernel/KviIpcSentinel.cpp
+++ b/src/kvirc/kernel/KviIpcSentinel.cpp
@@ -139,7 +139,7 @@ static Window kvi_x11_findIpcSentinel(Window win)
 bool kvi_sendIpcMessage(const char * message)
 {
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
-	HWND hSentinel = ::FindWindow("Qt5QWindowIcon", "kvirc4_ipc_sentinel");
+	HWND hSentinel = ::FindWindow(TEXT("Qt5QWindowIcon"), TEXT("kvirc4_ipc_sentinel"));
 	if(hSentinel != nullptr)
 	{
 		COPYDATASTRUCT cpd;

--- a/src/kvirc/kernel/KviMain.cpp
+++ b/src/kvirc/kernel/KviMain.cpp
@@ -96,7 +96,7 @@ int parseArgs(ParseArgs * a)
 			KviQString::appendFormatted(szMessage, "Homepage: http://www.kvirc.net/\n");
 
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
-			MessageBox(0, szMessage.toLocal8Bit().data(), "KVIrc", 0);
+			MessageBox(0, szMessage.toStdWString().c_str(), TEXT("KVIrc"), 0);
 #else
 			qDebug("%s", szMessage.toLocal8Bit().data());
 #endif
@@ -143,7 +143,7 @@ int parseArgs(ParseArgs * a)
 			KviQString::appendFormatted(szMessage, "                 irc[s][6]://<server>[:<port>][/<channel>[?<pass>]]\n");
 
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
-			MessageBox(0, szMessage.toLocal8Bit().data(), "KVIrc", 0);
+			MessageBox(0, szMessage.toStdWString().c_str(), TEXT("KVIrc"), 0);
 #else
 			qDebug("%s", szMessage.toLocal8Bit().data());
 #endif

--- a/src/kvirc/kvs/KviKvsCoreFunctions_gl.cpp
+++ b/src/kvirc/kvs/KviKvsCoreFunctions_gl.cpp
@@ -969,7 +969,7 @@ namespace KviKvsCoreFunctions
 		KVSCF_PARAMETER("type", KVS_PT_NONEMPTYSTRING, KVS_PF_OPTIONAL, szType)
 		KVSCF_PARAMETERS_END
 
-		QString szLocale(KviLocale::instance()->localeName().ptr());
+		QString szLocale = KviLocale::instance()->localeName();
 		if(szType == QLatin1String("lang"))
 			KVSCF_pRetBuffer->setString(szLocale.left(5));
 		else if(szType == QLatin1String("short"))

--- a/src/kvirc/kvs/KviKvsCoreSimpleCommands_mr.cpp
+++ b/src/kvirc/kvs/KviKvsCoreSimpleCommands_mr.cpp
@@ -415,7 +415,7 @@ namespace KviKvsCoreSimpleCommands
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
 		if(KVI_OPTION_BOOL(KviOption_boolUseSystemUrlHandlers))
 		{
-			intptr_t iRet = (intptr_t)::ShellExecute(NULL, "open", szUrl.toLocal8Bit().data(), NULL, NULL, SW_SHOWNORMAL);
+			intptr_t iRet = (intptr_t)::ShellExecute(NULL, TEXT("open"), szUrl.toStdWString().c_str(), NULL, NULL, SW_SHOWNORMAL);
 			if(iRet <= 32)
 			{
 				/*

--- a/src/kvirc/ui/KviMenuBar.cpp
+++ b/src/kvirc/ui/KviMenuBar.cpp
@@ -128,7 +128,7 @@ void KviMenuBar::setupHelpPopup(QMenu * pop)
 	help->addSeparator();
 	pAction = help->addAction(*(g_pIconManager->getSmallIcon(KviIconManager::HomePage)), __tr2qs("KVIrc Home&page"));
 	pAction->setData(KVI_INTERNALCOMMAND_KVIRC_HOMEPAGE);
-	if(QString::compare(KviLocale::instance()->localeName(), QString("ru"), Qt::CaseInsensitive))
+	if(QString::compare(KviLocale::instance()->localeName(), QString("ru"), Qt::CaseInsensitive) == 0)
 	{
 		pAction = help->addAction(*(g_pIconManager->getSmallIcon(KviIconManager::HomePage)), __tr2qs("KVIrc Russian Home&page"));
 		pAction->setData(KVI_INTERNALCOMMAND_KVIRC_HOMEPAGE_RU);

--- a/src/kvirc/ui/KviMenuBar.cpp
+++ b/src/kvirc/ui/KviMenuBar.cpp
@@ -128,7 +128,7 @@ void KviMenuBar::setupHelpPopup(QMenu * pop)
 	help->addSeparator();
 	pAction = help->addAction(*(g_pIconManager->getSmallIcon(KviIconManager::HomePage)), __tr2qs("KVIrc Home&page"));
 	pAction->setData(KVI_INTERNALCOMMAND_KVIRC_HOMEPAGE);
-	if(KviLocale::instance()->localeName() == "ru")
+	if(QString::compare(KviLocale::instance()->localeName(), QString("ru"), Qt::CaseInsensitive))
 	{
 		pAction = help->addAction(*(g_pIconManager->getSmallIcon(KviIconManager::HomePage)), __tr2qs("KVIrc Russian Home&page"));
 		pAction->setData(KVI_INTERNALCOMMAND_KVIRC_HOMEPAGE_RU);

--- a/src/kvirc/ui/KviMenuBar.cpp
+++ b/src/kvirc/ui/KviMenuBar.cpp
@@ -128,7 +128,7 @@ void KviMenuBar::setupHelpPopup(QMenu * pop)
 	help->addSeparator();
 	pAction = help->addAction(*(g_pIconManager->getSmallIcon(KviIconManager::HomePage)), __tr2qs("KVIrc Home&page"));
 	pAction->setData(KVI_INTERNALCOMMAND_KVIRC_HOMEPAGE);
-	if(kvi_strEqualCIN(KviLocale::instance()->localeName(), "ru", 2))
+	if(KviLocale::instance()->localeName() == "ru")
 	{
 		pAction = help->addAction(*(g_pIconManager->getSmallIcon(KviIconManager::HomePage)), __tr2qs("KVIrc Russian Home&page"));
 		pAction->setData(KVI_INTERNALCOMMAND_KVIRC_HOMEPAGE_RU);

--- a/src/modules/addon/WebAddonInterfaceDialog.cpp
+++ b/src/modules/addon/WebAddonInterfaceDialog.cpp
@@ -43,7 +43,7 @@ WebAddonInterfaceDialog::WebAddonInterfaceDialog(QWidget * par)
 
 	setPackagePageUrl(
 	    QString::fromLatin1("http://www.kvirc.de/app/addons.php?version=" KVI_VERSION "&lang=%1")
-	        .arg(QString::fromUtf8(KviLocale::instance()->localeName().ptr())));
+	        .arg(KviLocale::instance()->localeName()));
 }
 WebAddonInterfaceDialog::~WebAddonInterfaceDialog()
     = default;

--- a/src/modules/file/libkvifile.cpp
+++ b/src/modules/file/libkvifile.cpp
@@ -1491,9 +1491,9 @@ static bool file_kvs_fnc_diskSpace(KviKvsModuleFunctionCall * c)
 	fTotal = total.QuadPart;
 #else
 	// this one for linux and macos
-	const char * pcPath = szPath.toUtf8().data();
+	auto pcPath = szPath.toUtf8();
 	struct statvfs stFileSystem;
-	if (statvfs(pcPath, &stFileSystem) == -1) {
+	if (statvfs(pcPath.data(), &stFileSystem) == -1) {
 		c->warning(__tr2qs("An error occurred retrieving the amount of free space in '%Q'"), &szPath);
 		return true;
 	}

--- a/src/modules/filetransferwindow/FileTransferWindow.cpp
+++ b/src/modules/filetransferwindow/FileTransferWindow.cpp
@@ -666,7 +666,7 @@ void FileTransferWindow::openLocalFile()
 	if(tmp.isEmpty())
 		return;
 	tmp.replace("/", "\\");
-	ShellExecute(0, "open", tmp.toLocal8Bit().data(), NULL, NULL, SW_SHOWNORMAL); //You have to link the shell32.lib
+	ShellExecute(0, TEXT("open"), tmp.toStdWString().c_str(), NULL, NULL, SW_SHOWNORMAL); //You have to link the shell32.lib
 #else
 // G&N end
 #ifdef COMPILE_KDE4_SUPPORT

--- a/src/modules/mediaplayer/MpAmipInterface.cpp
+++ b/src/modules/mediaplayer/MpAmipInterface.cpp
@@ -77,7 +77,7 @@ MP_AC_DYNPTR(int, ac_eval, const char * cmd COMMA() char * result);
 
 static bool loadAmipDll()
 {
-	amip_dll = LoadLibrary("ac.dll");
+	amip_dll = LoadLibrary(TEXT("ac.dll"));
 	if(!amip_dll)
 		return false;
 

--- a/src/modules/mediaplayer/MpWinampInterface.cpp
+++ b/src/modules/mediaplayer/MpWinampInterface.cpp
@@ -175,7 +175,7 @@ static QTextCodec * mediaplayer_get_codec()
 
 static HWND find_winamp(KviWinampInterface * i)
 {
-	HWND hWnd = FindWindow("Winamp v1.x", NULL);
+	HWND hWnd = FindWindow(TEXT("Winamp v1.x"), NULL);
 	if(!hWnd)
 	{
 		// try to start the process ?
@@ -429,11 +429,11 @@ bool KviWinampInterface::jumpTo(kvs_int_t & iPos)
 bool KviWinampInterface::hide()
 {
 	HWND hWinamp = find_winamp(this);
-	HWND hWinampPE = FindWindow("Winamp PE", NULL);       /*Playlist*/
-	HWND hWinampEQ = FindWindow("Winamp EQ", NULL);       /*Equalizer*/
-	HWND hWinampMB = FindWindow("Winamp MB", NULL);       /*MiniBrowser*/
-	HWND hWinampGen = FindWindow("Winamp Gen", NULL);     /*Library*/
-	HWND hWinampVideo = FindWindow("Winamp Video", NULL); /*Video*/
+	HWND hWinampPE = FindWindow(TEXT("Winamp PE"), NULL);       /*Playlist*/
+	HWND hWinampEQ = FindWindow(TEXT("Winamp EQ"), NULL);       /*Equalizer*/
+	HWND hWinampMB = FindWindow(TEXT("Winamp MB"), NULL);       /*MiniBrowser*/
+	HWND hWinampGen = FindWindow(TEXT("Winamp Gen"), NULL);     /*Library*/
+	HWND hWinampVideo = FindWindow(TEXT("Winamp Video"), NULL); /*Video*/
 	if(hWinamp)
 	{
 		ShowWindow(hWinamp, SW_HIDE);

--- a/src/modules/options/OptionsWidget_textEncoding.cpp
+++ b/src/modules/options/OptionsWidget_textEncoding.cpp
@@ -122,7 +122,7 @@ OptionsWidget_textEncoding::OptionsWidget_textEncoding(QWidget * parent)
 		szTmp.replace("kvirc_", "");
 		szTmp.replace(".mo", "");
 		m_pForcedLocaleCombo->insertItem(m_pForcedLocaleCombo->count(), szTmp);
-		if(QString::compare(szTmp, m_szLanguage, Qt::CaseInsensitive))
+		if(QString::compare(szTmp, m_szLanguage, Qt::CaseInsensitive) == 0)
 			iMatch = i + 2;
 		i++;
 	}

--- a/src/modules/options/OptionsWidget_textEncoding.cpp
+++ b/src/modules/options/OptionsWidget_textEncoding.cpp
@@ -122,7 +122,7 @@ OptionsWidget_textEncoding::OptionsWidget_textEncoding(QWidget * parent)
 		szTmp.replace("kvirc_", "");
 		szTmp.replace(".mo", "");
 		m_pForcedLocaleCombo->insertItem(m_pForcedLocaleCombo->count(), szTmp);
-		if(szTmp == m_szLanguage)
+		if(QString::compare(szTmp, m_szLanguage, Qt::CaseInsensitive))
 			iMatch = i + 2;
 		i++;
 	}

--- a/src/modules/options/OptionsWidget_textEncoding.cpp
+++ b/src/modules/options/OptionsWidget_textEncoding.cpp
@@ -122,7 +122,7 @@ OptionsWidget_textEncoding::OptionsWidget_textEncoding(QWidget * parent)
 		szTmp.replace("kvirc_", "");
 		szTmp.replace(".mo", "");
 		m_pForcedLocaleCombo->insertItem(m_pForcedLocaleCombo->count(), szTmp);
-		if(KviQString::equalCI(szTmp, m_szLanguage))
+		if(szTmp == m_szLanguage)
 			iMatch = i + 2;
 		i++;
 	}

--- a/src/modules/setup/SetupWizard.cpp
+++ b/src/modules/setup/SetupWizard.cpp
@@ -544,7 +544,7 @@ SetupWizard::SetupWizard()
 	HKEY hKey;
 	QString szMircDir;
 
-	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, "ChatFile\\DefaultIcon", 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+	if(RegOpenKeyEx(HKEY_CLASSES_ROOT, TEXT("ChatFile\\DefaultIcon"), 0, KEY_READ, &hKey) == ERROR_SUCCESS)
 	{
 		if(RegQueryValueEx(hKey, 0, 0, 0, (LPBYTE)buffer, &len) == ERROR_SUCCESS)
 		{
@@ -802,11 +802,11 @@ void SetupWizard::makeLink()
 
 	// Dig in the registry looking up the Desktop path
 	if(RegOpenKeyEx(HKEY_CURRENT_USER,
-	       "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders",
+	       TEXT("Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders"),
 	       0, KEY_QUERY_VALUE, &hCU)
 	    == ERROR_SUCCESS)
 	{
-		RegQueryValueEx(hCU, "Desktop", NULL, &lpType,
+		RegQueryValueEx(hCU, TEXT("Desktop"), NULL, &lpType,
 		    (unsigned char *)&szLink, &ulSize);
 		RegCloseKey(hCU);
 	}
@@ -839,9 +839,9 @@ void SetupWizard::makeLink()
 		{
 			WORD wsz[MAX_PATH];
 			// Set the path to the shell link target.
-			psl->SetPath(QTextCodec::codecForLocale()->fromUnicode(szKvircExec).data());
+			psl->SetPath(szKvircExec.toStdWString().c_str());
 			// Set the description of the shell link.
-			psl->SetDescription("kvirc");
+			psl->SetDescription(TEXT("kvirc"));
 			// Ensure string is ANSI.
 			MultiByteToWideChar(CP_ACP, 0, QTextCodec::codecForLocale()->fromUnicode(szLinkTarget).data(), -1, (LPWSTR)wsz, MAX_PATH);
 			// Save the link via the IPersistFile::Save method.

--- a/src/modules/snd/libkvisnd.cpp
+++ b/src/modules/snd/libkvisnd.cpp
@@ -288,7 +288,7 @@ void KviSoundPlayer::cleanupPhonon()
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
 bool KviSoundPlayer::playWinmm(const QString & szFileName)
 {
-	sndPlaySound(szFileName.toLocal8Bit().data(), SND_ASYNC | SND_NODEFAULT);
+	sndPlaySound(szFileName.toStdWString().c_str(), SND_ASYNC | SND_NODEFAULT);
 	return true;
 }
 

--- a/src/modules/system/libkvisystem.cpp
+++ b/src/modules/system/libkvisystem.cpp
@@ -208,10 +208,7 @@ static bool system_kvs_fnc_getenv(KviKvsModuleFunctionCall * c)
 	KVSM_PARAMETER("variable", KVS_PT_NONEMPTYSTRING, 0, szVariable)
 	KVSM_PARAMETERS_END(c)
 
-	QByteArray szVar = szVariable.toLocal8Bit();
-
-	char * b = KviEnvironment::getVariable(szVar.data());
-	c->returnValue()->setString(b ? QString::fromLocal8Bit(b) : QString());
+	c->returnValue()->setString(KviEnvironment::getVariable(szVariable));
 	return true;
 }
 
@@ -651,23 +648,10 @@ static bool system_kvs_cmd_setenv(KviKvsModuleCommandCall * c)
 	KVSM_PARAMETER("value", KVS_PT_STRING, KVS_PF_OPTIONAL, szValue)
 	KVSM_PARAMETERS_END(c)
 
-	QByteArray szVar = szVariable.toLocal8Bit();
-	QByteArray szVal = szValue.toLocal8Bit();
-
-	if(szVal.isEmpty())
-		KviEnvironment::unsetVariable(szVar.data());
+	if(szValue.isEmpty())
+		KviEnvironment::unsetVariable(szVariable);
 	else
-	{
-		/*#ifdef COMPILE_ON_WINDOWS
-		QString Var,Val,VarAndVal;
-		Val			=	szVar.data();
-		Var			=	szVal.data();
-		VarAndVal	=	Var+"="+Val;
-		putenv(VarAndVal);
-#else*/ // <-- this stuff is implicit in KviEnvironment::setVariable: that's why we have the kvi_ version.
-		KviEnvironment::setVariable(szVar.data(), szVal.data());
-		/*#endif*/
-	}
+		KviEnvironment::setVariable(szVariable, szValue);
 	return true;
 }
 

--- a/src/modules/theme/WebThemeInterfaceDialog.cpp
+++ b/src/modules/theme/WebThemeInterfaceDialog.cpp
@@ -49,7 +49,7 @@ WebThemeInterfaceDialog::WebThemeInterfaceDialog(QWidget * par)
 
 	setPackagePageUrl(
 	    QString::fromLatin1("http://www.kvirc.de/app/themes.php?version=" KVI_VERSION "&lang=%1")
-	        .arg(QString::fromUtf8(KviLocale::instance()->localeName().ptr())));
+	        .arg(KviLocale::instance()->localeName()));
 }
 WebThemeInterfaceDialog::~WebThemeInterfaceDialog()
     = default;


### PR DESCRIPTION
This makes all the Windows code unicode-aware, and fixes a few bugs along the way (like the one that was discussed on irc yesterday)