### PR TITLE
Fix #2323

### DIFF
--- a/src/kvirc/kernel/KviIpcSentinel.cpp
+++ b/src/kvirc/kernel/KviIpcSentinel.cpp
@@ -296,7 +296,7 @@ typedef struct
 	kvi_u32_t full_sequence;
 } fake_xcb_generic_event_t;
 
-typedef struct xcb_property_notify_event_t
+typedef struct
 {
 	kvi_u8_t response_type;
 	kvi_u8_t pad0;


### PR DESCRIPTION
There should be no need to define xcb_property_notify_event_t here.
Doing so results in compile errors if it is already defined (because
something includes the xcb headers, which apparently is the case with
Qt 5.10).
