### PR TITLE
AppVeyor: grab gettext from vcpkg and clean up a bit

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@ version: 0.0.0.0.1-branch-{branch}-build-{build}
 image: Visual Studio 2017
 cache:
     - c:\spellcheck-dicts -> .appveyor.yml
-    - c:\Tools\vcpkg\installed
+    - c:\Tools\vcpkg\installed -> .appveyor.yml
 environment:
     matrix:
         - cmake_build_type: Release

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,6 @@
 version: 0.0.0.0.1-branch-{branch}-build-{build}
 image: Visual Studio 2017
 cache:
-    - c:\deps -> .appveyor.yml
     - c:\spellcheck-dicts -> .appveyor.yml
     - c:\Tools\vcpkg\installed
 environment:
@@ -60,45 +59,11 @@ environment:
 matrix:
     fast_finish: true
 install:
-    - systeminfo
-    - c:\cygwin\bin\uname -a
-    - c:\cygwin\bin\cat /proc/cpuinfo
-    - c:\cygwin\bin\cat /proc/meminfo
-    - c:\cygwin\bin\ls -l /cygdrive/c
-    - c:\cygwin\bin\ls -l "/cygdrive/c/Program Files (x86)"
-    - c:\cygwin\bin\ls -l "/cygdrive/c/Program Files"
-    - c:\cygwin\bin\ls -l /cygdrive/c/Tools
-    - c:\cygwin\bin\ls -l /cygdrive/c/Libraries
-    - c:\cygwin\bin\ls -l /cygdrive/c/ProgramData
-    - c:\cygwin\bin\env
-    - nuget install Gettext.Tools -OutputDirectory c:\deps
-    - c:\cygwin\bin\find /cygdrive/c/deps "-type" f
     - ps: |
-        if ((Test-Path "c:\OpenSSL-$env:ssl_arch") -And ((Get-Item "c:\OpenSSL-$env:ssl_arch\bin\ssleay32.dll").VersionInfo.ProductVersion -eq '1.0.2o')) {
-            echo "using preinstalled openssl"
-        } else {
-            echo "preinstalled openssl not found or not present in requested version, this is pretty sad."
-            echo "downloading openssl 1.0.2o package, don't worry, be happy!"
-            Invoke-WebRequest "https://slproweb.com/download/$($env:ssl_arch)OpenSSL-1_0_2o.exe" -OutFile c:\openssl-setup.exe
-            echo "installing openssl"
-            Start-Process -Wait -FilePath c:\openssl-setup.exe -ArgumentList "/silent /verysilent /sp- /suppressmsgboxes"
-        }
-    - c:\cygwin\bin\find /cygdrive/c/OpenSSL-%ssl_arch% "-type" f
-    - ps: |
-        if (Test-Path "c:/Program Files (x86)/NSIS/makensis.exe") {
-            echo "using preinstalled nsis"
-        } else {
-            choco install nsis -y
-        }
-    - ps: |
-        if (Test-Path "c:/Strawberry/kvirc_workaround") {
-            echo "using perl from cache"
-        } else {
-            choco install strawberryperl -y $env:choco_arch
-            # Strawberry perl doesn't support MSVC, but we force the support.
-            c:\cygwin\bin\bash -c "/bin/cat .appveyor.perl >> /cygdrive/c/Strawberry/perl/lib/core/config.h"
-            c:\cygwin\bin\touch /cygdrive/c/Strawberry/kvirc_workaround
-        }
+        choco install strawberryperl -y $env:choco_arch
+        # Strawberry perl doesn't support MSVC, but we force the support.
+        c:\cygwin\bin\bash -c "/bin/cat .appveyor.perl >> /cygdrive/c/Strawberry/perl/lib/core/config.h"
+        c:\cygwin\bin\touch /cygdrive/c/Strawberry/kvirc_workaround
     - ps: |
         c:\msys64\usr\bin\pacman -Q
         c:\msys64\usr\bin\pacman -S --noconfirm $env:mingw_fourple-enchant
@@ -121,32 +86,25 @@ install:
             (New-Object Net.WebClient).DownloadFile('https://sourceforge.net/projects/wordlist/files/speller/2017.01.22/hunspell-en_GB-ise-2017.01.22.zip', 'c:\spellcheck-dicts\zip\en_GB-ise.zip')
             c:\cygwin\bin\bash -lc "cd /cygdrive/c/spellcheck-dicts/unzip; 7z x -y ../zip/en_US.zip; 7z x -y ../zip/en_GB-ize.zip; 7z x -y ../zip/en_GB-ise.zip"
         }
-    - c:\cygwin\bin\ls -lR /cygdrive/c/spellcheck-dicts
 build_script:
     - mkdir build
     - cd build
     - '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %vc_arch%'
     - path
     - vcpkg remove --outdated
+    - vcpkg install gettext:%arch%-windows
     - vcpkg install zlib:%arch%-windows
     - ps: |
-        $gettext = c:\cygwin\bin\find /cygdrive/c/deps/ -name xgettext.exe
-        $gettext = c:\cygwin\bin\dirname $gettext
-        $gettext = c:\cygwin\bin\cygpath -m $gettext
-        $env:Path += ";" + $gettext
-        c:\cygwin\bin\find $env:ChocolateyInstall
         cmake .. "-GNMake Makefiles" "-DCMAKE_TOOLCHAIN_FILE=C:/Tools/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DCMAKE_BUILD_TYPE=$env:cmake_build_type" "-DCMAKE_PREFIX_PATH=c:/Qt/$env:qt_ver" "-DOPENSSL_ROOT_DIR=c:/OpenSSL-$env:ssl_arch" "-DWANT_PERL=YES" "-DPERL_EXECUTABLE=c:/Strawberry/perl/bin/perl.exe" "-DWANT_PHONON=NO" "-DCMAKE_START_TEMP_FILE=" "-DCMAKE_END_TEMP_FILE=" "-DCMAKE_VERBOSE_MAKEFILE=1" "-DEnchant_FOUND=1" "-DEnchant_INCLUDE_DIRS=c:/enchant-headers;$env:mingw_root/include/enchant;$env:mingw_root/include/glib-2.0" "-DEnchant_LDFLAGS=$env:mingw_root/lib/libenchant.dll.a" "-DWANT_KDE=NO" "-DWANT_PYTHON=YES" "-DWANT_QTWEBKIT=NO"
     - ps: Push-AppveyorArtifact CMakeCache.txt
     - nmake install VERBOSE=1
-    - c:\cygwin\bin\ls -l release/
     - ps: |
         $env:Path += ";c:/Qt/$env:qt_ver/bin"
         if ($env:cmake_build_type -eq "Debug") {
             windeployqt "--pdb" "--dir" "release/qt-plugins" "--libdir" "release/" "release/kvirc.exe" "release/modules/"
         } else {
             windeployqt "--dir" "release/qt-plugins" "--libdir" "release/" "release/kvirc.exe" "release/modules/"
-        } 
-    - c:\cygwin\bin\ls -l release/
+        }
     - ps: |
         if ($env:cmake_build_type -eq "Debug") {
             c:\cygwin\bin\cp -pv "c:/Tools/vcpkg/installed/$env:arch-windows/debug/bin/zlibd.pdb" "c:/Tools/vcpkg/installed/$env:arch-windows/debug/bin/zlibd1.dll" "/cygdrive/c/OpenSSL-$env:ssl_arch/libeay32.dll" "/cygdrive/c/OpenSSL-$env:ssl_arch/ssleay32.dll" "/cygdrive/c/OpenSSL-$env:ssl_arch/bin/msvcr120.dll" "c:/Program Files (x86)/Windows Kits/10/bin/$env:arch/ucrt/ucrtbased.dll" release/
@@ -175,9 +133,7 @@ build_script:
         c:\cygwin\bin\cp -pv /cygdrive/c/spellcheck-dicts/unzip/en_GB-ise.aff release/share/myspell/dicts/en_GB_ise.aff
         c:\cygwin\bin\cp -pv /cygdrive/c/spellcheck-dicts/unzip/en_GB-ize.dic release/share/myspell/dicts/en_GB_ize.dic
         c:\cygwin\bin\cp -pv /cygdrive/c/spellcheck-dicts/unzip/en_GB-ize.aff release/share/myspell/dicts/en_GB_ize.aff
-    - c:\cygwin\bin\ls -l release/
     - '"c:\Program Files (x86)\NSIS\makensis.exe" KVIrc.nsi'
-    - c:\cygwin\bin\ls -l
     - ps: |
         $exe = dir -name *.exe
         $new_name = $exe.Replace(".exe", "-$env:target_arch.exe")

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -60,10 +60,20 @@ matrix:
     fast_finish: true
 install:
     - ps: |
+        if ((Test-Path "c:\OpenSSL-$env:ssl_arch") -And ((Get-Item "c:\OpenSSL-$env:ssl_arch\bin\ssleay32.dll").VersionInfo.ProductVersion -eq '1.0.2o')) {
+            echo "using preinstalled openssl"
+        } else {
+            echo "preinstalled openssl not found or not present in requested version, this is pretty sad."
+            echo "downloading openssl 1.0.2o package, don't worry, be happy!"
+            Invoke-WebRequest "https://slproweb.com/download/$($env:ssl_arch)OpenSSL-1_0_2o.exe" -OutFile c:\openssl-setup.exe
+            echo "installing openssl"
+            Start-Process -Wait -FilePath c:\openssl-setup.exe -ArgumentList "/silent /verysilent /sp- /suppressmsgboxes"
+        }
+    - c:\cygwin\bin\find /cygdrive/c/OpenSSL-%ssl_arch% "-type" f
+    - ps: |
         choco install strawberryperl -y $env:choco_arch
         # Strawberry perl doesn't support MSVC, but we force the support.
         c:\cygwin\bin\bash -c "/bin/cat .appveyor.perl >> /cygdrive/c/Strawberry/perl/lib/core/config.h"
-        c:\cygwin\bin\touch /cygdrive/c/Strawberry/kvirc_workaround
     - ps: |
         c:\msys64\usr\bin\pacman -Q
         c:\msys64\usr\bin\pacman -S --noconfirm $env:mingw_fourple-enchant


### PR DESCRIPTION
* Gettext from vcpkg
* No longer handle OpenSSL ourselves since it's preinstalled in AV (https://www.appveyor.com/docs/build-environment/)
* No longer handle NSIS ourselves since it's preinstalled in AV (https://www.appveyor.com/docs/build-environment/)
* Remove the strawberry caching logic since we never cache it
* Remove a few `ls` so they don't flood the log. I mainly did it while testing, happy to put them back if wanted.