### PR TITLE
Remove EventEditorWindow.setCurrentHandlerEnabled.

### DIFF
--- a/src/modules/eventeditor/EventEditorWindow.h
+++ b/src/modules/eventeditor/EventEditorWindow.h
@@ -114,7 +114,6 @@ public:
 protected slots:
 	void currentItemChanged(QTreeWidgetItem * it, QTreeWidgetItem *);
 	void itemPressed(QTreeWidgetItem * it, const QPoint & pnt);
-	void setCurrentHandlerEnabled();
 	void toggleCurrentHandlerEnabled();
 	void removeCurrentHandler();
 	void addHandlerForCurrentEvent();


### PR DESCRIPTION
#### Changes proposed
- Remove [`EventEditorWindow.setCurrentHandlerEnabled`](https://github.com/kvirc/KVIrc/blob/82f44408f63075903c6fd9ff1fb4765caf840d47/src/modules/eventeditor/EventEditorWindow.h#L117), which had no implementation and was never used.

This fixes a build error.