### PR TITLE
Make the issue/PR templates much simpler

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,0 @@
-###### General guidelines for creating pull requests:
-
-* [**Click here**](https://github.com/kvirc/KVIrc/wiki/Contributing-code-to-KVIrc's-repositories) to read the information from our wiki.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,21 +1,11 @@
-### Expected behavior
+Is this a bug report?
+==============================
+Describe what the problem is. Attach screenshots if you feel like they will help explain the issue better.
+If you can, click "Help → About KVIrc", go to the "Executable Information" tab and copy its contents here. That may help us diagnose the issue.
+If you're experiencing a crash and you think we might not be able to reproduce it for some reason, a backtrace will be helpful: https://github.com/kvirc/KVIrc/wiki/Grabbing-a-useful-backtrace
 
+Is this a feature request?
+==============================
+Describe what you'd like to see implemented, and why you think it's a good idea.
 
-### Actual behavior
-
-
-[//]:# (Besides the text description, include any screenshots that help us visualize the issue you're facing)
-
-### Steps to reproduce the issue
-1.
-2.
-3.
-
-### System information
-[//]:# (Type ```/about.kvirc``` or click "Help → About KVIrc" and copy & paste the details from the "Executable Information" tab below between ``` marks)  
-[//]:# (Also Enter any OS information the "Executable Information" tab doesn't contain, e.g. KDE, Gentoo, Linux Mint, etc.)
-
-```
-
-```
-[//]:# (If you experienced crashes or segfaults please also include a stacktrace below, For how-to read: https://github.com/kvirc/KVIrc/wiki/Grabbing-a-useful-backtrace.)
+Thank you for helping us improve KVIrc!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,3 @@
-[//]: # (If your pull request is a fix to an open issue please add fixes #9999 to the commit comments.)
-[//]: # (If your proposal involves GUI improvements, add screenshots of before and after to help visualise the proposal on the fly.)
-#### Changes proposed
--
--
--
-
-[//]: # (If you have write privileges to repository, do label your pull request, else you could insert a mention prefixed with @GitHub-Username below.)
-
+Describe the changes you're proposing.
+If this pull request is intended to fix a bug, don't forget to mention its #number.
+If there are changes in the GUI, include screenshots of the changes.


### PR DESCRIPTION
I think the current issue/PR templates are very complex. I believe some people might feel intimidated by them, fearing the tickets will be closed or they'll be yelled at if they don't follow the template to the lettter. A bad bug report is better than no bug report at all and if there's some missing info we can always ask for it.