### PR TITLE
show ctcp message on send

### DIFF
--- a/data/defscript/default.kvc
+++ b/data/defscript/default.kvc
@@ -7,6 +7,6 @@ AddonVersion=4.1.1
 AliasVersion=4.1.1.6923
 ClassVersion=4.1.1
 EventVersion=4.1.1.7125
-PopupVersion=4.1.1.7126
+PopupVersion=4.1.1.7190
 RawVersion=4.1.1
 ToolbarVersion=4.1.1.6732

--- a/data/defscript/popups.kvs
+++ b/data/defscript/popups.kvs
@@ -264,51 +264,60 @@ defpopup(ctcp)
 	item(PING,$icon("serverping"))
 	{
 		ctcp $0 PING
+		echo -w=$active -i=$msgtype(GenericStatus) $tr("Sent CTCP PING to","defscript") $b$0$b
 	}
 
 	item(FINGER,$icon("finger"))
 	{
 		ctcp $0 FINGER
+		echo -w=$active -i=$msgtype(GenericStatus) $tr("Sent CTCP FINGER to","defscript") $b$0$b
 	}
 
 	item(VERSION,$icon("kvirc"))
 	{
 		ctcp $0 VERSION
+		echo -w=$active -i=$msgtype(GenericStatus) $tr("Sent CTCP VERSION to","defscript") $b$0$b
 	}
 
 	item(USERINFO,$icon("user"))
 	{
 		ctcp $0 USERINFO
+		echo -w=$active -i=$msgtype(GenericStatus) $tr("Sent CTCP USERINFO to","defscript") $b$0$b
 	}
 
 	item(CLIENTINFO,$icon("serverinfo"))
 	{
 		ctcp $0 CLIENTINFO
+		echo -w=$active -i=$msgtype(GenericStatus) $tr("Sent CTCP CLIENTINFO to","defscript") $b$0$b
 	}
 
 	item(SOURCE,$icon("ctcprequestunknown"))
 	{
 		ctcp $0 SOURCE
+		echo -w=$active -i=$msgtype(GenericStatus) $tr("Sent CTCP SOURCE to","defscript") $b$0$b
 	}
 
 	item(TIME,$icon("time"))
 	{
 		ctcp $0 TIME
+		echo -w=$active -i=$msgtype(GenericStatus) $tr("Sent CTCP TIME to","defscript") $b$0$b
 	}
 
 	item(PAGE...,$icon("messages"))
 	{
 		#dialog.textinput -d=$tr("Wakeup!","defscript") ($tr("CTCP Page to","defscript") $0,$tr("Enter the message text","defscript"),$tr("OK","defscript"),$tr("Cancel","defscript"))
-		dialog.textinput(CTCP Page $0,$tr("Enter the message text","defscript"),$tr("&Page","defscript"),$tr("Cancel","defscript"),"",$0)
+		dialog.textinput(CTCP Page $0,$tr("Enter the message text","defscript"),$tr("&Page","defscript"),$tr("&Cancel","defscript"),"",$0)
 		{
 			if($0 == 0)
 				ctcp $2 PAGE $1
+			echo -w=$active -i=$msgtype(GenericStatus) $tr("Sent CTCP PAGE to","defscript") $b$2$b
 		}
 	}
 
 	item(AVATAR,$icon("avatar"))
 	{
 		ctcp $0 AVATAR
+		echo -w=$active -i=$msgtype(GenericStatus) $tr("Sent CTCP AVATAR to","defscript") $b$0$b
 	}
 }
 
@@ -1836,4 +1845,3 @@ defpopup(channel)
 		avatar.notify $0
 	}
 }
-


### PR DESCRIPTION
there are no -i=$msgtype for the ctcp except ping, so am using that genericstatus which looks ugly and cant use $icon(name) in these which is a stupid limitation.

[//]: # (If your pull request is a fix to an open issue please add fixes #9999 to the commit comments.)
[//]: # (If your proposal involves GUI improvements, add screenshots of before and after to help visualise the proposal on the fly.)
#### Changes proposed
-  show ctcp message on send
-
-

[//]: # (If you have write privileges to repository, do label your pull request, else you could insert a mention prefixed with @GitHub-Username below.)

