### PR TITLE
AppVeyor: Grab openssl from vcpkg and fix vcpkg remove option

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,6 @@ environment:
         - cmake_build_type: Release
           arch: x64
           target_arch: x86_64
-          ssl_arch: Win64
           nuget_arch: x64
           vc_arch: amd64
           choco_arch:
@@ -21,7 +20,6 @@ environment:
         - cmake_build_type: Release
           arch: x86
           target_arch: x86
-          ssl_arch: Win32
           nuget_arch: Win32
           vc_arch: amd64_x86  # cross-compile from amd64 to x86
           choco_arch: --x86
@@ -34,7 +32,6 @@ environment:
         - cmake_build_type: Debug
           arch: x64
           target_arch: x86_64
-          ssl_arch: Win64
           nuget_arch: x64
           vc_arch: amd64
           choco_arch:
@@ -47,7 +44,6 @@ environment:
         - cmake_build_type: Debug
           arch: x86
           target_arch: x86
-          ssl_arch: Win32
           nuget_arch: Win32
           vc_arch: amd64_x86  # cross-compile from amd64 to x86
           choco_arch: --x86
@@ -63,17 +59,6 @@ install:
     # - c:\cygwin\bin\uname -a
     # - c:\cygwin\bin\cat /proc/cpuinfo
     # - c:\cygwin\bin\cat /proc/meminfo
-    - ps: |
-        if ((Test-Path "c:\OpenSSL-$env:ssl_arch") -And ((Get-Item "c:\OpenSSL-$env:ssl_arch\bin\ssleay32.dll").VersionInfo.ProductVersion -eq '1.0.2o')) {
-            echo "using preinstalled openssl"
-        } else {
-            echo "preinstalled openssl not found or not present in requested version, this is pretty sad."
-            echo "downloading openssl 1.0.2o package, don't worry, be happy!"
-            Invoke-WebRequest "https://slproweb.com/download/$($env:ssl_arch)OpenSSL-1_0_2o.exe" -OutFile c:\openssl-setup.exe
-            echo "installing openssl"
-            Start-Process -Wait -FilePath c:\openssl-setup.exe -ArgumentList "/silent /verysilent /sp- /suppressmsgboxes"
-        }
-    - c:\cygwin\bin\find /cygdrive/c/OpenSSL-%ssl_arch% "-type" f
     - ps: |
         choco install strawberryperl -y $env:choco_arch
         # Strawberry perl doesn't support MSVC, but we force the support.
@@ -110,11 +95,12 @@ build_script:
     - cd build
     - '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %vc_arch%'
     - path
-    - vcpkg remove --outdated
+    - vcpkg remove --outdated --recurse
     - vcpkg install gettext:%arch%-windows
     - vcpkg install zlib:%arch%-windows
+    - vcpkg install openssl:%arch%-windows
     - ps: |
-        cmake .. "-GNMake Makefiles" "-DCMAKE_TOOLCHAIN_FILE=C:/Tools/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DCMAKE_BUILD_TYPE=$env:cmake_build_type" "-DCMAKE_PREFIX_PATH=c:/Qt/$env:qt_ver" "-DOPENSSL_ROOT_DIR=c:/OpenSSL-$env:ssl_arch" "-DWANT_PERL=YES" "-DPERL_EXECUTABLE=c:/Strawberry/perl/bin/perl.exe" "-DWANT_PHONON=NO" "-DCMAKE_START_TEMP_FILE=" "-DCMAKE_END_TEMP_FILE=" "-DCMAKE_VERBOSE_MAKEFILE=1" "-DEnchant_FOUND=1" "-DEnchant_INCLUDE_DIRS=c:/enchant-headers;$env:mingw_root/include/enchant;$env:mingw_root/include/glib-2.0" "-DEnchant_LDFLAGS=$env:mingw_root/lib/libenchant.dll.a" "-DWANT_KDE=NO" "-DWANT_PYTHON=YES" "-DWANT_QTWEBKIT=NO"
+        cmake .. "-GNMake Makefiles" "-DCMAKE_TOOLCHAIN_FILE=C:/Tools/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DCMAKE_BUILD_TYPE=$env:cmake_build_type" "-DCMAKE_PREFIX_PATH=c:/Qt/$env:qt_ver" "-DWANT_OPENSSL=YES" "-DWANT_PERL=YES" "-DPERL_EXECUTABLE=c:/Strawberry/perl/bin/perl.exe" "-DWANT_PHONON=NO" "-DCMAKE_START_TEMP_FILE=" "-DCMAKE_END_TEMP_FILE=" "-DCMAKE_VERBOSE_MAKEFILE=1" "-DEnchant_FOUND=1" "-DEnchant_INCLUDE_DIRS=c:/enchant-headers;$env:mingw_root/include/enchant;$env:mingw_root/include/glib-2.0" "-DEnchant_LDFLAGS=$env:mingw_root/lib/libenchant.dll.a" "-DWANT_KDE=NO" "-DWANT_PYTHON=YES" "-DWANT_QTWEBKIT=NO"
     - ps: Push-AppveyorArtifact CMakeCache.txt
     - nmake install VERBOSE=1
     # - c:\cygwin\bin\ls -l release/
@@ -127,9 +113,9 @@ build_script:
         }
     - ps: |
         if ($env:cmake_build_type -eq "Debug") {
-            c:\cygwin\bin\cp -pv "c:/Tools/vcpkg/installed/$env:arch-windows/debug/bin/zlibd.pdb" "c:/Tools/vcpkg/installed/$env:arch-windows/debug/bin/zlibd1.dll" "/cygdrive/c/OpenSSL-$env:ssl_arch/libeay32.dll" "/cygdrive/c/OpenSSL-$env:ssl_arch/ssleay32.dll" "/cygdrive/c/OpenSSL-$env:ssl_arch/bin/msvcr120.dll" "c:/Program Files (x86)/Windows Kits/10/bin/$env:arch/ucrt/ucrtbased.dll" release/
+            c:\cygwin\bin\cp -pv "c:/Tools/vcpkg/installed/$env:arch-windows/debug/bin/zlibd.pdb" "c:/Tools/vcpkg/installed/$env:arch-windows/debug/bin/zlibd1.dll" "c:/Tools/vcpkg/installed/$env:arch-windows/debug/bin/libeay32.*" "c:/Tools/vcpkg/installed/$env:arch-windows/debug/bin/ssleay32.*" "c:/Program Files (x86)/Windows Kits/10/bin/$env:arch/ucrt/ucrtbased.dll" release/
         } else {
-            c:\cygwin\bin\cp -pv "c:/Tools/vcpkg/installed/$env:arch-windows/bin/zlib1.dll" "/cygdrive/c/OpenSSL-$env:ssl_arch/libeay32.dll" "/cygdrive/c/OpenSSL-$env:ssl_arch/ssleay32.dll" "/cygdrive/c/OpenSSL-$env:ssl_arch/bin/msvcr120.dll" release/
+            c:\cygwin\bin\cp -pv "c:/Tools/vcpkg/installed/$env:arch-windows/bin/zlib1.dll" "c:/Tools/vcpkg/installed/$env:arch-windows/bin/libeay32.dll" "c:/Tools/vcpkg/installed/$env:arch-windows/bin/ssleay32.dll" release/
         }
         c:\cygwin\bin\cp -pv $env:mingw_root/bin/libenchant.dll release/
         c:\cygwin\bin\cp -pv $env:mingw_root/bin/libpcre-1.dll release/


### PR DESCRIPTION
- Old openssl is built in VS2013, grab from vcpkg to make more consistent (VS2017).
  Remove dependency on msvcr120.dll
- Fix vcpkg remove option