### PR TITLE
Enable appveyor's fast_fail strategy

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -51,7 +51,8 @@ environment:
           mingw_fourple: mingw32/mingw-w64-i686
           mingw_root: c:/msys64/mingw32
           mingw_libgcc: libgcc_s_dw2-1.dll
-        fast_finish: true
+matrix:
+    fast_finish: true
 install:
     - systeminfo
     - c:\cygwin\bin\uname -a

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -147,7 +147,7 @@ build_script:
             windeployqt "--pdb" "--dir" "release/qt-plugins" "--libdir" "release/" "release/kvirc.exe" "release/modules/"
         } else {
             windeployqt "--dir" "release/qt-plugins" "--libdir" "release/" "release/kvirc.exe" "release/modules/"
-        }
+        } 
     - c:\cygwin\bin\ls -l release/
     - ps: |
         if ($env:cmake_build_type -eq "Debug") {

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -51,6 +51,7 @@ environment:
           mingw_fourple: mingw32/mingw-w64-i686
           mingw_root: c:/msys64/mingw32
           mingw_libgcc: libgcc_s_dw2-1.dll
+        fast_finish: true
 install:
     - systeminfo
     - c:\cygwin\bin\uname -a
@@ -145,7 +146,7 @@ build_script:
             windeployqt "--pdb" "--dir" "release/qt-plugins" "--libdir" "release/" "release/kvirc.exe" "release/modules/"
         } else {
             windeployqt "--dir" "release/qt-plugins" "--libdir" "release/" "release/kvirc.exe" "release/modules/"
-        } 
+        }
     - c:\cygwin\bin\ls -l release/
     - ps: |
         if ($env:cmake_build_type -eq "Debug") {


### PR DESCRIPTION
By default AppVeyor runs all build jobs. If at least one job has failed the entire build is marked as failed.

Docs: https://www.appveyor.com/docs/build-configuration/#failing-strategy

[//]: # (If your pull request is a fix to an open issue please add fixes #9999 to the commit comments.)
[//]: # (If your proposal involves GUI improvements, add screenshots of before and after to help visualise the proposal on the fly.)
#### Changes proposed
-
-
-

[//]: # (If you have write privileges to repository, do label your pull request, else you could insert a mention prefixed with @GitHub-Username below.)

