### PR TITLE
revert fast finish and let other builds attempt and likely build.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -51,8 +51,6 @@ environment:
           mingw_fourple: mingw32/mingw-w64-i686
           mingw_root: c:/msys64/mingw32
           mingw_libgcc: libgcc_s_dw2-1.dll
-matrix:
-    fast_finish: true
 install:
     - systeminfo
     - c:\cygwin\bin\uname -a


### PR DESCRIPTION
```
matrix:
    fast_finish: true
```
Causes all other builds after a failed build to be cancelled, which means if the first build fails all other 3 are cancelled and no artifacts and or builds for Windows.

e.g. fast fail 
1st build failed all cancelled https://ci.appveyor.com/project/DarthGandalf/kvirc/build/0.0.0.0.1-branch-master-build-2377
e.g. no fast_build
1st build failed all others ran and finished OK https://ci.appveyor.com/project/DarthGandalf/kvirc/build/0.0.0.0.1-branch-master-build-2366

#### I looked for **practical examples** where first build failed (a debug build) and all release builds where OK

[//]: # (If your pull request is a fix to an open issue please add fixes #9999 to the commit comments.)
[//]: # (If your proposal involves GUI improvements, add screenshots of before and after to help visualise the proposal on the fly.)
#### Changes proposed
- remove fast_fail strategy, and allow other builds to be attempted so we can have artifacts and usable builds.

The ONLY logical argument for this is, builds fail more often for external unrelated code changes than for actual bad code, Users that depend on appveyor builds for their updated binaries at least stand a better change of getting the usual binaries that work rather than nothing at all.

[//]: # (If you have write privileges to repository, do label your pull request, else you could insert a mention prefixed with @GitHub-Username below.)

