### PR TITLE
Installer fixes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -96,12 +96,6 @@ install:
             (New-Object Net.WebClient).DownloadFile('https://sourceforge.net/projects/wordlist/files/speller/2017.01.22/hunspell-en_GB-ise-2017.01.22.zip', 'c:\spellcheck-dicts\zip\en_GB-ise.zip')
             c:\cygwin\bin\bash -lc "cd /cygdrive/c/spellcheck-dicts/unzip; 7z x -y ../zip/en_US.zip; 7z x -y ../zip/en_GB-ize.zip; 7z x -y ../zip/en_GB-ise.zip"
         }
-    - ps: |
-        if (Test-Path "C:\Program Files (x86)\NSIS\Plugins\ShellExecAsUser.dll") {
-            echo "using ShellExecAsUser from cache"
-        } else {
-            (New-Object Net.WebClient).DownloadFile('http://nsis.sourceforge.net/mediawiki/images/c/c7/ShellExecAsUser.zip', 'c:\ShellExecAsUser.zip')
-            7z e -o"C:\Program Files (x86)\NSIS\Plugins\x86-unicode" c:\ShellExecAsUser.zip *.dll        }
 build_script:
     - mkdir build
     - cd build

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -96,6 +96,12 @@ install:
             (New-Object Net.WebClient).DownloadFile('https://sourceforge.net/projects/wordlist/files/speller/2017.01.22/hunspell-en_GB-ise-2017.01.22.zip', 'c:\spellcheck-dicts\zip\en_GB-ise.zip')
             c:\cygwin\bin\bash -lc "cd /cygdrive/c/spellcheck-dicts/unzip; 7z x -y ../zip/en_US.zip; 7z x -y ../zip/en_GB-ize.zip; 7z x -y ../zip/en_GB-ise.zip"
         }
+    - ps: |
+        if (Test-Path "C:\Program Files (x86)\NSIS\Plugins\ShellExecAsUser.dll") {
+            echo "using ShellExecAsUser from cache"
+        } else {
+            (New-Object Net.WebClient).DownloadFile('http://nsis.sourceforge.net/mediawiki/images/c/c7/ShellExecAsUser.zip', 'c:\ShellExecAsUser.zip')
+            7z e -o"C:\Program Files (x86)\NSIS\Plugins\x86-unicode" c:\ShellExecAsUser.zip *.dll        }
 build_script:
     - mkdir build
     - cd build

--- a/cmake/KVIrc.nsi.cmake
+++ b/cmake/KVIrc.nsi.cmake
@@ -40,7 +40,11 @@ Var LocalDir
 !define MUI_LANGDLL_REGISTRY_KEY "Software\KVIrc"
 !define MUI_LANGDLL_REGISTRY_VALUENAME "Installer Language"
 !define MUI_LANGDLL_ALWAYSSHOW
-!define MUI_FINISHPAGE_RUN "$INSTDIR\@KVIRC_BINARYNAME@.exe"
+
+!define MUI_FINISHPAGE_RUN
+!define MUI_FINISHPAGE_RUN_TEXT "Start KVIrc"
+!define MUI_FINISHPAGE_RUN_FUNCTION "LaunchKVIrc"
+!insertmacro MUI_PAGE_FINISH
 
 ; Pages
 !insertmacro MUI_PAGE_LICENSE "release\License\COPYING"
@@ -289,6 +293,11 @@ FunctionEnd
 
 ;--------------------------------
 ; Functions
+
+Function LaunchKVIrc
+   SetOutPath $INSTDIR
+   ShellExecAsUser::ShellExecAsUser "" "$INSTDIR\@KVIRC_BINARYNAME@.exe" ""
+FunctionEnd
 
 Function RemoveAutostartShortcuts
   ; Remove user created startup shortcuts

--- a/cmake/KVIrc.nsi.cmake
+++ b/cmake/KVIrc.nsi.cmake
@@ -299,40 +299,6 @@ Function LaunchKVIrc
    ShellExecAsUser::ShellExecAsUser "" "$INSTDIR\@KVIRC_BINARYNAME@.exe" ""
 FunctionEnd
 
-Function RemoveAutostartShortcuts
-  ; Remove user created startup shortcuts
-  ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders" "Common Startup"
-  StrLen $R1 "$R0"
-  ${If} $R1 > 0
-    StrCpy $R0 "\KVIrc.lnk" $R1
-    Delete "$R0"
-  ${EndIf}
-
-  ReadRegStr $R0 HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders" "Common Startup"
-  StrLen $R1 "$R0"
-  ${If} $R1 > 0
-    StrCpy $R0 "\KVIrc.lnk" $R1
-    Delete "$R0"
-  ${EndIf}
-FunctionEnd
-
-Function un.RemoveAutostartShortcuts
-  ; Remove user created startup shortcuts
-  ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders" "Common Startup"
-  StrLen $R1 "$R0"
-  ${If} $R1 > 0
-    StrCpy $R0 "\KVIrc.lnk" $R1
-    Delete "$R0"
-  ${EndIf}
-
-  ReadRegStr $R0 HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders" "Common Startup"
-  StrLen $R1 "$R0"
-  ${If} $R1 > 0
-    StrCpy $R0 "\KVIrc.lnk" $R1
-    Delete "$R0"
-  ${EndIf}
-FunctionEnd
-
 Function CheckUserInstallRights
   ClearErrors
   UserInfo::GetName

--- a/cmake/KVIrc.nsi.cmake
+++ b/cmake/KVIrc.nsi.cmake
@@ -76,8 +76,6 @@ LangString StartMenuSection ${LANG_ENGLISH} "Start menu"
 LangString StartMenuSectionDescr ${LANG_ENGLISH} "Create start menu icon"
 LangString MsgUninstallOldInstaller ${LANG_ENGLISH} "Previous versions of KVIrc must be uninstalled."
 LangString KVIrcIsRunning ${LANG_ENGLISH} "An instance of KVIrc is currently running. Exit KVIrc and then try again."
-LangString WinampSection ${LANG_ENGLISH} "Winamp plugin"
-LangString WinampSectionDescr ${LANG_ENGLISH} "Install Winamp plugin"
 LangString WinVerUnsupported ${LANG_ENGLISH} "KVIrc does not support the currently running Windows version.$\r$\nWindows 7 or higher is required."
 
 !include ".\translations\*.nsi"
@@ -141,12 +139,6 @@ Section $(TraySection) TraySection_IDX
   CreateShortCut "$QUICKLAUNCH\KVIrc.lnk" "$INSTDIR\@KVIRC_BINARYNAME@.exe" "" "$INSTDIR\@KVIRC_BINARYNAME@.exe" 0 "" "" $(ProgramDescription)
 SectionEnd
 
-Section $(WinampSection) WinampSection_IDX
-  ReadRegStr $R0 HKCU Software\Winamp ""
-  IfFileExists "$R0\winamp.exe" 0 +2
-  Rename "$INSTDIR\modules\gen_kvirc.dll" "$R0\Plugins\gen_kvirc.dll"
-SectionEnd
-
 ;--------------------------------
 ; Descriptions
 
@@ -159,8 +151,6 @@ SectionEnd
         $(DesktopSectionDescr)
 !insertmacro MUI_DESCRIPTION_TEXT ${TraySection_IDX} \
         $(TraySectionDescr)
-!insertmacro MUI_DESCRIPTION_TEXT ${WinampSection_IDX} \
-        $(WinampSectionDescr)
 !insertmacro MUI_FUNCTION_DESCRIPTION_END
 
 
@@ -179,10 +169,6 @@ Function .onInit
         ; change install dir
         StrCpy $INSTDIR $PROGRAMFILES64\KVIrc
     ${EndIf}
-
-    ReadRegStr $R0 HKCU Software\Winamp ""
-    IfFileExists "$R0\winamp.exe" continue 0
-        SectionSetFlags ${WinampSection_IDX} 16 # 10000 in binary: disabled+unchecked
 continue:
 
 
@@ -253,11 +239,6 @@ Section !un.$(UnGeneralFiles)
     Delete "$INSTDIR\*.exe"
     Delete "$INSTDIR\*.ini"
     RMDir "$INSTDIR"
-
-    ReadRegStr $R0 HKCU Software\Winamp ""
-        IfFileExists "$R0\Plugins\gen_kvirc.dll" 0 +2
-        Delete "$R0\Plugins\gen_kvirc.dll"
-
 SectionEnd
 
 ;Remove local data dir

--- a/cmake/KVIrc.nsi.cmake
+++ b/cmake/KVIrc.nsi.cmake
@@ -280,37 +280,6 @@ Function LaunchKVIrc
    ShellExecAsUser::ShellExecAsUser "" "$INSTDIR\@KVIRC_BINARYNAME@.exe" ""
 FunctionEnd
 
-Function CheckUserInstallRights
-  ClearErrors
-  UserInfo::GetName
-  IfErrors Win9x
-  Pop $0
-  UserInfo::GetAccountType
-  Pop $1
-
-  StrCmp $1 "Admin" 0 +3
-    StrCpy $1 "HKLM"
-  Goto done
-  StrCmp $1 "Power" 0 +3
-    StrCpy $1 "HKLM"
-  Goto done
-  StrCmp $1 "User" 0 +3
-    StrCpy $1 "HKCU"
-  Goto done
-  StrCmp $1 "Guest" 0 +3
-    StrCpy $1 "NONE"
-  Goto done
-  ; Unknown error
-    StrCpy $1 "NONE"
-  Goto done
-
-  Win9x:
-    StrCpy $1 "HKLM"
-
-  done:
-    Push $1
-FunctionEnd
-
 Function CloseKVIrcInstances
 ; Waits for all running instances of KVIrc to close
     Push $0 ;saving stack

--- a/cmake/KVIrc.nsi.cmake
+++ b/cmake/KVIrc.nsi.cmake
@@ -44,7 +44,6 @@ Var LocalDir
 !define MUI_FINISHPAGE_RUN
 !define MUI_FINISHPAGE_RUN_TEXT "Start KVIrc"
 !define MUI_FINISHPAGE_RUN_FUNCTION "LaunchKVIrc"
-!insertmacro MUI_PAGE_FINISH
 
 ; Pages
 !insertmacro MUI_PAGE_LICENSE "release\License\COPYING"
@@ -56,10 +55,6 @@ Var LocalDir
 !insertmacro MUI_UNPAGE_CONFIRM
 !insertmacro MUI_UNPAGE_COMPONENTS
 !insertmacro MUI_UNPAGE_INSTFILES
-
-;--------------------------------
-!insertmacro MUI_RESERVEFILE_LANGDLL
-ReserveFile "${NSISDIR}\Plugins\x86-unicode\UserInfo.dll"
 
 !insertmacro MUI_LANGUAGE "English"
 LangString UnLocalDataDescr ${LANG_ENGLISH} "This will delete your settings, themes and logs. Keep it unchecked if you plan to reinstall KVIrc later."
@@ -169,8 +164,6 @@ Function .onInit
         ; change install dir
         StrCpy $INSTDIR $PROGRAMFILES64\KVIrc
     ${EndIf}
-continue:
-
 
     SetShellVarContext all
     ; Remove old installer, check for 32-bit first, we don't want both installed
@@ -201,9 +194,6 @@ uninst:
 done:
 
 FunctionEnd
-
-;Function .onInstSuccess
-;FunctionEnd
 
 ;--------------------------------
 ; Uninstaller
@@ -276,8 +266,7 @@ FunctionEnd
 ; Functions
 
 Function LaunchKVIrc
-   SetOutPath $INSTDIR
-   ShellExecAsUser::ShellExecAsUser "" "$INSTDIR\@KVIRC_BINARYNAME@.exe" ""
+  Exec '"$WINDIR\explorer.exe" "$INSTDIR\@KVIRC_BINARYNAME@.exe"'
 FunctionEnd
 
 Function CloseKVIrcInstances


### PR DESCRIPTION
* fix the finish page so it launches KVIrc as the user that ran the install before UAC privilege escalation.
* remove autostart related functions
* remove Winamp installer option


Rebase of https://github.com/kvirc/KVIrc/pull/2147 + additions from https://github.com/kvirc/KVIrc/issues/1691


