### PR TITLE
doc: Allow to override build date

### DIFF
--- a/admin/gendoc.pl
+++ b/admin/gendoc.pl
@@ -28,8 +28,8 @@
 # GLOBAL CONFIGS
 #################################################################################################
 
-$g_currenttime=gmtime;
-$g_currentuser = getlogin || getpwuid($<) || "Unknown";
+$g_currenttime = gmtime($ENV{SOURCE_DATE_EPOCH} || time);
+$g_currentuser = $ENV{USER} || getlogin || getpwuid($<) || "Unknown";
 $g_syntaxcolor="#802000";
 
 $g_kvssyntaxcolor="#802000";


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.