### PR TITLE
OptionsWidget_message: fix label text "Use specified smart colors for own nick:"

### DIFF
--- a/src/modules/options/OptionsWidget_message.cpp
+++ b/src/modules/options/OptionsWidget_message.cpp
@@ -77,7 +77,7 @@ OptionsWidget_privmsg::OptionsWidget_privmsg(QWidget * parent)
 
 	KviTalHBox * hb = new KviTalHBox(g);
 	hb->setSpacing(4);
-	m_pSpecialSmartColorSelector = addBoolSelector(hb, __tr2qs_ctx("Use specified colors for own nick:", "options"), KviOption_boolUseSpecifiedSmartColorForOwnNick, KVI_OPTION_BOOL(KviOption_boolColorNicks));
+	m_pSpecialSmartColorSelector = addBoolSelector(hb, __tr2qs_ctx("Use specified smart colors for own nick:", "options"), KviOption_boolUseSpecifiedSmartColorForOwnNick, KVI_OPTION_BOOL(KviOption_boolColorNicks));
 
 	m_pSmartColorSelector = addMircTextColorSelector(hb, "", KviOption_uintUserIrcViewOwnForeground, KviOption_uintUserIrcViewOwnBackground, KVI_OPTION_BOOL(KviOption_boolColorNicks) && KVI_OPTION_BOOL(KviOption_boolUseSpecifiedSmartColorForOwnNick));
 


### PR DESCRIPTION


part resolution for  #2297

[//]: # (If your pull request is a fix to an open issue please add fixes #9999 to the commit comments.)
[//]: # (If your proposal involves GUI improvements, add screenshots of before and after to help visualise the proposal on the fly.)
#### Changes proposed
- Label should reflect **boolUseSpecifiedSmartColorForOwnNick**
-
-

[//]: # (If you have write privileges to repository, do label your pull request, else you could insert a mention prefixed with @GitHub-Username below.)

