### PR TITLE
Support 64-bit X509 certificate serial numbers

### DIFF
--- a/src/kvilib/net/KviSSL.cpp
+++ b/src/kvilib/net/KviSSL.cpp
@@ -862,7 +862,7 @@ void KviSSLCertificate::extractPubKeyInfo()
 
 void KviSSLCertificate::extractSerialNumber()
 {
-	m_szSerialNumber = KviCString();
+	m_szSerialNumber.clear();
 	ASN1_INTEGER * i = X509_get_serialNumber(m_pX509);
 	if(i)
 	{

--- a/src/kvilib/net/KviSSL.cpp
+++ b/src/kvilib/net/KviSSL.cpp
@@ -322,8 +322,8 @@ void KviSSL::shutdown()
 {
 	if(m_pSSL)
 	{
-//avoid to die on a SIGPIPE if the connection has close (SSL_shutdown can call send())
-//see bug #440
+		//avoid to die on a SIGPIPE if the connection has close (SSL_shutdown can call send())
+		//see bug #440
 
 #if !(defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW))
 		// ignore SIGPIPE
@@ -704,7 +704,7 @@ int KviSSLCertificate::fingerprintDigestId()
 	if(!m_pX509)
 		return -1;
 
-	const X509_ALGOR *alg;
+	const X509_ALGOR * alg;
 #if OPENSSL_VERSION_NUMBER >= 0x10100005L
 	X509_get0_signature(nullptr, &alg, m_pX509);
 #else
@@ -715,7 +715,6 @@ int KviSSLCertificate::fingerprintDigestId()
 	if(NID == NID_undef)
 	{
 		return 0; // unknown digest function: it means the signature can't be verified: the certificate can't be trusted
-
 	}
 
 	const EVP_MD * mdType = nullptr;
@@ -865,13 +864,13 @@ void KviSSLCertificate::extractSerialNumber()
 {
 	m_szSerialNumber = KviCString();
 	ASN1_INTEGER * i = X509_get_serialNumber(m_pX509);
-	if (i)
+	if(i)
 	{
 		BIGNUM * bn = ASN1_INTEGER_to_BN(i, nullptr);
-		if (bn)
+		if(bn)
 		{
-			char *str = BN_bn2dec(bn);
-			if (str)
+			char * str = BN_bn2dec(bn);
+			if(str)
 			{
 				m_szSerialNumber = KviCString(str);
 				OPENSSL_free(str);
@@ -885,8 +884,8 @@ void KviSSLCertificate::extractSignature()
 {
 	static char hexdigits[] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
 
-	const ASN1_BIT_STRING *sig;
-	const X509_ALGOR *alg;
+	const ASN1_BIT_STRING * sig;
+	const X509_ALGOR * alg;
 #if OPENSSL_VERSION_NUMBER >= 0x10100005L
 	X509_get0_signature(&sig, &alg, m_pX509);
 #else

--- a/src/kvilib/net/KviSSL.cpp
+++ b/src/kvilib/net/KviSSL.cpp
@@ -864,8 +864,16 @@ void KviSSLCertificate::extractPubKeyInfo()
 void KviSSLCertificate::extractSerialNumber()
 {
 	ASN1_INTEGER * i = X509_get_serialNumber(m_pX509);
-	if(i)
+	if (i)
+	{
+#if OPENSSL_VERSION_NUMBER >= 0x10100005L
+		int res = ASN1_INTEGER_get_int64(&m_iSerialNumber, i);
+		if (res != 0)
+			m_iSerialNumber = -1;
+#else
 		m_iSerialNumber = ASN1_INTEGER_get(i);
+#endif
+	}
 	else
 		m_iSerialNumber = -1;
 }

--- a/src/kvilib/net/KviSSL.h
+++ b/src/kvilib/net/KviSSL.h
@@ -53,7 +53,7 @@ protected:
 	KviPointerHashTable<const char *, KviCString> * m_pIssuer;
 	int m_iPubKeyBits;
 	KviCString m_szPubKeyType;
-	kvi_i64_t m_iSerialNumber;
+	KviCString m_szSerialNumber;
 	int m_iVersion;
 	KviCString m_szSignatureType;
 	KviCString m_szSignatureContents;
@@ -92,7 +92,7 @@ public:
 	int publicKeyBits() { return m_iPubKeyBits; };
 	const char * publicKeyType() { return m_szPubKeyType.ptr(); };
 
-	kvi_i64_t serialNumber() { return m_iSerialNumber; };
+	const char * serialNumber() { return m_szSerialNumber.len() ? m_szSerialNumber.ptr() : nullptr; };
 
 	int version() { return m_iVersion; };
 

--- a/src/kvilib/net/KviSSL.h
+++ b/src/kvilib/net/KviSSL.h
@@ -53,7 +53,7 @@ protected:
 	KviPointerHashTable<const char *, KviCString> * m_pIssuer;
 	int m_iPubKeyBits;
 	KviCString m_szPubKeyType;
-	int m_iSerialNumber;
+	kvi_i64_t m_iSerialNumber;
 	int m_iVersion;
 	KviCString m_szSignatureType;
 	KviCString m_szSignatureContents;
@@ -92,7 +92,7 @@ public:
 	int publicKeyBits() { return m_iPubKeyBits; };
 	const char * publicKeyType() { return m_szPubKeyType.ptr(); };
 
-	int serialNumber() { return m_iSerialNumber; };
+	kvi_i64_t serialNumber() { return m_iSerialNumber; };
 
 	int version() { return m_iVersion; };
 

--- a/src/kvirc/kernel/KviSSLMaster.cpp
+++ b/src/kvirc/kernel/KviSSLMaster.cpp
@@ -64,7 +64,7 @@ namespace KviSSLMaster
 	{
 		wnd->output(KVI_OUT_SSL, __tr2qs("[SSL]: %c%s"), KviControlCodes::Bold, description);
 		wnd->output(KVI_OUT_SSL, __tr2qs("[SSL]:  Version: %c%d"), KviControlCodes::Bold, c->version());
-		wnd->output(KVI_OUT_SSL, __tr2qs("[SSL]:  Serial number: %c%d"), KviControlCodes::Bold, c->serialNumber());
+		wnd->output(KVI_OUT_SSL, __tr2qs("[SSL]:  Serial number: %c%lld"), KviControlCodes::Bold, c->serialNumber());
 		wnd->output(KVI_OUT_SSL, __tr2qs("[SSL]:  Subject:"));
 		wnd->output(KVI_OUT_SSL, __tr2qs("[SSL]:     Common name: %c%s"), KviControlCodes::Bold, c->subjectCommonName());
 		wnd->output(KVI_OUT_SSL, __tr2qs("[SSL]:     Organization: %c%s"), KviControlCodes::Bold, c->subjectOrganization());

--- a/src/kvirc/kernel/KviSSLMaster.cpp
+++ b/src/kvirc/kernel/KviSSLMaster.cpp
@@ -64,7 +64,7 @@ namespace KviSSLMaster
 	{
 		wnd->output(KVI_OUT_SSL, __tr2qs("[SSL]: %c%s"), KviControlCodes::Bold, description);
 		wnd->output(KVI_OUT_SSL, __tr2qs("[SSL]:  Version: %c%d"), KviControlCodes::Bold, c->version());
-		wnd->output(KVI_OUT_SSL, __tr2qs("[SSL]:  Serial number: %c%lld"), KviControlCodes::Bold, c->serialNumber());
+		wnd->output(KVI_OUT_SSL, __tr2qs("[SSL]:  Serial number: %c%s"), KviControlCodes::Bold, c->serialNumber());
 		wnd->output(KVI_OUT_SSL, __tr2qs("[SSL]:  Subject:"));
 		wnd->output(KVI_OUT_SSL, __tr2qs("[SSL]:     Common name: %c%s"), KviControlCodes::Bold, c->subjectCommonName());
 		wnd->output(KVI_OUT_SSL, __tr2qs("[SSL]:     Organization: %c%s"), KviControlCodes::Bold, c->subjectOrganization());
@@ -280,7 +280,7 @@ namespace KviSSLMaster
 		}
 		if(szQuery.compare("serialNumber") == 0)
 		{
-			pRetBuffer->setInteger(pCert->serialNumber());
+			pRetBuffer->setString(pCert->serialNumber());
 			return true;
 		}
 		if(szQuery.compare("pemBase64") == 0)


### PR DESCRIPTION
Avoid "too large" errors when querying the serial number of a certificate when it doesn't fit in a 32-bit integer.