### PR TITLE
[libkvifile docs] $file.localdir should document $escape due to popupadd.ExtPopup usecase slash stripping

### DIFF
--- a/src/modules/file/libkvifile.cpp
+++ b/src/modules/file/libkvifile.cpp
@@ -1236,7 +1236,7 @@ static bool file_kvs_cmd_writeLines(KviKvsModuleCommandCall * c)
 		[example]
 			echo KVIrc looks for pictures in $file.localdir(pics)
 			echo panic.png would be translated to $file.localdir(pics/panic.png)
-			echo panic.png would be translated to $escape($file.localdir(pics/panic.png
+			echo panic.png would be translated to $escape($file.localdir(pics/panic.png))
 		[/example]
 	@seealso:
 		[fnc]$escape[/fnc]

--- a/src/modules/file/libkvifile.cpp
+++ b/src/modules/file/libkvifile.cpp
@@ -1219,7 +1219,7 @@ static bool file_kvs_cmd_writeLines(KviKvsModuleCommandCall * c)
 		Returns the path to the KVIrc local data directory.
 		The KVIrc local data directory is always writable and contains
 		the various subdirectories that KVIrc uses internally: audio, avatars,
-		config, help, incoming, log, modules, msgcolors and pics.
+		config, help, incoming, log, modules, msgcolors, events, aliases, actions and pics.
 		[br][br]
 		If <relative_path> is passed, then it is appended to the local directory path.
 		The path is adjusted to contain single separators suitable for the platform
@@ -1234,8 +1234,7 @@ static bool file_kvs_cmd_writeLines(KviKvsModuleCommandCall * c)
 		Overall [b]$escape($file.localdir(pics/panic.png)) is a more correct approach.
 	@examples:
 		[example]
-			echo KVIrc looks for pictures in $file.localdir(pics)
-			echo panic.png would be translated to $file.localdir(pics/panic.png)
+			echo KVIrc looks for pictures in $escape($file.localdir(pics))
 			echo panic.png would be translated to $escape($file.localdir(pics/panic.png))
 		[/example]
 	@seealso:

--- a/src/modules/file/libkvifile.cpp
+++ b/src/modules/file/libkvifile.cpp
@@ -1216,19 +1216,30 @@ static bool file_kvs_cmd_writeLines(KviKvsModuleCommandCall * c)
 	@syntax:
 		<string> $file.localdir([relative_path:string])
 	@description:
-		Returns the path to the KVIrc local data directory.[br][br]
+		Returns the path to the KVIrc local data directory.
 		The KVIrc local data directory is always writable and contains
 		the various subdirectories that KVIrc uses internally: audio, avatars,
-		config, help, incoming, log, modules, msgcolors and pics.[br][br]
-		If <relative_path> is passed, then it is appended to the local directory path.[br][br]
+		config, help, incoming, log, modules, msgcolors and pics.
+		[br][br]
+		If <relative_path> is passed, then it is appended to the local directory path.
 		The path is adjusted to contain single separators suitable for the platform
 		that KVIrc is actually running on (thus you do not need to care about path
-		separators in the <relative_path>, KVIrc will adjust them).[br]
+		separators in the <relative_path>, KVIrc will adjust them).
+		[br][br]
+		When adding popup entries especially via script using [b]popup.addExtPopup[/b]
+		you should escape the path [b]$escape($file.localdir(pics/panic.png))[/b]
+		this is multiOS friendly and adds a custom icon path to Windows that is not broken
+		when KVS parses the context menu entry due to Windows paths being backslashed,
+		which are special characters in KVS that require escaping.[br]
+		Overall [b]$escape($file.localdir(pics/panic.png)) is a more correct approach.
 	@examples:
 		[example]
 			echo KVIrc looks for pictures in $file.localdir(pics)
 			echo panic.png would be translated to $file.localdir(pics/panic.png)
+			echo panic.png would be translated to $escape($file.localdir(pics/panic.png
 		[/example]
+	@seealso:
+		[fnc]$escape[/fnc]
 */
 
 static bool file_kvs_fnc_localdir(KviKvsModuleFunctionCall * c)


### PR DESCRIPTION
See discussion in #2295

[//]: # (If your pull request is a fix to an open issue please add fixes #9999 to the commit comments.)
[//]: # (If your proposal involves GUI improvements, add screenshots of before and after to help visualise the proposal on the fly.)
#### Changes proposed
- add documentation to $file.localdir reference to $escape

[//]: # (If you have write privileges to repository, do label your pull request, else you could insert a mention prefixed with @GitHub-Username below.)

