### PR TITLE
KviIrcConnectionServerInfo: Add 2 missing InspIRCd chanmodes

### DIFF
--- a/src/kvirc/kernel/KviIrcConnectionServerInfo.cpp
+++ b/src/kvirc/kernel/KviIrcConnectionServerInfo.cpp
@@ -2117,11 +2117,17 @@ const QString & KviInspIRCdIrcServerInfo::getChannelModeDescription(char mode)
 		case 'g':
 			return __tr2qs("Spam filter");
 			break;
+		case 'h':
+			return __tr2qs("Half-operators");
+			break;
 		case 'j':
 			return __tr2qs("Join throttling (<num>:<secs>)");
 			break;
 		case 'q':
 			return __tr2qs("Channel owners");
+			break;
+		case 'r':
+			return __tr2qs("Registered");
 			break;
 		case 'u':
 			return __tr2qs("Auditorium: /NAMES and /WHO show only ops");


### PR DESCRIPTION
[//]: # (If your pull request is a fix to an open issue please add fixes #9999 to the commit comments.)
[//]: # (If your proposal involves GUI improvements, add screenshots of before and after to help visualise the proposal on the fly.)
#### Changes proposed
- This adds the half-ops (h) and registered channels (r) modes (fixes #2230)

[//]: # (If you have write privileges to repository, do label your pull request, else you could insert a mention prefixed with @GitHub-Username below.)

