### PR TITLE
add clang-format setting to avoid starting commas

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,6 +10,7 @@ IndentCaseLabels: true
 SpaceBeforeParens: Never
 BreakBeforeBraces: Allman
 BreakConstructorInitializersBeforeComma: false
+BreakBeforeInheritanceComma: false
 
 AlignTrailingComments: true
 DerivePointerAlignment: false


### PR DESCRIPTION
should match KVIrc style? (https://clang.llvm.org/docs/ClangFormatStyleOptions.html)

<!--
Describe the changes you're proposing.
If this pull request is intended to fix a bug, don't forget to mention its #number.
If there are changes in the GUI, include screenshots of the changes.
-->
