### PR TITLE
cache the Strawberry dir

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -116,9 +116,9 @@ install:
         if (Test-Path "c:/spellcheck-dicts/zip/en_US.zip") {
             echo "using en dict from cache"
         } else {
-            (New-Object Net.WebClient).DownloadFile('http://sourceforge.net/projects/wordlist/files/speller/2017.01.22/hunspell-en_US-2017.01.22.zip', 'c:\spellcheck-dicts\zip\en_US.zip')
-            (New-Object Net.WebClient).DownloadFile('http://sourceforge.net/projects/wordlist/files/speller/2017.01.22/hunspell-en_GB-ize-2017.01.22.zip', 'c:\spellcheck-dicts\zip\en_GB-ize.zip')
-            (New-Object Net.WebClient).DownloadFile('http://sourceforge.net/projects/wordlist/files/speller/2017.01.22/hunspell-en_GB-ise-2017.01.22.zip', 'c:\spellcheck-dicts\zip\en_GB-ise.zip')
+            (New-Object Net.WebClient).DownloadFile('https://sourceforge.net/projects/wordlist/files/speller/2017.01.22/hunspell-en_US-2017.01.22.zip', 'c:\spellcheck-dicts\zip\en_US.zip')
+            (New-Object Net.WebClient).DownloadFile('https://sourceforge.net/projects/wordlist/files/speller/2017.01.22/hunspell-en_GB-ize-2017.01.22.zip', 'c:\spellcheck-dicts\zip\en_GB-ize.zip')
+            (New-Object Net.WebClient).DownloadFile('https://sourceforge.net/projects/wordlist/files/speller/2017.01.22/hunspell-en_GB-ise-2017.01.22.zip', 'c:\spellcheck-dicts\zip\en_GB-ise.zip')
             c:\cygwin\bin\bash -lc "cd /cygdrive/c/spellcheck-dicts/unzip; 7z x -y ../zip/en_US.zip; 7z x -y ../zip/en_GB-ize.zip; 7z x -y ../zip/en_GB-ise.zip"
         }
     - c:\cygwin\bin\ls -lR /cygdrive/c/spellcheck-dicts

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ cache:
     - c:\Strawberry -> .appveyor.yml
 environment:
     matrix:
-        - cmake_build_type: Debug
+        - cmake_build_type: Release
           arch: x64
           target_arch: x86_64
           ssl_arch: Win64
@@ -18,7 +18,7 @@ environment:
           mingw_root: c:/msys64/mingw64
           mingw_libgcc: libgcc_s_seh-1.dll
 
-        - cmake_build_type: Debug
+        - cmake_build_type: Release
           arch: x86
           target_arch: x86
           ssl_arch: Win32
@@ -31,7 +31,7 @@ environment:
           mingw_root: c:/msys64/mingw32
           mingw_libgcc: libgcc_s_dw2-1.dll
 
-        - cmake_build_type: Release
+        - cmake_build_type: Debug
           arch: x64
           target_arch: x86_64
           ssl_arch: Win64
@@ -44,7 +44,7 @@ environment:
           mingw_root: c:/msys64/mingw64
           mingw_libgcc: libgcc_s_seh-1.dll
 
-        - cmake_build_type: Release
+        - cmake_build_type: Debug
           arch: x86
           target_arch: x86
           ssl_arch: Win32

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,6 +2,7 @@ version: 0.0.0.0.1-branch-{branch}-build-{build}
 cache:
     - c:\deps -> .appveyor.yml
     - c:\spellcheck-dicts -> .appveyor.yml
+    - c:\Strawberry -> .appveyor.yml
 environment:
     matrix:
         - cmake_build_type: Debug
@@ -151,7 +152,7 @@ build_script:
             windeployqt "--pdb" "--dir" "release/qt-plugins" "--libdir" "release/" "release/kvirc.exe" "release/modules/"
         } else {
             windeployqt "--dir" "release/qt-plugins" "--libdir" "release/" "release/kvirc.exe" "release/modules/"
-        } 
+        }
     - c:\cygwin\bin\ls -l release/
     - ps: |
         if ($env:cmake_build_type -eq "Debug") {

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Welcome, this is the GitHub development and bug tracker home for the KVIrc project.
 
-KVIrc is a free and portable IRC client leveraging the Qt GUI toolkit.  
+KVIrc is a free and portable IRC client leveraging the Qt GUI toolkit.
 KVIrc is written by Szymon Stefanek and the KVIrc development team, with the contribution and support of many IRC addicted developers around the world.
 
 ### Getting involved


### PR DESCRIPTION
I actually wanted to cache the Chocolatey dir first but the appveyor config is a bit weird, in the logs it looked like it should use some sort of cached/already existing strawberry installation but that is never true on appveyor so it always downloads and installs and then patches it, this caching should make this faster.