### PR TITLE
Escape things in the class editor. Fixes #2211.

### DIFF
--- a/src/kvirc/kvs/object/KviKvsObjectClass.cpp
+++ b/src/kvirc/kvs/object/KviKvsObjectClass.cpp
@@ -193,12 +193,15 @@ bool KviKvsObjectClass::save(const QString & szFileName)
 	{
 		if(h->isScriptHandler() && !h->isClone())
 		{
+			QString reminder = h->reminder();
+			KviQString::escapeKvs(&reminder);
+
 			szBuffer += "	";
 			if(h->flags() & KviKvsObjectFunctionHandler::Internal)
 				szBuffer += "internal ";
 			szBuffer += "function ";
 			szBuffer += it.currentKey();
-			szBuffer += "(" + h->reminder() + ")\n";
+			szBuffer += "(\"" + reminder + "\")\n";
 			QString szCode = h->scriptHandlerCode();
 			KviCommandFormatter::blockFromBuffer(szCode);
 			KviCommandFormatter::indent(szCode);

--- a/src/modules/classeditor/ClassEditorWindow.cpp
+++ b/src/modules/classeditor/ClassEditorWindow.cpp
@@ -808,7 +808,7 @@ void ClassEditorWidget::currentItemChanged(QTreeWidgetItem * pTree, QTreeWidgetI
 		{
 			QString szReminderText = __tr2qs_ctx("Reminder text.", "editor");
 			szReminderText += ": <b>";
-			szReminderText += m_pLastEditedItem->reminder();
+			szReminderText += m_pLastEditedItem->reminder().toHtmlEscaped();
 			szReminderText += "</b>";
 			m_pReminderLabel->setText(szReminderText);
 			m_pReminderLabel->show();
@@ -1054,12 +1054,15 @@ void ClassEditorWidget::exportClassBuffer(QString & szBuffer, ClassEditorTreeWid
 		ClassEditorTreeWidgetItem * pFunction = (ClassEditorTreeWidgetItem *)pItem->child(i);
 		if(pFunction->isMethod())
 		{
+			QString reminder = pFunction->reminder();
+			KviQString::escapeKvs(&reminder);
+
 			szBuffer += "\t";
 			if(pFunction->isInternalFunction())
 				szBuffer += "internal ";
 			szBuffer += "function ";
 			szBuffer += pFunction->name();
-			szBuffer += "(" + pFunction->reminder() + ")\n";
+			szBuffer += "(\"" + reminder + "\")\n";
 			QString szCode = pFunction->buffer();
 			KviCommandFormatter::blockFromBuffer(szCode);
 			KviCommandFormatter::indent(szCode);


### PR DESCRIPTION
#### Changes proposed
- When building classes, function reminder text is now quoted and escaped. This fixes the first part of the issue report. The same change is applied when exporting classes.
- Reminder text is now HTML-encoded before being displayed. This fixes the second part of the issue report. I'm not sure whether it would be helpful to allow HTML tags there, but it seems simpler to escape them.
