### PR TITLE
Improve the script tester a little bit

### DIFF
--- a/src/modules/codetester/CodeTesterWindow.cpp
+++ b/src/modules/codetester/CodeTesterWindow.cpp
@@ -75,8 +75,7 @@ CodeTesterWindow::CodeTesterWindow()
 
 	m_pIrcView = new KviIrcView(m_pSplitter, this);
 
-	QList<int> li;
-	li << width() / 2 << width() / 2;
+	QList<int> li { width() / 2, width() / 2 };
 	m_pSplitter->setSizes(li);
 }
 

--- a/src/modules/codetester/CodeTesterWindow.cpp
+++ b/src/modules/codetester/CodeTesterWindow.cpp
@@ -34,6 +34,7 @@
 #include "KviConsoleWindow.h"
 #include "KviKvsScript.h"
 #include "KviKvsVariantList.h"
+#include "KviIrcView.h"
 
 #include <QPushButton>
 #include <QLayout>
@@ -44,11 +45,19 @@
 
 extern std::unordered_set<CodeTesterWindow *> g_pCodeTesterWindowList;
 
-CodeTesterWidget::CodeTesterWidget(QWidget * par)
-    : QWidget(par)
+CodeTesterWindow::CodeTesterWindow()
+    : KviWindow(KviWindow::ScriptEditor, "codetester", nullptr)
 {
+	g_pCodeTesterWindowList.insert(this);
 	setObjectName("code_tester");
-	QGridLayout * g = new QGridLayout(this);
+
+	m_pSplitter = new KviTalSplitter(Qt::Horizontal, this);
+	m_pSplitter->setObjectName("main_splitter");
+	m_pSplitter->setChildrenCollapsible(false);
+
+	// layouts can't be added to splitters directly, so we embed the layout in a widget.
+	QWidget * l = new QWidget(this);
+	QGridLayout * g = new QGridLayout(l);
 	m_pEditor = KviScriptEditor::createInstance(this);
 	g->addWidget(m_pEditor, 0, 0, 1, 4);
 
@@ -61,36 +70,30 @@ CodeTesterWidget::CodeTesterWidget(QWidget * par)
 	m_pParams = new QLineEdit(this);
 	m_pParams->setToolTip(__tr2qs_ctx("Here you can specify a semicolon-separated list of parameters that will be available in the code as $0, $1, $2, ..", "editor"));
 	g->addWidget(m_pParams, 1, 2);
+
+	m_pSplitter->addWidget(l);
+
+	m_pIrcView = new KviIrcView(m_pSplitter, this);
+
+	QList<int> li;
+	li << width() / 2 << width() / 2;
+	m_pSplitter->setSizes(li);
 }
 
-CodeTesterWidget::~CodeTesterWidget()
+CodeTesterWindow::~CodeTesterWindow()
 {
 	KviScriptEditor::destroyInstance(m_pEditor);
+	g_pCodeTesterWindowList.erase(this);
 }
 
-//#warning "Allow to bind the command to a specified window"
-
-void CodeTesterWidget::execute()
+void CodeTesterWindow::execute()
 {
 	QString buffer;
 	m_pEditor->getText(buffer);
 	KviConsoleWindow * pConsole = g_pApp->activeConsole();
 	QStringList slParams = m_pParams->text().split(';');
 	KviKvsVariantList params{&slParams};
-	KviKvsScript::run(buffer, pConsole, &params);
-}
-
-CodeTesterWindow::CodeTesterWindow()
-    : KviWindow(KviWindow::ScriptEditor, "codetester", nullptr)
-{
-	g_pCodeTesterWindowList.insert(this);
-
-	m_pTester = new CodeTesterWidget(this);
-}
-
-CodeTesterWindow::~CodeTesterWindow()
-{
-	g_pCodeTesterWindowList.erase(this);
+	KviKvsScript::run(buffer, this, &params);
 }
 
 QPixmap * CodeTesterWindow::myIconPtr()
@@ -100,7 +103,7 @@ QPixmap * CodeTesterWindow::myIconPtr()
 
 void CodeTesterWindow::resizeEvent(QResizeEvent *)
 {
-	m_pTester->setGeometry(0, 0, width(), height());
+	m_pSplitter->setGeometry(0, 0, width(), height());
 }
 
 void CodeTesterWindow::fillCaptionBuffers()

--- a/src/modules/codetester/CodeTesterWindow.h
+++ b/src/modules/codetester/CodeTesterWindow.h
@@ -33,22 +33,6 @@ class QPushButton;
 class QLabel;
 class KviScriptEditor;
 
-class CodeTesterWidget : public QWidget
-{
-	Q_OBJECT
-public:
-	CodeTesterWidget(QWidget * par);
-	~CodeTesterWidget();
-
-private:
-	KviScriptEditor * m_pEditor;
-	QLineEdit * m_pParams;
-	QPushButton * m_pExecuteButton;
-	QLabel * m_pModeLabel;
-private slots:
-	void execute();
-};
-
 class CodeTesterWindow : public KviWindow
 {
 	Q_OBJECT
@@ -56,8 +40,15 @@ public:
 	CodeTesterWindow();
 	~CodeTesterWindow();
 
-protected:
-	CodeTesterWidget * m_pTester;
+private:
+	KviTalSplitter * m_pSplitter;
+	KviScriptEditor * m_pEditor;
+	QPushButton * m_pExecuteButton;
+	QLabel * m_pModeLabel;
+	QLineEdit * m_pParams;
+
+private slots:
+	void execute();
 
 protected:
 	virtual QPixmap * myIconPtr();

--- a/src/modules/editor/ScriptEditorImplementation.cpp
+++ b/src/modules/editor/ScriptEditorImplementation.cpp
@@ -317,10 +317,6 @@ void ScriptEditorWidget::updateOptions()
 	disableSyntaxHighlighter();
 	enableSyntaxHighlighter();
 
-	p = ((ScriptEditorImplementation *)m_pParent)->findLineEdit()->palette();
-	p.setColor(foregroundRole(), g_clrFind);
-	((ScriptEditorImplementation *)m_pParent)->findLineEdit()->setPalette(p);
-
 	//set cursor custom width
 	if(KVI_OPTION_BOOL(KviOption_boolEnableCustomCursorWidth))
 	{
@@ -715,16 +711,16 @@ ScriptEditorImplementation::ScriptEditorImplementation(QWidget * par)
 	m_lastCursorPos = 0;
 	QGridLayout * g = new QGridLayout(this);
 
+	m_pEditor = new ScriptEditorWidget(this);
+
 	m_pFindLineEdit = new QLineEdit(" ", this);
 	m_pFindLineEdit->setText("");
 
 	QPalette p = m_pFindLineEdit->palette();
-	p.setColor(foregroundRole(), g_clrFind);
+	p.setColor(QPalette::Text, g_clrFind);
 	m_pFindLineEdit->setPalette(p);
 
-	m_pEditor = new ScriptEditorWidget(this);
-
-	g->addWidget(m_pEditor, 0, 0, 1, 4);
+	g->addWidget(m_pEditor, 0, 0, 1, 5);
 	g->setRowStretch(0, 1);
 
 	QToolButton * b = new QToolButton(this);
@@ -753,13 +749,18 @@ ScriptEditorImplementation::ScriptEditorImplementation(QWidget * par)
 	pLab->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
 	g->addWidget(pLab, 1, 1);
 
+	m_pFindButton = new QPushButton(QString(__tr2qs_ctx("&Find", "editor")), this);
+	g->addWidget(m_pFindButton, 1, 3);
+
 	m_pRowColLabel = new QLabel(QString(__tr2qs_ctx("Line: %1 Col: %2", "editor")).arg(1).arg(1), this);
 	m_pRowColLabel->setFrameStyle(QFrame::Sunken | QFrame::Panel);
 	m_pRowColLabel->setMinimumWidth(80);
-	g->addWidget(m_pRowColLabel, 1, 3);
+	g->addWidget(m_pRowColLabel, 1, 4);
 
 	connect(m_pFindLineEdit, SIGNAL(returnPressed()), m_pEditor, SLOT(slotFind()));
 	connect(m_pFindLineEdit, SIGNAL(returnPressed()), this, SLOT(slotFind()));
+	connect(m_pFindButton, SIGNAL(clicked()), m_pEditor, SLOT(slotFind()));
+	connect(m_pFindButton, SIGNAL(clicked()), this, SLOT(slotFind()));
 	connect(m_pEditor, SIGNAL(cursorPositionChanged()), this, SLOT(updateRowColLabel()));
 	connect(m_pEditor, SIGNAL(selectionChanged()), this, SLOT(updateRowColLabel()));
 	m_lastCursorPos = 0;

--- a/src/modules/editor/ScriptEditorImplementation.h
+++ b/src/modules/editor/ScriptEditorImplementation.h
@@ -155,6 +155,7 @@ protected:
 	ScriptEditorWidgetColorOptions * m_pOptionsDialog;
 	ScriptEditorWidget * m_pEditor;
 	QLabel * m_pRowColLabel;
+	QPushButton * m_pFindButton;
 	int m_lastCursorPos;
 
 public:


### PR DESCRIPTION
* Now the code editor is focused when the script tester is open, instead of the find bar. I have also added a find button to all code editors, and I have fixed the colour of the "find" qlineedit, which has been broken since forever.

* A dedicated ircview has been added for the script tester, which is the default target for `echo`/etc. This would close #1758