### PR TITLE
Clean up the names of event handlers

### DIFF
--- a/src/kvirc/kvs/KviKvsCoreCallbackCommands.cpp
+++ b/src/kvirc/kvs/KviKvsCoreCallbackCommands.cpp
@@ -530,6 +530,10 @@ namespace KviKvsCoreCallbackCommands
 			list instead of being added.[br]
 			The <event_name> may be one of the KVIrc builtin event names
 			or a numeric code (from 0 to 999) of a RAW server message.[br]
+			<handler_name> can only contain alphanumeric characters. If the
+			provided handler name contains invalid characters, they are
+			silently removed. If the provided handler name does not contain
+			a single valid character, the handler will be named "unnamed".[br]
 			If the -q switch is specified then the command runs in quiet mode.
 		@seealso:
 			[cmd]eventctl[/cmd] [fnc]$iseventenabled[/fnc]
@@ -558,6 +562,7 @@ namespace KviKvsCoreCallbackCommands
 		}
 		else
 		{
+			KviKvsEventManager::instance()->cleanHandlerName(szHandlerName);
 			iNumber = KviKvsEventManager::instance()->findAppEventIndexByName(szEventName);
 			if(!KviKvsEventManager::instance()->isValidAppEvent(iNumber))
 			{

--- a/src/kvirc/kvs/KviKvsCoreSimpleCommands_af.cpp
+++ b/src/kvirc/kvs/KviKvsCoreSimpleCommands_af.cpp
@@ -1498,6 +1498,7 @@ namespace KviKvsCoreSimpleCommands
 		}
 		else
 		{
+			KviKvsEventManager::instance()->cleanHandlerName(szHandlerName);
 			iNumber = KviKvsEventManager::instance()->findAppEventIndexByName(szEventName);
 			if(!KviKvsEventManager::instance()->isValidAppEvent(iNumber))
 			{

--- a/src/kvirc/kvs/event/KviKvsEventManager.cpp
+++ b/src/kvirc/kvs/event/KviKvsEventManager.cpp
@@ -33,6 +33,8 @@
 #include "KviWindow.h"
 #include "KviKvsVariantList.h"
 
+#include <QRegExp>
+
 /*
 	@doc: events
 	@type:
@@ -634,5 +636,14 @@ void KviKvsEventManager::saveAppEvents(const QString & szFileName)
 			if((i == 4) && !bCompat)
 				i--;
 		}
+	}
+}
+
+void KviKvsEventManager::cleanHandlerName(QString & szHandlerName)
+{
+	szHandlerName.replace(invalidHandlerNameCharsRegExp, "");
+	if (szHandlerName.isEmpty())
+	{
+		szHandlerName = "unnamed";
 	}
 }

--- a/src/kvirc/kvs/event/KviKvsEventManager.h
+++ b/src/kvirc/kvs/event/KviKvsEventManager.h
@@ -36,6 +36,9 @@ class KviKvsVariantList;
 
 #define KVI_KVS_NUM_RAW_EVENTS 1000
 
+const QRegExp handlerNameRegExp = QRegExp("^[A-Za-z0-9_]*$");
+const QRegExp invalidHandlerNameCharsRegExp = QRegExp("[^A-Za-z0-9_]");
+
 class KVIRC_API KviKvsEventManager : public QObject
 {
 	Q_OBJECT
@@ -127,6 +130,8 @@ public:
 	void saveAppEvents(const QString & szFileName);
 	void loadRawEvents(const QString & szFileName);
 	void saveRawEvents(const QString & szFileName);
+
+	void cleanHandlerName(QString & szHandlerName);
 signals:
 	void eventHandlerDisabled(const QString &);
 };

--- a/src/modules/eventeditor/EventEditorWindow.cpp
+++ b/src/modules/eventeditor/EventEditorWindow.cpp
@@ -112,9 +112,13 @@ EventEditor::EventEditor(QWidget * par)
 
 	m_pNameEditor = new QLineEdit(box);
 	m_pNameEditor->setToolTip(__tr2qs_ctx("Edit the event handler name.", "editor"));
+	QRegExpValidator * pValidator = new QRegExpValidator(handlerNameRegExp, this);
+	m_pNameEditor->setValidator(pValidator);
+	m_pNameEditor->setEnabled(false);
 
 	m_pEditor = KviScriptEditor::createInstance(box);
 	m_pEditor->setFocus();
+	m_pEditor->setEnabled(false);
 	m_bOneTimeSetupDone = false;
 	m_pLastEditedItem = nullptr;
 }
@@ -368,8 +372,7 @@ void EventEditor::saveLastEditedItem()
 		return;
 	((EventEditorHandlerTreeWidgetItem *)m_pLastEditedItem)->setCursorPosition(m_pEditor->getCursor());
 	QString buffer = m_pNameEditor->text();
-	//not-so elaborate fix for #218, we'd better rework this
-	buffer.replace(QRegExp("[^A-Za-z0-9_]"), "");
+	KviKvsEventManager::instance()->cleanHandlerName(buffer);
 	if(!KviQString::equalCI(buffer, m_pLastEditedItem->m_szName))
 	{
 		getUniqueHandlerName((EventEditorEventTreeWidgetItem *)(m_pLastEditedItem->parent()), buffer);

--- a/src/modules/eventeditor/EventEditorWindow.h
+++ b/src/modules/eventeditor/EventEditorWindow.h
@@ -66,7 +66,6 @@ public:
 	const int & cursorPosition() { return m_cPos; };
 	void setCursorPosition(const int & cPos)
 	{
-		qDebug("set cursor to %d", cPos);
 		m_cPos = cPos;
 	};
 


### PR DESCRIPTION
This is a tentative fix for #1959. Since there was some heated discussion in that ticket I'm not committing it without a pr. I'm not sure it's the best solution but I think it's a step in the right direction.
