### PR TITLE
Prioritize tab completion by last spoken order

### DIFF
--- a/src/kvirc/kernel/KviOptions.cpp
+++ b/src/kvirc/kernel/KviOptions.cpp
@@ -636,7 +636,8 @@ KviUIntOption g_uintOptionsTable[KVI_NUM_UINT_OPTIONS] = {
 	UINT_OPTION("ToolBarButtonStyle", 0, KviOption_groupTheme), // 0 = Qt::ToolButtonIconOnly
 	UINT_OPTION("MaximumBlowFishKeySize", 56, KviOption_sectFlagNone),
 	UINT_OPTION("CustomCursorWidth", 1, KviOption_resetUpdateGui),
-	UINT_OPTION("UserListMinimumWidth", 100, KviOption_sectFlagUserListView | KviOption_resetUpdateGui | KviOption_groupTheme)
+	UINT_OPTION("UserListMinimumWidth", 100, KviOption_sectFlagUserListView | KviOption_resetUpdateGui | KviOption_groupTheme),
+	UINT_OPTION("NickCompletionOrder", 2, KviOption_sectFlagNone)
 };
 
 #define FONT_OPTION(_name, _face, _size, _flags) \

--- a/src/kvirc/kernel/KviOptions.cpp
+++ b/src/kvirc/kernel/KviOptions.cpp
@@ -637,7 +637,7 @@ KviUIntOption g_uintOptionsTable[KVI_NUM_UINT_OPTIONS] = {
 	UINT_OPTION("MaximumBlowFishKeySize", 56, KviOption_sectFlagNone),
 	UINT_OPTION("CustomCursorWidth", 1, KviOption_resetUpdateGui),
 	UINT_OPTION("UserListMinimumWidth", 100, KviOption_sectFlagUserListView | KviOption_resetUpdateGui | KviOption_groupTheme),
-	UINT_OPTION("NickCompletionOrder", 2, KviOption_sectFlagNone)
+	UINT_OPTION("NickCompletionOrder", 2, KviOption_sectFlagInput)
 };
 
 #define FONT_OPTION(_name, _face, _size, _flags) \

--- a/src/kvirc/kernel/KviOptions.h
+++ b/src/kvirc/kernel/KviOptions.h
@@ -595,8 +595,9 @@ DECLARE_OPTION_STRUCT(KviStringListOption, QStringList)
 #define KviOption_uintMaximumBlowFishKeySize 80
 #define KviOption_uintCustomCursorWidth 81                                    /* Interface */
 #define KviOption_uintUserListMinimumWidth 82
+#define KviOption_uintNickCompletionOrder 83
 
-#define KVI_NUM_UINT_OPTIONS 83
+#define KVI_NUM_UINT_OPTIONS 84
 
 namespace KviIdentdOutputMode
 {

--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -2368,10 +2368,12 @@ void KviInputEditor::standardNickCompletion(bool bAddMask, QString & szWord, boo
 
 		if(m_pUserListView->completeNickStandard(szWord, m_szLastCompletedNick, szBuffer, bAddMask))
 		{
+			// Because szBuffer does not necessarily equal the completed nickname,
+			// completeNickStandard will update m_szLastCompletedNick with the nickname.
+
 			// completed: save the buffer
 			m_szLastCompletionBuffer = m_szTextBuffer;
 			m_iLastCompletionCursorPosition = m_iCursorPosition;
-			m_szLastCompletedNick = szBuffer;
 			standardNickCompletionInsertCompletedText(szWord, szBuffer, bFirstWordInLine, bInCommand);
 			m_bLastCompletionFinished = 0;
 			// REPAINT CALLED FROM OUTSIDE!
@@ -2397,7 +2399,6 @@ void KviInputEditor::standardNickCompletion(bool bAddMask, QString & szWord, boo
 		if(m_pUserListView->completeNickStandard(szWord, m_szLastCompletedNick, szBuffer, bAddMask))
 		{
 			// completed
-			m_szLastCompletedNick = szBuffer;
 			standardNickCompletionInsertCompletedText(szWord, szBuffer, bFirstWordInLine, bInCommand);
 			m_bLastCompletionFinished = 0;
 			// REPAINT CALLED FROM OUTSIDE!
@@ -2417,12 +2418,12 @@ void KviInputEditor::standardNickCompletion(bool bAddMask, QString & szWord, boo
 	//getWordBeforeCursor(word,&bFirstWordInLine);
 	if(szWord.isEmpty())
 		return;
-	if(m_pUserListView->completeNickStandard(szWord, "", szBuffer, bAddMask))
+	m_szLastCompletedNick = "";
+	if(m_pUserListView->completeNickStandard(szWord, m_szLastCompletedNick, szBuffer, bAddMask))
 	{
 		// completed
 		m_szLastCompletionBuffer = m_szTextBuffer;
 		m_iLastCompletionCursorPosition = m_iCursorPosition;
-		m_szLastCompletedNick = szBuffer;
 		standardNickCompletionInsertCompletedText(szWord, szBuffer, bFirstWordInLine, bInCommand);
 		m_bLastCompletionFinished = 0;
 		// REPAINT CALLED FROM OUTSIDE!

--- a/src/kvirc/ui/KviOptionsWidget.cpp
+++ b/src/kvirc/ui/KviOptionsWidget.cpp
@@ -69,6 +69,14 @@ KviOptionsWidget::~KviOptionsWidget()
 	delete m_pSelectorInterfaceList;
 }
 
+void KviOptionsWidget::setBasicTip(QWidget * w, const QString & optionName)
+{
+	QString tmp = m_szBasicTipStart;
+	tmp += optionName;
+	tmp += m_szBasicTipEnd;
+	KviTalToolTip::add(w, tmp);
+}
+
 void KviOptionsWidget::mergeTip(QWidget * w, const QString & tip)
 {
 	static QString begin = "<table width=\"100%\"><tr><td bgcolor=\"#fefef0\"><font color=\"#000000\">";
@@ -209,10 +217,7 @@ KviDirectorySelector * KviOptionsWidget::addDirectorySelector(int x1, int y1, in
 	m_iResetFlags |= (g_stringOptionsTable[optId].flags & KviOption_resetMask);
 	KviDirectorySelector * d = addDirectorySelector(x1, y1, x2, y2, txt, &(KVI_OPTION_STRING(optId)), bEnabled);
 
-	QString tmp = m_szBasicTipStart;
-	tmp += g_stringOptionsTable[optId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+	setBasicTip(d, g_stringOptionsTable[optId].name);
 
 	return d;
 }
@@ -222,10 +227,7 @@ KviDirectorySelector * KviOptionsWidget::addDirectorySelector(QWidget * pParent,
 	m_iResetFlags |= (g_stringOptionsTable[optId].flags & KviOption_resetMask);
 	KviDirectorySelector * d = addDirectorySelector(pParent, txt, &(KVI_OPTION_STRING(optId)), bEnabled);
 
-	QString tmp = m_szBasicTipStart;
-	tmp += g_stringOptionsTable[optId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+	setBasicTip(d, g_stringOptionsTable[optId].name);
 
 	return d;
 }
@@ -250,10 +252,7 @@ KviFileSelector * KviOptionsWidget::addFileSelector(int x1, int y1, int x2, int 
 	m_iResetFlags |= (g_stringOptionsTable[optId].flags & KviOption_resetMask);
 	KviFileSelector * d = addFileSelector(x1, y1, x2, y2, txt, &(KVI_OPTION_STRING(optId)), bEnabled);
 
-	QString tmp = m_szBasicTipStart;
-	tmp += g_stringOptionsTable[optId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+	setBasicTip(d, g_stringOptionsTable[optId].name);
 
 	return d;
 }
@@ -263,10 +262,7 @@ KviFileSelector * KviOptionsWidget::addFileSelector(QWidget * pParent, const QSt
 	m_iResetFlags |= (g_stringOptionsTable[optId].flags & KviOption_resetMask);
 	KviFileSelector * d = addFileSelector(pParent, txt, &(KVI_OPTION_STRING(optId)), bEnabled);
 
-	QString tmp = m_szBasicTipStart;
-	tmp += g_stringOptionsTable[optId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+	setBasicTip(d, g_stringOptionsTable[optId].name);
 
 	return d;
 }
@@ -291,10 +287,7 @@ KviSoundSelector * KviOptionsWidget::addSoundSelector(int x1, int y1, int x2, in
 	m_iResetFlags |= (g_stringOptionsTable[optId].flags & KviOption_resetMask);
 	KviSoundSelector * d = addSoundSelector(x1, y1, x2, y2, txt, &(KVI_OPTION_STRING(optId)), bEnabled);
 
-	QString tmp = m_szBasicTipStart;
-	tmp += g_stringOptionsTable[optId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+	setBasicTip(d, g_stringOptionsTable[optId].name);
 
 	return d;
 }
@@ -304,10 +297,7 @@ KviSoundSelector * KviOptionsWidget::addSoundSelector(QWidget * pParent, const Q
 	m_iResetFlags |= (g_stringOptionsTable[optId].flags & KviOption_resetMask);
 	KviSoundSelector * d = addSoundSelector(pParent, txt, &(KVI_OPTION_STRING(optId)), bEnabled);
 
-	QString tmp = m_szBasicTipStart;
-	tmp += g_stringOptionsTable[optId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+	setBasicTip(d, g_stringOptionsTable[optId].name);
 
 	return d;
 }
@@ -331,10 +321,9 @@ KviBoolSelector * KviOptionsWidget::addBoolSelector(int x1, int y1, int x2, int 
 {
 	m_iResetFlags |= (g_boolOptionsTable[optId].flags & KviOption_resetMask);
 	KviBoolSelector * d = addBoolSelector(x1, y1, x2, y2, txt, &(KVI_OPTION_BOOL(optId)), bEnabled);
-	QString tmp = m_szBasicTipStart;
-	tmp += g_boolOptionsTable[optId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+
+	setBasicTip(d, g_boolOptionsTable[optId].name);
+
 	return d;
 }
 
@@ -342,10 +331,9 @@ KviBoolSelector * KviOptionsWidget::addBoolSelector(QWidget * pParent, const QSt
 {
 	m_iResetFlags |= (g_boolOptionsTable[optId].flags & KviOption_resetMask);
 	KviBoolSelector * d = addBoolSelector(pParent, txt, &(KVI_OPTION_BOOL(optId)), bEnabled);
-	QString tmp = m_szBasicTipStart;
-	tmp += g_boolOptionsTable[optId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+
+	setBasicTip(d, g_boolOptionsTable[optId].name);
+
 	return d;
 }
 
@@ -361,10 +349,9 @@ KviPixmapSelector * KviOptionsWidget::addPixmapSelector(int x1, int y1, int x2, 
 {
 	m_iResetFlags |= (g_pixmapOptionsTable[optId].flags & KviOption_resetMask);
 	KviPixmapSelector * d = addPixmapSelector(x1, y1, x2, y2, txt, &(KVI_OPTION_PIXMAP(optId)), bEnabled);
-	QString tmp = m_szBasicTipStart;
-	tmp += g_pixmapOptionsTable[optId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+
+	setBasicTip(d, g_pixmapOptionsTable[optId].name);
+
 	return d;
 }
 
@@ -393,10 +380,9 @@ KviUIntSelector * KviOptionsWidget::addUIntSelector(int x1, int y1, int x2, int 
 {
 	m_iResetFlags |= (g_uintOptionsTable[optId].flags & KviOption_resetMask);
 	KviUIntSelector * d = addUIntSelector(x1, y1, x2, y2, txt, &(KVI_OPTION_UINT(optId)), uLowBound, uHighBound, uDefault, bEnabled);
-	QString tmp = m_szBasicTipStart;
-	tmp += g_uintOptionsTable[optId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+
+	setBasicTip(d, g_uintOptionsTable[optId].name);
+
 	return d;
 }
 
@@ -406,10 +392,9 @@ KviUIntSelector * KviOptionsWidget::addUIntSelector(QWidget * pParent, const QSt
 {
 	m_iResetFlags |= (g_uintOptionsTable[optId].flags & KviOption_resetMask);
 	KviUIntSelector * d = addUIntSelector(pParent, txt, &(KVI_OPTION_UINT(optId)), uLowBound, uHighBound, uDefault, bEnabled);
-	QString tmp = m_szBasicTipStart;
-	tmp += g_uintOptionsTable[optId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+
+	setBasicTip(d, g_uintOptionsTable[optId].name);
+
 	return d;
 }
 
@@ -442,10 +427,9 @@ KviStringSelector * KviOptionsWidget::addStringSelector(int x1, int y1, int x2, 
 {
 	m_iResetFlags |= (g_stringOptionsTable[optId].flags & KviOption_resetMask);
 	KviStringSelector * d = addStringSelector(x1, y1, x2, y2, txt, &(KVI_OPTION_STRING(optId)), bEnabled);
-	QString tmp = m_szBasicTipStart;
-	tmp += g_stringOptionsTable[optId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+
+	setBasicTip(d, g_stringOptionsTable[optId].name);
+
 	return d;
 }
 
@@ -453,10 +437,9 @@ KviStringSelector * KviOptionsWidget::addStringSelector(QWidget * pParent, const
 {
 	m_iResetFlags |= (g_stringOptionsTable[optId].flags & KviOption_resetMask);
 	KviStringSelector * d = addStringSelector(pParent, txt, &(KVI_OPTION_STRING(optId)), bEnabled);
-	QString tmp = m_szBasicTipStart;
-	tmp += g_stringOptionsTable[optId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+
+	setBasicTip(d, g_stringOptionsTable[optId].name);
+
 	return d;
 }
 
@@ -479,10 +462,9 @@ KviPasswordSelector * KviOptionsWidget::addPasswordSelector(int x1, int y1, int 
 {
 	m_iResetFlags |= (g_stringOptionsTable[optId].flags & KviOption_resetMask);
 	KviPasswordSelector * d = addPasswordSelector(x1, y1, x2, y2, txt, &(KVI_OPTION_STRING(optId)), bEnabled);
-	QString tmp = m_szBasicTipStart;
-	tmp += g_stringOptionsTable[optId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+
+	setBasicTip(d, g_stringOptionsTable[optId].name);
+
 	return d;
 }
 
@@ -490,10 +472,9 @@ KviPasswordSelector * KviOptionsWidget::addPasswordSelector(QWidget * pParent, c
 {
 	m_iResetFlags |= (g_stringOptionsTable[optId].flags & KviOption_resetMask);
 	KviPasswordSelector * d = addPasswordSelector(pParent, txt, &(KVI_OPTION_STRING(optId)), bEnabled);
-	QString tmp = m_szBasicTipStart;
-	tmp += g_stringOptionsTable[optId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+
+	setBasicTip(d, g_stringOptionsTable[optId].name);
+
 	return d;
 }
 
@@ -509,10 +490,9 @@ KviStringListSelector * KviOptionsWidget::addStringListSelector(int x1, int y1, 
 {
 	m_iResetFlags |= (g_stringlistOptionsTable[optId].flags & KviOption_resetMask);
 	KviStringListSelector * d = addStringListSelector(x1, y1, x2, y2, txt, &(KVI_OPTION_STRINGLIST(optId)), bEnabled);
-	QString tmp = m_szBasicTipStart;
-	tmp += g_stringlistOptionsTable[optId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+
+	setBasicTip(d, g_stringlistOptionsTable[optId].name);
+
 	return d;
 }
 
@@ -535,10 +515,9 @@ KviColorSelector * KviOptionsWidget::addColorSelector(int x1, int y1, int x2, in
 {
 	m_iResetFlags |= (g_colorOptionsTable[optId].flags & KviOption_resetMask);
 	KviColorSelector * d = addColorSelector(x1, y1, x2, y2, txt, &(KVI_OPTION_COLOR(optId)), bEnabled);
-	QString tmp = m_szBasicTipStart;
-	tmp += g_colorOptionsTable[optId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+
+	setBasicTip(d, g_colorOptionsTable[optId].name);
+
 	return d;
 }
 
@@ -546,10 +525,9 @@ KviColorSelector * KviOptionsWidget::addColorSelector(QWidget * pParent, const Q
 {
 	m_iResetFlags |= (g_colorOptionsTable[optId].flags & KviOption_resetMask);
 	KviColorSelector * d = addColorSelector(pParent, txt, &(KVI_OPTION_COLOR(optId)), bEnabled);
-	QString tmp = m_szBasicTipStart;
-	tmp += g_colorOptionsTable[optId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+
+	setBasicTip(d, g_colorOptionsTable[optId].name);
+
 	return d;
 }
 
@@ -573,10 +551,9 @@ KviMircTextColorSelector * KviOptionsWidget::addMircTextColorSelector(int x1, in
 	m_iResetFlags |= (g_uintOptionsTable[optForeId].flags & KviOption_resetMask);
 	m_iResetFlags |= (g_uintOptionsTable[optBackId].flags & KviOption_resetMask);
 	KviMircTextColorSelector * d = addMircTextColorSelector(x1, y1, x2, y2, txt, &(KVI_OPTION_UINT(optForeId)), &(KVI_OPTION_UINT(optBackId)), bEnabled);
-	QString tmp = m_szBasicTipStart;
-	tmp += g_uintOptionsTable[optForeId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+
+	setBasicTip(d, g_uintOptionsTable[optForeId].name);
+
 	return d;
 }
 
@@ -585,10 +562,9 @@ KviMircTextColorSelector * KviOptionsWidget::addMircTextColorSelector(QWidget * 
 	m_iResetFlags |= (g_uintOptionsTable[optForeId].flags & KviOption_resetMask);
 	m_iResetFlags |= (g_uintOptionsTable[optBackId].flags & KviOption_resetMask);
 	KviMircTextColorSelector * d = addMircTextColorSelector(pParent, txt, &(KVI_OPTION_UINT(optForeId)), &(KVI_OPTION_UINT(optBackId)), bEnabled);
-	QString tmp = m_szBasicTipStart;
-	tmp += g_uintOptionsTable[optForeId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+
+	setBasicTip(d, g_uintOptionsTable[optForeId].name);
+
 	return d;
 }
 
@@ -611,10 +587,9 @@ KviFontSelector * KviOptionsWidget::addFontSelector(int x1, int y1, int x2, int 
 {
 	m_iResetFlags |= (g_fontOptionsTable[optId].flags & KviOption_resetMask);
 	KviFontSelector * d = addFontSelector(x1, y1, x2, y2, txt, &(KVI_OPTION_FONT(optId)), bEnabled);
-	QString tmp = m_szBasicTipStart;
-	tmp += g_fontOptionsTable[optId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+
+	setBasicTip(d, g_fontOptionsTable[optId].name);
+
 	return d;
 }
 
@@ -622,10 +597,9 @@ KviFontSelector * KviOptionsWidget::addFontSelector(QWidget * pParent, const QSt
 {
 	m_iResetFlags |= (g_fontOptionsTable[optId].flags & KviOption_resetMask);
 	KviFontSelector * d = addFontSelector(pParent, txt, &(KVI_OPTION_FONT(optId)), bEnabled);
-	QString tmp = m_szBasicTipStart;
-	tmp += g_fontOptionsTable[optId].name;
-	tmp += m_szBasicTipEnd;
-	KviTalToolTip::add(d, tmp);
+
+	setBasicTip(d, g_fontOptionsTable[optId].name);
+
 	return d;
 }
 

--- a/src/kvirc/ui/KviOptionsWidget.h
+++ b/src/kvirc/ui/KviOptionsWidget.h
@@ -61,6 +61,7 @@ protected:
 	void commitOptionsReset();
 
 public:
+	void setBasicTip(QWidget * w, const QString & optionName);
 	void mergeTip(QWidget * w, const QString & tip);
 	KviPointerList<KviSelectorInterface> * selectors() { return m_pSelectorInterfaceList; };
 

--- a/src/kvirc/ui/KviUserListView.cpp
+++ b/src/kvirc/ui/KviUserListView.cpp
@@ -245,6 +245,7 @@ KviUserListView::KviUserListView(QWidget * pParent, KviWindowToolPageButton * pB
 	m_ieEntries = 0;
 	m_iIEntries = 0;
 	m_iSelectedCount = 0;
+	m_CompletionList = nullptr;
 
 	applyOptions();
 }
@@ -256,6 +257,7 @@ KviUserListView::~KviUserListView()
 	delete m_pToolTip;
 	delete m_pViewArea;
 	delete m_pUsersLabel;
+	delete m_CompletionList;
 }
 
 void KviUserListView::emitRightClick()
@@ -485,60 +487,115 @@ void KviUserListView::completeNickBashLike(const QString & szBegin, std::vector<
 	}
 }
 
-bool KviUserListView::completeNickStandard(const QString & szBegin, const QString & szSkipAfter, QString & szBuffer, bool bAppendMask)
+bool KviUserListView::completeNickStandard(const QString & szBegin, QString & szSkipAfter, QString & szBuffer, bool bAppendMask)
 {
-	KviUserListEntry * pEntry = m_pHeadItem;
+	// For normal nickname completion, we'll build a list of matching nicknames in order,
+	// then look through it to the next nickname each time Tab is pressed.
+	if (m_CompletionList == nullptr)
+	{
+		// No list; build it.
+		m_CompletionList = new std::list<QString>();
+
+		KviUserListEntry * pEntry = m_pHeadItem;
+
+		for(KviUserListEntry * pEntry = m_pHeadItem; pEntry; pEntry = pEntry->m_pNext)
+		{
+			// FIXME: completion should skip my own nick or place it as last entry in the chain (?)
+
+			//	if(KviConsoleWindow * c = m_pKviWindow->console())
+			//	{
+			//		if(kvi_strEqualCI(entry->m_szNick.ptr(),c->currentNickName())
+			//	}
+
+			if(pEntry->m_szNick.length() >= szBegin.length())
+			{
+				bool bEqual = KviQString::equalCIN(szBegin, pEntry->m_szNick, szBegin.length());
+				if(!bEqual && KVI_OPTION_BOOL(KviOption_boolIgnoreSpecialCharactersInNickCompletion))
+				{
+					QString szTmp = pEntry->m_szNick;
+					szTmp.remove(QRegExp("[^a-zA-Z0-9]"));
+					bEqual = KviQString::equalCIN(szBegin, szTmp, szBegin.length());
+				}
+
+				if(bEqual)
+				{
+					// Matching entry; insert it into the list.
+					std::list<QString>::iterator it;
+					switch (KVI_OPTION_UINT(KviOption_uintNickCompletionOrder))
+					{
+						case 0:  // As listed
+							m_CompletionList->push_back(pEntry->m_szNick);
+							break;
+						case 1:  // Alphabetical
+							for (it = m_CompletionList->begin(); it != m_CompletionList->end(); ++it)
+							{
+								if ((KviQString::cmpCI(pEntry->m_szNick, *it,
+									KVI_OPTION_BOOL(KviOption_boolPlaceNickWithNonAlphaCharsAtEnd)) < 0))
+								{
+									break;
+								}
+							}
+							m_CompletionList->insert(it, pEntry->m_szNick);
+							break;
+						default:  // Last action time
+							for (it = m_CompletionList->begin(); it != m_CompletionList->end(); ++it)
+							{
+								if (pEntry->m_lastActionTime > (*m_pEntryDict->find(*it)).m_lastActionTime)
+								{
+									break;
+								}
+							}
+							m_CompletionList->insert(it, pEntry->m_szNick);
+							break;
+					}
+
+				}
+			}
+		}
+	}
+
+	// The list exists; find the next match.
+	std::list<QString>::iterator it = m_CompletionList->begin();
 
 	if(!szSkipAfter.isEmpty())
 	{
-		while(pEntry)
+		while(it != m_CompletionList->end())
 		{
-			if(KviQString::equalCI(szSkipAfter, pEntry->m_szNick))
+			if(KviQString::equalCI(szSkipAfter, *it))
 			{
-				pEntry = pEntry->m_pNext;
+				++it;
 				break;
 			}
-			pEntry = pEntry->m_pNext;
+			++it;
 		}
 	}
 
-	// FIXME: completion should skip my own nick or place it as last entry in the chain (?)
-
-	//	if(KviConsoleWindow * c = m_pKviWindow->console())
-	//	{
-	//		if(kvi_strEqualCI(entry->m_szNick.ptr(),c->currentNickName())
-	//	}
-
-	// Ok...now the real completion
-	while(pEntry)
+	if(it != m_CompletionList->end())
 	{
-		if(pEntry->m_szNick.length() >= szBegin.length())
+		szSkipAfter = *it;
+		szBuffer = *it;
+		if(bAppendMask)
 		{
-			bool bEqual = KviQString::equalCIN(szBegin, pEntry->m_szNick, szBegin.length());
-			if(!bEqual && KVI_OPTION_BOOL(KviOption_boolIgnoreSpecialCharactersInNickCompletion))
+			KviUserListEntry * entry = m_pEntryDict->find(*it);
+			if (entry)
 			{
-				QString szTmp = pEntry->m_szNick;
-				szTmp.remove(QRegExp("[^a-zA-Z0-9]"));
-				bEqual = KviQString::equalCIN(szBegin, szTmp, szBegin.length());
+				szBuffer += "!";
+				szBuffer += entry->m_pGlobalData->user();
+				szBuffer += "@";
+				szBuffer += entry->m_pGlobalData->host();
 			}
-
-			if(bEqual)
+			else
 			{
-				// This is ok.
-				szBuffer = pEntry->m_szNick;
-				if(bAppendMask)
-				{
-					szBuffer += "!";
-					szBuffer += pEntry->m_pGlobalData->user();
-					szBuffer += "@";
-					szBuffer += pEntry->m_pGlobalData->host();
-				}
-				return true;
+				// They left the user list during the completion session.
+				szBuffer += "!*@*";
 			}
 		}
-		pEntry = pEntry->m_pNext;
+		return true;
 	}
 
+	// No more matches; delete the list.
+	delete m_CompletionList;
+	m_CompletionList = nullptr;
 	return false;
 }
 

--- a/src/kvirc/ui/KviUserListView.h
+++ b/src/kvirc/ui/KviUserListView.h
@@ -276,6 +276,8 @@ protected:
 	int m_iIEntries;
 	KviWindow * m_pKviWindow;
 
+	std::list<QString> * m_CompletionList;
+
 public:
 	/**
 	* \brief Updates the list view area
@@ -720,12 +722,12 @@ public:
 	* It looks for the letters typed, if it found at least a result, it
 	* cycles through the completed nicknames
 	* \param szBegin The starting of the nick
-	* \param szSkipAfter The string to skip after the nick is completed
+	* \param szSkipAfter The string to skip after the nick is completed. Will be updated with the completed nickname.
 	* \param szBuffer The buffer where to store the data
 	* \param bAppendMask Whether to append the complete mask
 	* \return bool
 	*/
-	bool completeNickStandard(const QString & szBegin, const QString & szSkipAfter, QString & szBuffer, bool bAppendMask);
+	bool completeNickStandard(const QString & szBegin, QString & szSkipAfter, QString & szBuffer, bool bAppendMask);
 
 	/**
 	* \brief Completes the nick in Bash-like behaviour

--- a/src/modules/options/OptionsWidget_channel.cpp
+++ b/src/modules/options/OptionsWidget_channel.cpp
@@ -97,9 +97,11 @@ OptionsWidget_channelAdvanced::OptionsWidget_channelAdvanced(QWidget * pParent)
 
 	b = addBoolSelector(0, 0, 4, 0, __tr2qs_ctx("Log joined channels history", "options"), KviOption_boolLogChannelHistory);
 
-	addLabel(0, 1, 0, 1, __tr2qs_ctx("Default ban mask:", "options"));
+	QLabel * pLabel = addLabel(0, 1, 0, 1, __tr2qs_ctx("Default ban mask:", "options"));
+	setBasicTip(pLabel, g_uintOptionsTable[KviOption_uintDefaultBanType].name);
 
 	m_pBanTypeCombo = new QComboBox(this);
+	setBasicTip(m_pBanTypeCombo, g_uintOptionsTable[KviOption_uintDefaultBanType].name);
 	addWidgetToLayout(m_pBanTypeCombo, 1, 1, 4, 1);
 
 	KviIrcMask hostmask("nick!user@machine.host.top");

--- a/src/modules/options/OptionsWidget_connection.cpp
+++ b/src/modules/options/OptionsWidget_connection.cpp
@@ -109,25 +109,27 @@ OptionsWidget_connectionSsl::OptionsWidget_connectionSsl(QWidget * parent)
 	KviTalGroupBox * gbox = addGroupBox(0, 0, 0, 0, Qt::Horizontal, __tr2qs_ctx("Certificate", "options"));
 
 	b = addBoolSelector(gbox, __tr2qs_ctx("Use SSL certificate (PEM format only)", "options"),
-	    &(KVI_OPTION_BOOL(KviOption_boolUseSSLCertificate)), true);
+	    KviOption_boolUseSSLCertificate, true);
 
-	f = addFileSelector(gbox, __tr2qs_ctx("Certificate location:", "options"), &(KVI_OPTION_STRING(KviOption_stringSSLCertificatePath)),
+	f = addFileSelector(gbox, __tr2qs_ctx("Certificate location:", "options"), KviOption_stringSSLCertificatePath,
 	    KVI_OPTION_BOOL(KviOption_boolUseSSLCertificate));
 	connect(b, SIGNAL(toggled(bool)), f, SLOT(setEnabled(bool)));
 
 	p = new KviPasswordSelector(gbox, __tr2qs_ctx("Certificate password:", "options"), &(KVI_OPTION_STRING(KviOption_stringSSLCertificatePass)),
 	    KVI_OPTION_BOOL(KviOption_boolUseSSLCertificate));
+	setBasicTip(p, g_stringOptionsTable[KviOption_stringSSLCertificatePass].name);
 	connect(b, SIGNAL(toggled(bool)), p, SLOT(setEnabled(bool)));
 
 	gbox = addGroupBox(0, 1, 0, 1, Qt::Horizontal, __tr2qs_ctx("Private Key", "options"));
 
-	b = addBoolSelector(gbox, __tr2qs_ctx("Use SSL private key", "options"), &(KVI_OPTION_BOOL(KviOption_boolUseSSLPrivateKey)), true);
-	f = addFileSelector(gbox, __tr2qs_ctx("Private key location:", "options"), &(KVI_OPTION_STRING(KviOption_stringSSLPrivateKeyPath)),
+	b = addBoolSelector(gbox, __tr2qs_ctx("Use SSL private key", "options"), KviOption_boolUseSSLPrivateKey, true);
+	f = addFileSelector(gbox, __tr2qs_ctx("Private key location:", "options"), KviOption_stringSSLPrivateKeyPath,
 	    KVI_OPTION_BOOL(KviOption_boolUseSSLPrivateKey));
 	connect(b, SIGNAL(toggled(bool)), f, SLOT(setEnabled(bool)));
 
 	p = addPasswordSelector(gbox, __tr2qs_ctx("Private key password:", "options"), &(KVI_OPTION_STRING(KviOption_stringSSLPrivateKeyPass)),
 	    KVI_OPTION_BOOL(KviOption_boolUseSSLPrivateKey));
+	setBasicTip(p, g_stringOptionsTable[KviOption_stringSSLPrivateKeyPass].name);
 	connect(b, SIGNAL(toggled(bool)), p, SLOT(setEnabled(bool)));
 
 	addRowSpacer(0, 3, 0, 3);
@@ -202,6 +204,7 @@ OptionsWidget_identService::OptionsWidget_identService(QWidget * parent)
 	connect(m_pEnableIdent, SIGNAL(toggled(bool)), this, SLOT(enableIpv4InIpv6(bool)));
 
 	KviTalGroupBox * gbox = addGroupBox(0, 1, 0, 1, Qt::Horizontal, __tr2qs_ctx("Output Verbosity", "options"), KVI_OPTION_BOOL(KviOption_boolUseIdentService));
+	setBasicTip(gbox, g_uintOptionsTable[KviOption_uintIdentdOutputMode].name);
 	connect(m_pEnableIdent, SIGNAL(toggled(bool)), gbox, SLOT(setEnabled(bool)));
 
 	addLabel(gbox, __tr2qs_ctx("Output Ident service messages to:", "options"));

--- a/src/modules/options/OptionsWidget_identity.cpp
+++ b/src/modules/options/OptionsWidget_identity.cpp
@@ -338,9 +338,8 @@ KviIdentityGeneralOptionsWidget::KviIdentityGeneralOptionsWidget(QWidget * paren
 	l->setMinimumWidth(120);
 
 	m_pAgeCombo = new QComboBox(hb);
-	QString szTip1 = __tr2qs_ctx("Here you can specify your age.", "options") + szTrailing;
-	KviTalToolTip::add(l, szTip1);
-	KviTalToolTip::add(m_pAgeCombo, szTip1);
+	setBasicTip(hb, g_stringOptionsTable[KviOption_stringCtcpUserInfoAge].name);
+	mergeTip(hb, __tr2qs_ctx("Here you can specify your age.", "options") + szTrailing);
 	m_pAgeCombo->addItem(__tr2qs_ctx("Unspecified", "options"));
 	unsigned int i;
 	for(i = 1; i < 120; i++)
@@ -366,9 +365,8 @@ KviIdentityGeneralOptionsWidget::KviIdentityGeneralOptionsWidget(QWidget * paren
 	l->setMinimumWidth(120);
 
 	m_pGenderCombo = new QComboBox(hb);
-	QString szTip2 = __tr2qs_ctx("Here you can specify your gender.", "options") + szTrailing;
-	KviTalToolTip::add(l, szTip2);
-	KviTalToolTip::add(m_pGenderCombo, szTip2);
+	setBasicTip(hb, g_stringOptionsTable[KviOption_stringCtcpUserInfoGender].name);
+	mergeTip(hb, __tr2qs_ctx("Here you can specify your gender.", "options") + szTrailing);
 	m_pGenderCombo->addItem(__tr2qs_ctx("Unspecified", "options"));
 	m_pGenderCombo->addItem(__tr2qs_ctx("Female", "options"));
 	m_pGenderCombo->addItem(__tr2qs_ctx("Male", "options"));
@@ -674,6 +672,7 @@ OptionsWidget_identityAdvanced::OptionsWidget_identityAdvanced(QWidget * parent)
 	layout()->setMargin(10);
 
 	KviTalGroupBox * gbox = addGroupBox(0, 0, 0, 0, Qt::Horizontal, __tr2qs_ctx("User Mode", "options"));
+	setBasicTip(gbox, g_stringOptionsTable[KviOption_stringDefaultUserMode].name);
 	m_pISelector = addBoolSelector(gbox, __tr2qs_ctx("Invisible (+i)", "options"), &m_bI);
 	m_pSSelector = addBoolSelector(gbox, __tr2qs_ctx("Server notices (+s)", "options"), &m_bS);
 	m_pWSelector = addBoolSelector(gbox, __tr2qs_ctx("WALLOPS (+w)", "options"), &m_bW);

--- a/src/modules/options/OptionsWidget_input.cpp
+++ b/src/modules/options/OptionsWidget_input.cpp
@@ -159,10 +159,24 @@ OptionsWidget_inputFeatures::OptionsWidget_inputFeatures(QWidget * parent)
 
 	addBoolSelector(g, __tr2qs_ctx("Ignore special characters in nick completion", "options"), KviOption_boolIgnoreSpecialCharactersInNickCompletion);
 
-	// TODO: Add a combo box for KviOption_uintNickCompletionOrder
-	// 0: as listed
-	// 1: alphabetical
-	// 2: by last action time
+	KviTalHBox * hb = new KviTalHBox(g);
+
+	QLabel * l = new QLabel(__tr2qs_ctx("Nickname completion order:", "options"), hb);
+	l->setMinimumWidth(120);
+
+	m_pCompletionOrderCombo = new QComboBox(hb);
+	m_pCompletionOrderCombo->addItem(__tr2qs_ctx("As listed", "options"));
+	m_pCompletionOrderCombo->addItem(__tr2qs_ctx("Alphabetical", "options"));
+	m_pCompletionOrderCombo->addItem(__tr2qs_ctx("By last action time", "options"));
+
+	// TODO: add the tooltip
+
+	if (KVI_OPTION_UINT(KviOption_uintNickCompletionOrder) < 3)
+		m_pCompletionOrderCombo->setCurrentIndex(KVI_OPTION_UINT(KviOption_uintNickCompletionOrder));
+	else
+		m_pCompletionOrderCombo->setCurrentIndex(2);
+
+	hb->setStretchFactor(m_pCompletionOrderCombo, 1);
 
 	KviBoolSelector * d = addBoolSelector(0, 7, 0, 7, __tr2qs_ctx("Use a custom cursor width", "options"), KviOption_boolEnableCustomCursorWidth);
 	KviUIntSelector * f = addUIntSelector(0, 8, 0, 8, __tr2qs_ctx("Custom cursor width:", "options"), KviOption_uintCustomCursorWidth, 1, 24, 8, KVI_OPTION_BOOL(KviOption_boolEnableCustomCursorWidth));
@@ -173,3 +187,8 @@ OptionsWidget_inputFeatures::OptionsWidget_inputFeatures(QWidget * parent)
 
 OptionsWidget_inputFeatures::~OptionsWidget_inputFeatures()
     = default;
+
+void OptionsWidget_inputFeatures::commit()
+{
+	KVI_OPTION_UINT(KviOption_uintNickCompletionOrder) = m_pCompletionOrderCombo->currentIndex();
+}

--- a/src/modules/options/OptionsWidget_input.cpp
+++ b/src/modules/options/OptionsWidget_input.cpp
@@ -45,12 +45,16 @@ OptionsWidget_inputLook::OptionsWidget_inputLook(QWidget * parent)
 
 	addPixmapSelector(0, 7, 1, 7, __tr2qs_ctx("Background image:", "options"), KviOption_pixmapInputBackground);
 
-	addLabel(0, 8, 0, 8, __tr2qs_ctx("Horizontal align:", "options"));
+	QLabel * pLabel = addLabel(0, 8, 0, 8, __tr2qs_ctx("Horizontal align:", "options"));
+	setBasicTip(pLabel, g_uintOptionsTable[KviOption_uintInputPixmapAlign].name);
 	m_pHorizontalAlign = new QComboBox(this);
+	setBasicTip(m_pHorizontalAlign, g_uintOptionsTable[KviOption_uintInputPixmapAlign].name);
 	addWidgetToLayout(m_pHorizontalAlign, 1, 8, 1, 8);
 
-	addLabel(0, 9, 0, 9, __tr2qs_ctx("Vertical align:", "options"));
+	pLabel = addLabel(0, 9, 0, 9, __tr2qs_ctx("Vertical align:", "options"));
+	setBasicTip(pLabel, g_uintOptionsTable[KviOption_uintInputPixmapAlign].name);
 	m_pVerticalAlign = new QComboBox(this);
+	setBasicTip(m_pVerticalAlign, g_uintOptionsTable[KviOption_uintInputPixmapAlign].name);
 	addWidgetToLayout(m_pVerticalAlign, 1, 9, 1, 9);
 
 	m_pHorizontalAlign->addItem(__tr2qs_ctx("Tile", "options"));
@@ -160,6 +164,7 @@ OptionsWidget_inputFeatures::OptionsWidget_inputFeatures(QWidget * parent)
 	addBoolSelector(g, __tr2qs_ctx("Ignore special characters in nick completion", "options"), KviOption_boolIgnoreSpecialCharactersInNickCompletion);
 
 	KviTalHBox * hb = new KviTalHBox(g);
+	setBasicTip(hb, g_uintOptionsTable[KviOption_uintNickCompletionOrder].name);
 
 	QLabel * l = new QLabel(__tr2qs_ctx("Nickname completion order:", "options"), hb);
 	l->setMinimumWidth(120);
@@ -168,8 +173,6 @@ OptionsWidget_inputFeatures::OptionsWidget_inputFeatures(QWidget * parent)
 	m_pCompletionOrderCombo->addItem(__tr2qs_ctx("As listed", "options"));
 	m_pCompletionOrderCombo->addItem(__tr2qs_ctx("Alphabetical", "options"));
 	m_pCompletionOrderCombo->addItem(__tr2qs_ctx("By last action time", "options"));
-
-	// TODO: add the tooltip
 
 	if (KVI_OPTION_UINT(KviOption_uintNickCompletionOrder) < 3)
 		m_pCompletionOrderCombo->setCurrentIndex(KVI_OPTION_UINT(KviOption_uintNickCompletionOrder));

--- a/src/modules/options/OptionsWidget_input.cpp
+++ b/src/modules/options/OptionsWidget_input.cpp
@@ -159,6 +159,11 @@ OptionsWidget_inputFeatures::OptionsWidget_inputFeatures(QWidget * parent)
 
 	addBoolSelector(g, __tr2qs_ctx("Ignore special characters in nick completion", "options"), KviOption_boolIgnoreSpecialCharactersInNickCompletion);
 
+	// TODO: Add a combo box for KviOption_uintNickCompletionOrder
+	// 0: as listed
+	// 1: alphabetical
+	// 2: by last action time
+
 	KviBoolSelector * d = addBoolSelector(0, 7, 0, 7, __tr2qs_ctx("Use a custom cursor width", "options"), KviOption_boolEnableCustomCursorWidth);
 	KviUIntSelector * f = addUIntSelector(0, 8, 0, 8, __tr2qs_ctx("Custom cursor width:", "options"), KviOption_uintCustomCursorWidth, 1, 24, 8, KVI_OPTION_BOOL(KviOption_boolEnableCustomCursorWidth));
 	f->setSuffix(__tr2qs_ctx(" pixels", "options"));

--- a/src/modules/options/OptionsWidget_input.h
+++ b/src/modules/options/OptionsWidget_input.h
@@ -54,6 +54,9 @@ public:
 class OptionsWidget_inputFeatures : public KviOptionsWidget
 {
 	Q_OBJECT
+private:
+	QComboBox * m_pNickCompletionOrder;
+
 public:
 	OptionsWidget_inputFeatures(QWidget * parent);
 	~OptionsWidget_inputFeatures();

--- a/src/modules/options/OptionsWidget_input.h
+++ b/src/modules/options/OptionsWidget_input.h
@@ -55,11 +55,13 @@ class OptionsWidget_inputFeatures : public KviOptionsWidget
 {
 	Q_OBJECT
 private:
-	QComboBox * m_pNickCompletionOrder;
+	QComboBox * m_pCompletionOrderCombo;
 
 public:
 	OptionsWidget_inputFeatures(QWidget * parent);
 	~OptionsWidget_inputFeatures();
+
+	virtual void commit();
 };
 
 #endif //!_OPTW_INPUT_H_

--- a/src/modules/options/OptionsWidget_input.h
+++ b/src/modules/options/OptionsWidget_input.h
@@ -61,7 +61,7 @@ public:
 	OptionsWidget_inputFeatures(QWidget * parent);
 	~OptionsWidget_inputFeatures();
 
-	virtual void commit();
+	void commit() override;
 };
 
 #endif //!_OPTW_INPUT_H_

--- a/src/modules/options/OptionsWidget_ircOutput.cpp
+++ b/src/modules/options/OptionsWidget_ircOutput.cpp
@@ -41,9 +41,11 @@ OptionsWidget_ircOutput::OptionsWidget_ircOutput(QWidget * pParent)
 	createLayout();
 
 	QLabel * pLabel = new QLabel(__tr2qs_ctx("Output verbosity:", "options"), this);
+	setBasicTip(pLabel, g_uintOptionsTable[KviOption_uintOutputVerbosityLevel].name);
 	addWidgetToLayout(pLabel, 0, 0, 0, 0);
 
 	m_pVerbosityCombo = new QComboBox(this);
+	setBasicTip(m_pVerbosityCombo, g_uintOptionsTable[KviOption_uintOutputVerbosityLevel].name);
 	m_pVerbosityCombo->addItem(__tr2qs_ctx("Mute", "options"));
 	m_pVerbosityCombo->addItem(__tr2qs_ctx("Quiet", "options"));
 	m_pVerbosityCombo->addItem(__tr2qs_ctx("Normal", "options"));
@@ -56,9 +58,11 @@ OptionsWidget_ircOutput::OptionsWidget_ircOutput(QWidget * pParent)
 	m_pVerbosityCombo->setCurrentIndex(KVI_OPTION_UINT(KviOption_uintOutputVerbosityLevel));
 
 	pLabel = new QLabel(__tr2qs_ctx("DateTime format:", "options"), this);
+	setBasicTip(pLabel, g_uintOptionsTable[KviOption_uintOutputDatetimeFormat].name);
 	addWidgetToLayout(pLabel, 0, 1, 0, 1);
 
 	m_pDatetimeCombo = new QComboBox(this);
+	setBasicTip(m_pDatetimeCombo, g_uintOptionsTable[KviOption_uintOutputDatetimeFormat].name);
 	m_pDatetimeCombo->addItem(__tr2qs_ctx("Classic format", "options"));
 	m_pDatetimeCombo->addItem(__tr2qs_ctx("ISO 8601 format", "options"));
 	m_pDatetimeCombo->addItem(__tr2qs_ctx("System locale format", "options"));

--- a/src/modules/options/OptionsWidget_ircView.cpp
+++ b/src/modules/options/OptionsWidget_ircView.cpp
@@ -49,12 +49,16 @@ OptionsWidget_ircViewLook::OptionsWidget_ircViewLook(QWidget * parent)
 
 	addPixmapSelector(0, 2, 1, 2, __tr2qs_ctx("Background image:", "options"), KviOption_pixmapIrcViewBackground);
 
-	addLabel(0, 3, 0, 3, __tr2qs_ctx("Horizontal align:", "options"));
+	QLabel * pLabel = addLabel(0, 3, 0, 3, __tr2qs_ctx("Horizontal align:", "options"));
+	setBasicTip(pLabel, g_uintOptionsTable[KviOption_uintIrcViewPixmapAlign].name);
 	m_pHorizontalAlign = new QComboBox(this);
+	setBasicTip(m_pHorizontalAlign, g_uintOptionsTable[KviOption_uintIrcViewPixmapAlign].name);
 	addWidgetToLayout(m_pHorizontalAlign, 1, 3, 1, 3);
 
-	addLabel(0, 4, 0, 4, __tr2qs_ctx("Vertical align:", "options"));
+	pLabel = addLabel(0, 4, 0, 4, __tr2qs_ctx("Vertical align:", "options"));
+	setBasicTip(pLabel, g_uintOptionsTable[KviOption_uintIrcViewPixmapAlign].name);
 	m_pVerticalAlign = new QComboBox(this);
+	setBasicTip(m_pVerticalAlign, g_uintOptionsTable[KviOption_uintIrcViewPixmapAlign].name);
 	addWidgetToLayout(m_pVerticalAlign, 1, 4, 1, 4);
 
 	m_pHorizontalAlign->addItem(__tr2qs_ctx("Tile", "options"));
@@ -178,8 +182,10 @@ OptionsWidget_ircViewMarker::OptionsWidget_ircViewMarker(QWidget * parent)
 	KviUIntSelector * s = addUIntSelector(0, 2, 1, 2, __tr2qs_ctx("Marker size:", "options"), KviOption_uintIrcViewMarkerSize, 1, 5, 1);
 	s->setSuffix(__tr2qs_ctx(" pixels", "options"));
 
-	addLabel(0, 3, 0, 3, __tr2qs_ctx("Marker style:", "options"));
+	QLabel * pLabel = addLabel(0, 3, 0, 3, __tr2qs_ctx("Marker style:", "options"));
+	setBasicTip(pLabel, g_uintOptionsTable[KviOption_uintIrcViewMarkerStyle].name);
 	m_pMarkerStyle = new QComboBox(this);
+	setBasicTip(m_pMarkerStyle, g_uintOptionsTable[KviOption_uintIrcViewMarkerStyle].name);
 	addWidgetToLayout(m_pMarkerStyle, 1, 3, 1, 3);
 
 	addRowSpacer(0, 4, 0, 4);

--- a/src/modules/options/OptionsWidget_notifier.cpp
+++ b/src/modules/options/OptionsWidget_notifier.cpp
@@ -44,12 +44,16 @@ OptionsWidget_notifierLook::OptionsWidget_notifierLook(QWidget * parent)
 
 	addPixmapSelector(0, 5, 1, 5, __tr2qs_ctx("Background image:", "options"), KviOption_pixmapNotifierBackground);
 
-	addLabel(0, 6, 0, 6, __tr2qs_ctx("Horizontal align:", "options"));
+	QLabel * pLabel = addLabel(0, 6, 0, 6, __tr2qs_ctx("Horizontal align:", "options"));
+	setBasicTip(pLabel, g_uintOptionsTable[KviOption_uintNotifierPixmapAlign].name);
 	m_pHorizontalAlign = new QComboBox(this);
+	setBasicTip(m_pHorizontalAlign, g_uintOptionsTable[KviOption_uintNotifierPixmapAlign].name);
 	addWidgetToLayout(m_pHorizontalAlign, 1, 6, 1, 6);
 
-	addLabel(0, 7, 0, 7, __tr2qs_ctx("Vertical align:", "options"));
+	pLabel = addLabel(0, 7, 0, 7, __tr2qs_ctx("Vertical align:", "options"));
+	setBasicTip(pLabel, g_uintOptionsTable[KviOption_uintNotifierPixmapAlign].name);
 	m_pVerticalAlign = new QComboBox(this);
+	setBasicTip(m_pVerticalAlign, g_uintOptionsTable[KviOption_uintNotifierPixmapAlign].name);
 	addWidgetToLayout(m_pVerticalAlign, 1, 7, 1, 7);
 
 	m_pHorizontalAlign->addItem(__tr2qs_ctx("Tile", "options"));

--- a/src/modules/options/OptionsWidget_sound.cpp
+++ b/src/modules/options/OptionsWidget_sound.cpp
@@ -60,6 +60,7 @@ OptionsWidget_soundGeneral::OptionsWidget_soundGeneral(QWidget * parent)
 	KviTalToolTip::add(g, __tr2qs_ctx("This allows you to select the sound system to be used with KVIrc.", "options"));
 
 	KviTalHBox * h = new KviTalHBox(g);
+	setBasicTip(h, g_stringOptionsTable[KviOption_stringSoundSystem].name);
 
 	m_pSoundSystemBox = new QComboBox(h);
 
@@ -76,6 +77,7 @@ OptionsWidget_soundGeneral::OptionsWidget_soundGeneral(QWidget * parent)
 	                          "options"));
 
 	h = new KviTalHBox(g);
+	setBasicTip(h, g_stringOptionsTable[KviOption_stringPreferredMediaPlayer].name);
 
 	m_pMediaPlayerBox = new QComboBox(h);
 
@@ -94,6 +96,7 @@ OptionsWidget_soundGeneral::OptionsWidget_soundGeneral(QWidget * parent)
 	h = new KviTalHBox(g);
 
 	m_pTagsEncodingCombo = new QComboBox(h);
+	setBasicTip(m_pTagsEncodingCombo, g_stringOptionsTable[KviOption_stringMp3TagsEncoding].name);
 	m_pTagsEncodingCombo->addItem(__tr2qs_ctx("Use Language Encoding", "options"));
 
 	int i = 0;

--- a/src/modules/options/OptionsWidget_textEncoding.cpp
+++ b/src/modules/options/OptionsWidget_textEncoding.cpp
@@ -49,17 +49,23 @@ OptionsWidget_textEncoding::OptionsWidget_textEncoding(QWidget * parent)
 	gbox->setLayout(grid);
 
 	//server encoding
-	grid->addWidget(addLabel(gbox, __tr2qs_ctx("Default server encoding:", "options")), 0, 0);
+	QLabel * pLabel = addLabel(gbox, __tr2qs_ctx("Default server encoding:", "options"));
+	setBasicTip(pLabel, g_stringOptionsTable[KviOption_stringDefaultSrvEncoding].name);
+	grid->addWidget(pLabel, 0, 0);
 
 	m_pSrvEncodingCombo = new QComboBox(gbox);
+	setBasicTip(m_pSrvEncodingCombo, g_stringOptionsTable[KviOption_stringDefaultSrvEncoding].name);
 	grid->addWidget(m_pSrvEncodingCombo, 0, 1);
 
 	m_pSrvEncodingCombo->addItem(__tr2qs_ctx("Use Language Encoding", "options"));
 
 	//text encoding
-	grid->addWidget(addLabel(gbox, __tr2qs_ctx("Default text encoding:", "options")), 1, 0);
+	pLabel = addLabel(gbox, __tr2qs_ctx("Default text encoding:", "options"));
+	setBasicTip(pLabel, g_stringOptionsTable[KviOption_stringDefaultTextEncoding].name);
+	grid->addWidget(pLabel, 1, 0);
 
 	m_pTextEncodingCombo = new QComboBox(gbox);
+	setBasicTip(m_pTextEncodingCombo, g_stringOptionsTable[KviOption_stringDefaultTextEncoding].name);
 	grid->addWidget(m_pTextEncodingCombo, 1, 1);
 
 	m_pTextEncodingCombo->addItem(__tr2qs_ctx("Use Language Encoding", "options"));

--- a/src/modules/options/OptionsWidget_userList.cpp
+++ b/src/modules/options/OptionsWidget_userList.cpp
@@ -90,6 +90,7 @@ OptionsWidget_userListGrid::OptionsWidget_userListGrid(QWidget * parent)
 	connect(b, SIGNAL(toggled(bool)), s, SLOT(setEnabled(bool)));
 
 	KviTalHBox * hb = new KviTalHBox(this);
+	setBasicTip(hb, g_uintOptionsTable[KviOption_uintUserListViewGridType].name);
 	addWidgetToLayout(hb, 0, 2, 0, 2);
 	hb->setSpacing(4);
 
@@ -130,12 +131,16 @@ OptionsWidget_userListBackground::OptionsWidget_userListBackground(QWidget * par
 
 	addPixmapSelector(0, 1, 1, 1, __tr2qs_ctx("Background image:", "options"), KviOption_pixmapUserListViewBackground);
 
-	addLabel(0, 2, 0, 2, __tr2qs_ctx("Horizontal alignment:", "options"));
+	QLabel * pLabel = addLabel(0, 2, 0, 2, __tr2qs_ctx("Horizontal alignment:", "options"));
+	setBasicTip(pLabel, g_uintOptionsTable[KviOption_uintUserListPixmapAlign].name);
 	m_pHorizontalAlign = new QComboBox(this);
+	setBasicTip(m_pHorizontalAlign, g_uintOptionsTable[KviOption_uintUserListPixmapAlign].name);
 	addWidgetToLayout(m_pHorizontalAlign, 1, 2, 1, 2);
 
-	addLabel(0, 3, 0, 3, __tr2qs_ctx("Vertical alignment:", "options"));
+	pLabel = addLabel(0, 3, 0, 3, __tr2qs_ctx("Vertical alignment:", "options"));
+	setBasicTip(pLabel, g_uintOptionsTable[KviOption_uintUserListPixmapAlign].name);
 	m_pVerticalAlign = new QComboBox(this);
+	setBasicTip(m_pVerticalAlign, g_uintOptionsTable[KviOption_uintUserListPixmapAlign].name);
 	addWidgetToLayout(m_pVerticalAlign, 1, 3, 1, 3);
 
 	m_pHorizontalAlign->addItem(__tr2qs_ctx("Tile", "options"));

--- a/src/modules/options/OptionsWidget_windowList.cpp
+++ b/src/modules/options/OptionsWidget_windowList.cpp
@@ -105,12 +105,16 @@ OptionsWidget_windowListTreeBackground::OptionsWidget_windowListTreeBackground(Q
 
 	addPixmapSelector(0, 1, 1, 1, __tr2qs_ctx("Background image:", "options"), KviOption_pixmapTreeWindowListBackground);
 
-	addLabel(0, 2, 0, 2, __tr2qs_ctx("Horizontal align:", "options"));
+	QLabel * pLabel = addLabel(0, 2, 0, 2, __tr2qs_ctx("Horizontal align:", "options"));
+	setBasicTip(pLabel, g_uintOptionsTable[KviOption_uintTreeWindowListPixmapAlign].name);
 	m_pHorizontalAlign = new QComboBox(this);
+	setBasicTip(m_pHorizontalAlign, g_uintOptionsTable[KviOption_uintTreeWindowListPixmapAlign].name);
 	addWidgetToLayout(m_pHorizontalAlign, 1, 2, 1, 2);
 
-	addLabel(0, 3, 0, 3, __tr2qs_ctx("Vertical align:", "options"));
+	pLabel = addLabel(0, 3, 0, 3, __tr2qs_ctx("Vertical align:", "options"));
+	setBasicTip(pLabel, g_uintOptionsTable[KviOption_uintTreeWindowListPixmapAlign].name);
 	m_pVerticalAlign = new QComboBox(this);
+	setBasicTip(m_pVerticalAlign, g_uintOptionsTable[KviOption_uintTreeWindowListPixmapAlign].name);
 	addWidgetToLayout(m_pVerticalAlign, 1, 3, 1, 3);
 
 	m_pHorizontalAlign->addItem(__tr2qs_ctx("Tile", "options"));


### PR DESCRIPTION
This pull request addresses #2216.

#### Changes proposed
- Expand standard nickname completion to allow re-ordering the matches. (bash-like completion is unaffected.)
- Fix a bug whereby a nickname completion made using `Shift`+`Tab` in standard mode was always treated as the last match.
- Add a new option, `uintNickCompletionOrder`, that governs how the matches are ordered. The options are as follows:
  - `0`: The same order as in the user list: by status, then alphabetical (the previous behaviour).
  - `1`: Alphabetical, A to Z.
  - `2` (default): By last action time, most to least recent.
- Add `/option` tooltips for more controls in the options dialog.

![K2j5R8n](https://i.imgur.com/K2j5R8n.png)


