### PR TITLE
 KviHttp: support relative redirects; fix #2398 

### DIFF
--- a/src/kvilib/net/KviHttpRequest.cpp
+++ b/src/kvilib/net/KviHttpRequest.cpp
@@ -717,9 +717,10 @@ bool KviHttpRequest::processHeader(KviCString & szHeader)
 						return false;
 					}
 
-					KviCString * location = hdr.find("Location");
+					KviCString * headerLocation = hdr.find("Location");
+					QString location(headerLocation->ptr());
 
-					if(!location)
+					if(location.isEmpty())
 					{
 						resetInternalStatus();
 						m_szLastError = __tr2qs("Bad redirect");
@@ -727,7 +728,17 @@ bool KviHttpRequest::processHeader(KviCString & szHeader)
 						return false;
 					}
 
-					KviUrl url(location->ptr());
+					KviUrl url;
+
+					if(location.startsWith('/'))
+					{
+						// relative redirect, use the old url and only update the path
+						url = m_connectionUrl;
+						url.setPath(location);
+					} else {
+						// absolute redirect
+						url.setUrl(location);
+					}
 
 					if(
 					    (url.url() == m_connectionUrl.url()) || (url.url() == m_url.url()))

--- a/src/kvilib/net/KviUrl.cpp
+++ b/src/kvilib/net/KviUrl.cpp
@@ -66,6 +66,18 @@ void KviUrl::parse()
 	m_uPort = url.port(0);
 }
 
+void KviUrl::build()
+{
+	QUrl url;
+	url.setScheme(m_szProtocol);
+	url.setHost(m_szHost);
+	url.setPath(m_szPath);
+	url.setUserName(m_szUser);
+	url.setPassword(m_szPass);
+	url.setPort(m_uPort);
+	m_szUrl = url.toString();
+}
+
 KviUrl & KviUrl::operator=(const QString & szUrl)
 {
 	m_szUrl = szUrl;
@@ -75,3 +87,47 @@ KviUrl & KviUrl::operator=(const QString & szUrl)
 
 KviUrl & KviUrl::operator=(const KviUrl &)
     = default;
+
+void KviUrl::setUrl(QString & szUrl)
+{
+	m_szUrl = szUrl;
+	parse();
+}
+
+void KviUrl::setProtocol(QString & szProtocol)
+{
+	m_szProtocol = szProtocol;
+	build();
+}
+
+void KviUrl::setHost(QString & szHost)
+{
+	m_szHost = szHost;
+	build();
+}
+
+void KviUrl::setPath(QString & szPath)
+{
+	m_szPath = szPath;
+	if(m_szPath.isEmpty())
+		m_szPath = QString("/");
+	build();
+}
+
+void KviUrl::setUser(QString & szUser)
+{
+	m_szUser = szUser;
+	build();
+}
+
+void KviUrl::setPass(QString & szPass)
+{
+	m_szPass = szPass;
+	build();
+}
+
+void KviUrl::setPort(kvi_u32_t uPort)
+{
+	m_uPort = uPort;
+	build();
+}

--- a/src/kvilib/net/KviUrl.h
+++ b/src/kvilib/net/KviUrl.h
@@ -50,6 +50,7 @@ protected:
 
 protected:
 	void parse();
+	void build();
 
 public:
 	const QString & url() const { return m_szUrl; };
@@ -59,6 +60,14 @@ public:
 	const QString & user() const { return m_szUser; };
 	const QString & pass() const { return m_szPass; };
 	kvi_u32_t port() const { return m_uPort; };
+
+	void setUrl(QString & szUrl);
+	void setProtocol(QString & szProtocol);
+	void setHost(QString & szHost);
+	void setPath(QString & szPath);
+	void setUser(QString & szUser);
+	void setPass(QString & szPass);
+	void setPort(kvi_u32_t uPort);
 
 	KviUrl & operator=(const QString & szUrl);
 	KviUrl & operator=(const KviUrl &);

--- a/src/kvirc/CMakeLists.txt
+++ b/src/kvirc/CMakeLists.txt
@@ -322,12 +322,18 @@ if(APPLE)
 	get_filename_component(QT_LIBRARY_DIR ${QT_LIBRARY_DIR} PATH)
 	get_filename_component(QT_LIBRARY_DIR "${QT_LIBRARY_DIR}/.." ABSOLUTE)
 
-    # qt4: codecs, iconengines, imageformats, phonon_backend, sqldrivers
     # qt5: audio, iconengines, imageformats, mediaservice, platforms, sqldrivers
-
     install(DIRECTORY "${QT_PLUGINS_DIR}/" DESTINATION ${plugin_dest_dir} COMPONENT Runtime
-        FILES_MATCHING REGEX "(audio|codecs|iconengines|imageformats|mediaservice|phonon_backend|platforms|sqldrivers)/.*\\.dylib"
-        REGEX ".*_debug\\.dylib" EXCLUDE)
+        FILES_MATCHING
+        PATTERN "*.dSYM" EXCLUDE
+        PATTERN "*_debug.dylib" EXCLUDE
+        PATTERN "audio/*.dylib"
+        PATTERN "iconengines/*.dylib"
+        PATTERN "imageformats/*.dylib"
+        PATTERN "mediaservice/*.dylib"
+        PATTERN "platforms/*.dylib"
+        PATTERN "sqldrivers/*.dylib"
+    )
 
 	install(CODE "
 	    file(WRITE \"${qtconf_dest_dir}/qt.conf\" \"[Paths]

--- a/src/kvirc/kernel/KviApplication.h
+++ b/src/kvirc/kernel/KviApplication.h
@@ -378,7 +378,7 @@ private:
 #endif //COMPILE_PSEUDO_TRANSPARENCY
 public slots:
 	// KviApplication.cpp : Slots
-	void saveConfiguration();
+	void saveConfiguration() override;
 	void updateGui();
 	void updatePseudoTransparency();
 	void restoreDefaultScript();

--- a/src/kvirc/kernel/KviIrcDataStreamMonitor.h
+++ b/src/kvirc/kernel/KviIrcDataStreamMonitor.h
@@ -33,7 +33,7 @@ class KVIRC_API KviIrcDataStreamMonitor : public KviHeapObject
 {
 public:
 	KviIrcDataStreamMonitor(KviIrcContext * pContext);
-	~KviIrcDataStreamMonitor();
+	virtual ~KviIrcDataStreamMonitor();
 
 protected:
 	KviIrcContext * m_pMyContext;


### PR DESCRIPTION
KviUrl: permit modification of the url
KviHttpRequest: check for relative redirects and change the url's path

Also, minor fixes for 2 compilation warnings (clang) and a fix for proper bundling of Qt plugins on mac
