### PR TITLE
Fix invalid IP integer for DCC RSEND request

### DIFF
--- a/src/modules/dcc/DccBroker.cpp
+++ b/src/modules/dcc/DccBroker.cpp
@@ -241,8 +241,7 @@ void DccBroker::rsendExecute(DccDescriptor * dcc)
 		szTag = t->m_szTag;
 
 		// DCC [ST]SEND <filename> <fakeipaddress> <zero-port> <filesize> <sessionid>
-		// 127.0.0.1 is not an integer. Maybe 0 or 2130706433 would be better...
-		dcc->console()->connection()->sendFmtData("PRIVMSG %s :%cDCC %s %s 0 0 %s %s%c",
+		dcc->console()->connection()->sendFmtData("PRIVMSG %s :%cDCC %s %s 2130706433 0 %s %s%c",
 		    dcc->console()->connection()->encodeText(dcc->szNick).data(),
 		    0x01,
 		    dcc->console()->connection()->encodeText(dcc->szType).data(),

--- a/src/modules/dcc/DccBroker.cpp
+++ b/src/modules/dcc/DccBroker.cpp
@@ -241,7 +241,8 @@ void DccBroker::rsendExecute(DccDescriptor * dcc)
 		szTag = t->m_szTag;
 
 		// DCC [ST]SEND <filename> <fakeipaddress> <zero-port> <filesize> <sessionid>
-		dcc->console()->connection()->sendFmtData("PRIVMSG %s :%cDCC %s %s 127.0.0.1 0 %s %s%c",
+		// 127.0.0.1 is not an integer. Maybe 0 or 2130706433 would be better...
+		dcc->console()->connection()->sendFmtData("PRIVMSG %s :%cDCC %s %s 0 0 %s %s%c",
 		    dcc->console()->connection()->encodeText(dcc->szNick).data(),
 		    0x01,
 		    dcc->console()->connection()->encodeText(dcc->szType).data(),


### PR DESCRIPTION
Fixes #2251 

#### Changes proposed
- Instead of hardcoding "127.0.0.1" in the string message, since the IP is supposed to be sent in integer form and not all clients are able to parse the message correctly if it remains like so, I propose to send 0 or 2130706433 (which would be 127.0.0.1) instead.

