### PR TITLE
defscript popups: improvements and fixes

### DIFF
--- a/data/defscript/default.kvc
+++ b/data/defscript/default.kvc
@@ -7,6 +7,6 @@ AddonVersion=4.1.1
 AliasVersion=4.1.1.6923
 ClassVersion=4.1.1
 EventVersion=4.1.1.7125
-PopupVersion=4.1.1.7125
+PopupVersion=4.1.1.7126
 RawVersion=4.1.1
 ToolbarVersion=4.1.1.6732

--- a/data/defscript/popups.kvs
+++ b/data/defscript/popups.kvs
@@ -1418,7 +1418,7 @@ defpopup(ignore)
 
 	label(%:ignLabelText)
 
-	popup($tr("Ignore As...","defscript"),$icon("ignore")) (!%:inIgnoreList && !%:regName)
+	popup($tr("Ignore As...","defscript"),$icon("ignore")) (!%:inIgnoreList)
 	{
 		item($tr("Ignore As","defscript") $0 "("$mask($0,0)")") ("$reguser.exactMatch($mask($0,0))" == "")
 		{

--- a/data/defscript/popups.kvs
+++ b/data/defscript/popups.kvs
@@ -1418,12 +1418,7 @@ defpopup(ignore)
 
 	label(%:ignLabelText)
 
-	item($tr("Enable Ignore","defscript"),$icon("ignore")) (!%:inIgnoreList && %:regName)
-	{
-		reguser.setIgnoreEnabled %:regName 1;
-	}
-
-	popup($tr("Ignore As...","defscript"),$icon("ignore")) (!%:inIgnoreList)
+	popup($tr("Ignore As...","defscript"),$icon("ignore")) (!%:inIgnoreList && !%:regName)
 	{
 		item($tr("Ignore As","defscript") $0 "("$mask($0,0)")") ("$reguser.exactMatch($mask($0,0))" == "")
 		{
@@ -1642,7 +1637,12 @@ defpopup(ignore)
 		}
 	}
 
-	item($tr("Unignore","defscript"),$icon("discard")) (%:inIgnoreList)
+	item($tr("Enable Ignore","defscript"),$icon("ignore")) (!%:inIgnoreList && %:regName)
+	{
+		reguser.setIgnoreEnabled %:regName 1;
+	}
+
+	item($tr("Disable Ignore","defscript"),$icon("discard")) (%:inIgnoreList && %:regName)
 	{
 		reguser.setIgnoreEnabled %:regName 0;
 	}
@@ -1718,7 +1718,8 @@ defpopup(registration)
 
 	item($tr("Edit Registration...","defscript")) (%:regName)
 	{
-		reguser.edit -t "%:regName"
+		# According to documentation this opens the registration menu only
+		reguser.edit -t
 	}
 
 	item($tr("Unregister","defscript") %:regName) (%:regName)
@@ -1811,7 +1812,7 @@ defpopup(channel)
 
 	separator
 
-	item($tr("&Query","defscript") %:visible,$icon("query")) ($server)
+	item($tr("&Query","defscript") $0 %:visible,$icon("query")) ($server)
 	{
 		query $0
 	}
@@ -1826,9 +1827,9 @@ defpopup(channel)
 
 	extpopup($tr("&Registration","defscript"),registration,$icon("regusers")) (!%:multiple && $server)
 
-	extpopup($tr("&Highlight","defscript"),highlight,$icon("highlighttext")) (!%:multiple && $server)
-
 	extpopup($tr("Ig&nore","defscript"),ignore,$icon("ignore")) (!%:multiple && $server)
+
+	extpopup($tr("&Highlight","defscript"),highlight,$icon("highlighttext")) (!%:multiple && $server)
 
 	item($tr("Notify Avatar","defscript"),$icon("avatar")) ($server)
 	{

--- a/data/defscript/popups.kvs
+++ b/data/defscript/popups.kvs
@@ -845,9 +845,9 @@ defpopup(defaulttextview)
 
 	extpopup($tr("&Registration","defscript"),registration,$icon("regusers")) (!%:multiple && $server)
 
-	extpopup($tr("&Highlight","defscript"),highlight,$icon("highlighttext")) (!%:multiple && $server)
-
 	extpopup($tr("Ig&nore","defscript"),ignore,$icon("ignore")) (!%:multiple && $server)
+
+	extpopup($tr("&Highlight","defscript"),highlight,$icon("highlighttext")) (!%:multiple && $server)
 
 	item($tr("Notify avatar","defscript"),$icon("avatar")) ($server)
 	{


### PR DESCRIPTION
[//]: # (If your pull request is a fix to an open issue please add fixes #9999 to the commit comments.)
[//]: # (If your proposal involves GUI improvements, add screenshots of before and after to help visualise the proposal on the fly.)
#### Changes proposed
**defpopup(ignore)**
* Renamed Unignore to Disable Ignore, this seems more consistent option naming.
* Moved Enabled Ignore below Ignore As... so both Enable and Disable ignore are successive entries (cosmetic change)
* Fixed error with visible conditions for Enable/Disable Ignore (now only shows when necessary depending on ignore status.  (i.e. clicking enable ignore when user is not registered resulted in error missing name etc...)

**defpopup(channel)**
* Added $0 to Query (more consistent with other entries) ```Query <username>```
* Move highlight downwards in menu order, seems order of option _feels_ more intuitive when context menu is open on username.

**defpopup(registration)**
* Remove non usable "%:regName" from ```reguser.edit``` command.

[//]: # (If you have write privileges to repository, do label your pull request, else you could insert a mention prefixed with @GitHub-Username below.)

