### PR TITLE
Fix the sound system autodetection

### DIFF
--- a/src/modules/setup/libkvisetup.cpp
+++ b/src/modules/setup/libkvisetup.cpp
@@ -33,9 +33,12 @@
 #include "KviWindow.h"
 #include "KviTheme.h"
 #include "KviIrcServerDataBase.h"
+#include "KviModuleManager.h"
 
 #include <QString>
 #include <QFile>
+
+extern KVIRC_API KviModuleManager * g_pModuleManager;
 
 // this will be chosen during the setup process
 QString g_szChoosenIncomingDirectory;
@@ -117,6 +120,11 @@ KVIMODULEEXPORTFUNC void setup_finish()
 			delete pParams;
 			KVI_OPTION_BOOL(KviOption_boolShowServersConnectDialogOnStart) = true;
 		}
+
+		// detect the most appropriate sound system
+		KviModule * m = g_pModuleManager->getModule("snd");
+		if(m)
+			m->ctrl("detectSoundSystem", nullptr);
 	}
 }
 

--- a/src/modules/snd/libkvisnd.cpp
+++ b/src/modules/snd/libkvisnd.cpp
@@ -210,16 +210,6 @@ bool KviSoundPlayer::event(QEvent * e)
 
 void KviSoundPlayer::detectSoundSystem()
 {
-#ifdef COMPILE_PHONON_SUPPORT
-	// FIXME: Phonon seems to freeze on windows sometimes.. maybe it's better to auto-detect winmm ?
-	if(!m_pPhononPlayer)
-		m_pPhononPlayer = Phonon::createPlayer(Phonon::MusicCategory);
-	if(m_pPhononPlayer->state() != Phonon::ErrorState)
-	{
-		KVI_OPTION_STRING(KviOption_stringSoundSystem) = "phonon";
-		return;
-	}
-#endif
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
 	KVI_OPTION_STRING(KviOption_stringSoundSystem) = "winmm";
 #else


### PR DESCRIPTION
1. We didn't detect an appropriate sound system during startup so Windows was left with "null". Now it should default to "winmm".

2. The phonon detection code was broken (#2277) so unless someone wants to fix it, it's better if we simply default to "qt", which (I assume) will always work, unlike "phonon".

This is meant to fix #2277 and #1730