### PR TITLE
SASL: Add support for EXTERNAL method.

### DIFF
--- a/src/kvilib/irc/KviIrcServer.cpp
+++ b/src/kvilib/irc/KviIrcServer.cpp
@@ -94,6 +94,7 @@ KviIrcServer::KviIrcServer(const KviIrcServer & serv)
 	m_bAutoConnect = serv.m_bAutoConnect;
 	m_szSaslNick = serv.m_szSaslNick;
 	m_szSaslPass = serv.m_szSaslPass;
+	m_szSaslMethod = serv.m_szSaslMethod;
 
 	if(serv.m_pAutoJoinChannelList)
 		m_pAutoJoinChannelList = new QStringList(*(serv.m_pAutoJoinChannelList));
@@ -244,6 +245,8 @@ bool KviIrcServer::load(KviConfigurationFile * pCfg, const QString & szPrefix)
 	m_szSaslPass = pCfg->readEntry(szTmp);
 	szTmp = QString("%1SaslNick").arg(szPrefix);
 	m_szSaslNick = pCfg->readEntry(szTmp);
+	szTmp = QString("%1SaslMethod").arg(szPrefix);
+	m_szSaslMethod = pCfg->readEntry(szTmp, QStringLiteral("PLAIN"));
 	szTmp = QString("%1RealName").arg(szPrefix);
 	m_szRealName = pCfg->readEntry(szTmp);
 	szTmp = QString("%1InitUmode").arg(szPrefix);
@@ -339,6 +342,11 @@ void KviIrcServer::save(KviConfigurationFile * pCfg, const QString & szPrefix)
 	{
 		szTmp = QString("%1SaslNick").arg(szPrefix);
 		pCfg->writeEntry(szTmp, m_szSaslNick);
+	}
+	if(!m_szSaslMethod.isEmpty() && enabledSASL())
+	{
+		szTmp = QString("%1SaslMethod").arg(szPrefix);
+		pCfg->writeEntry(szTmp, m_szSaslMethod);
 	}
 	if(!m_szRealName.isEmpty())
 	{

--- a/src/kvilib/irc/KviIrcServer.h
+++ b/src/kvilib/irc/KviIrcServer.h
@@ -111,6 +111,7 @@ private:
 	int m_iProxy;                         /**< proxy server's id */
 	QString m_szSaslNick;                 /**< nickname for sasl auth */
 	QString m_szSaslPass;                 /**< password for sasl auth */
+	QString m_szSaslMethod;               /**< method name for sasl auth */
 
 public:
 	KviIrcServerReconnectInfo * reconnectInfo()
@@ -158,6 +159,12 @@ public:
 	* \return const QString &
 	*/
 	inline const QString & saslPass() const { return m_szSaslPass; };
+
+	/**
+	* \brief Returns the sasl authentication method to be used
+	* \return const QString &
+	*/
+	const QString & saslMethod() const { return m_szSaslMethod; }
 
 	/**
 	* \brief Returns the nickname of the user associated to the server
@@ -389,6 +396,13 @@ public:
 	* \return void
 	*/
 	inline void setSaslNick(const QString & szNick) { m_szSaslNick = szNick; };
+
+	/**
+	* \brief Sets the sasl method to be used for auth
+	* \param szMethod The method name
+	* \return void
+	*/
+	void setSaslMethod(const QString & szMethod) { m_szSaslMethod = szMethod; }
 
 	/**
 	* \brief Sets the realname of the user associated to the server

--- a/src/kvilib/net/KviSASL.cpp
+++ b/src/kvilib/net/KviSASL.cpp
@@ -28,11 +28,19 @@
 #include "KviMemory.h"
 
 #include <QByteArray>
+#include <QStringList>
 
 namespace KviSASL
 {
+	QStringList supportedMethods()
+	{
+		return {
+			QStringLiteral("PLAIN"),
+			QStringLiteral("EXTERNAL")
+		};
+	}
 
-	bool plainMethod(KviCString & szIn, KviCString & szOut, QByteArray & baNick, QByteArray & baPass)
+	bool plainMethod(const KviCString & szIn, KviCString & szOut, const QByteArray & baNick, const QByteArray & baPass)
 	{
 		if(szIn == "+")
 		{
@@ -54,6 +62,17 @@ namespace KviSASL
 
 			szOut.bufferToBase64(answer2, answerLen);
 			KviMemory::free(answer2);
+
+			return true;
+		}
+		return false;
+	}
+
+	bool externalMethod(const KviCString & szIn, KviCString & szOut)
+	{
+		if(szIn == "+")
+		{
+			szOut = szIn;
 
 			return true;
 		}

--- a/src/kvilib/net/KviSASL.h
+++ b/src/kvilib/net/KviSASL.h
@@ -28,16 +28,23 @@
 
 class KviCString;
 class QByteArray;
+class QStringList;
 
 /**
 * \namespace KviSASL
 * \brief This namespace implement some SASL authentication methods.
 *
-* Currently implementhed methods are PLAIN and DH-BLOWFISH
+* Currently implementhed methods are PLAIN and EXTERNAL
 */
 
 namespace KviSASL
 {
+	/**
+	* \brief Returns a list of the supported SASL methods
+	* \return QStringList
+	*/
+	extern KVILIB_API QStringList supportedMethods();
+
 	/**
 	* \brief Create the auth message for PLAIN authentication
 	* \param szIn The server-provided token
@@ -46,7 +53,15 @@ namespace KviSASL
 	* \param baPass	The password
 	* \return bool
 	*/
-	extern KVILIB_API bool plainMethod(KviCString & szIn, KviCString & szOut, QByteArray & baNick, QByteArray & baPass);
+	extern KVILIB_API bool plainMethod(const KviCString & szIn, KviCString & szOut, const QByteArray & baNick, const QByteArray & baPass);
+
+	/**
+	* \brief Create the auth message for EXTERNAL authentication
+	* \param szIn The server-provided token
+	* \param szOut A KviCString that will be filled with the authentication message
+	* \return bool
+	*/
+	extern KVILIB_API bool externalMethod(const KviCString & szIn, KviCString & szOut);
 };
 
 #endif //_KVI_SASL_H_

--- a/src/kvirc/kernel/KviIrcConnectionStateData.h
+++ b/src/kvirc/kernel/KviIrcConnectionStateData.h
@@ -98,6 +98,7 @@ protected:
 	kvi_time_t m_tLastReceivedWhoisReply = 0;   // the time that we have received the last whois reply, reset to 0 when we receive an /END OF WHOIS
 	QStringList m_lEnabledCaps;                 // the CAPs currently enabled
 	bool m_bIdentifyMsgCapabilityEnabled = false; // do we have the msg-identity CAP enabled ?
+	QString m_szSentSaslMethod;
 public:
 	///
 	/// Sets the current login nickname state
@@ -122,6 +123,9 @@ public:
 	{
 		return m_bIdentifyMsgCapabilityEnabled;
 	}
+
+	const QString & sentSaslMethod() const { return m_szSentSaslMethod; }
+	void setSentSaslMethod(const QString& szMethod) { m_szSentSaslMethod = szMethod; }
 
 	bool sentStartTls() const { return m_bSentStartTls; }
 	void setSentStartTls() { m_bSentStartTls = true; }

--- a/src/modules/options/OptionsWidget_servers.cpp
+++ b/src/modules/options/OptionsWidget_servers.cpp
@@ -55,6 +55,7 @@
 #include "KviPointerHashTable.h"
 #include "KviTalToolTip.h"
 #include "KviIrcNetwork.h"
+#include "KviSASL.h"
 
 #include <QLineEdit>
 #include <QCursor>
@@ -901,19 +902,33 @@ IrcServerDetailsWidget::IrcServerDetailsWidget(QWidget * par, KviIrcServer * s)
 
 	m_pEnableSASLCheck->setChecked(s->enabledSASL());
 
-	l = new QLabel(__tr2qs_ctx("SASL nickname:", "options"), pSASLGroup);
+	l = new QLabel(__tr2qs_ctx("SASL method:", "options"), pSASLGroup);
 	pSASLLayout->addWidget(l, 1, 0);
+	m_pSaslMethodComboBox = new QComboBox(pSASLGroup);
+	m_pSaslMethodComboBox->setDuplicatesEnabled(false);
+	for(auto&& method : KviSASL::supportedMethods())
+		m_pSaslMethodComboBox->addItem(method);
+	KviTalToolTip::add(m_pSaslMethodComboBox, __tr2qs_ctx("Select which SASL method you want to use to authenticate with.<br><br>"
+	                                                      "EXTERNAL will fallback to PLAIN if a non-SSL connection is used or no .pem file is loaded.", "options"));
+	pSASLLayout->addWidget(m_pSaslMethodComboBox, 1, 1);
+
+	int index = m_pSaslMethodComboBox->findText(s->saslMethod());
+	if(index != -1)
+		m_pSaslMethodComboBox->setCurrentIndex(index);
+
+	l = new QLabel(__tr2qs_ctx("SASL nickname:", "options"), pSASLGroup);
+	pSASLLayout->addWidget(l, 2, 0);
 	m_pSaslNickEditor = new QLineEdit(pSASLGroup);
 	m_pSaslNickEditor->setText(s->saslNick());
-	KviTalToolTip::add(m_pSaslNickEditor, __tr2qs_ctx("If you want to enable SASL authentication, insert your nickname here.", "options"));
-	pSASLLayout->addWidget(m_pSaslNickEditor, 1, 1);
+	KviTalToolTip::add(m_pSaslNickEditor, __tr2qs_ctx("If you want to enable SASL authentication, insert your nickname here. (Not required for EXTERNAL)", "options"));
+	pSASLLayout->addWidget(m_pSaslNickEditor, 2, 1);
 
 	l = new QLabel(__tr2qs_ctx("SASL password:", "options"), pSASLGroup);
-	pSASLLayout->addWidget(l, 2, 0);
-	m_pSaslPassEditor = new KviPasswordLineEdit(pSASLGroup); // <---- ?????
+	pSASLLayout->addWidget(l, 3, 0);
+	m_pSaslPassEditor = new KviPasswordLineEdit(pSASLGroup);
 	m_pSaslPassEditor->setText(s->saslPass());
-	KviTalToolTip::add(m_pSaslPassEditor, __tr2qs_ctx("If you want to enable SASL authentication, insert your password here.", "options"));
-	pSASLLayout->addWidget(m_pSaslPassEditor, 2, 1);
+	KviTalToolTip::add(m_pSaslPassEditor, __tr2qs_ctx("If you want to enable SASL authentication, insert your password here. (Not required for EXTERNAL)", "options"));
+	pSASLLayout->addWidget(m_pSaslPassEditor, 3, 1);
 
 	pSASLGroup->setEnabled(s->enabledCAP());
 	connect(m_pEnableCAPCheck, SIGNAL(toggled(bool)), pSASLGroup, SLOT(setEnabled(bool)));
@@ -1115,10 +1130,11 @@ void IrcServerDetailsWidget::fillData(KviIrcServer * s)
 	if(m_pEnableSTARTTLSCheck)
 		s->setEnabledSTARTTLS(m_pEnableSTARTTLSCheck->isChecked());
 
+	s->setSaslMethod(m_pSaslMethodComboBox->currentText());
 	s->setSaslNick(m_pSaslNickEditor->text());
 	s->setSaslPass(m_pSaslPassEditor->text());
 	if(m_pEnableSASLCheck)
-		s->setEnabledSASL(m_pEnableSASLCheck->isChecked() && !m_pSaslNickEditor->text().isEmpty() && !m_pSaslPassEditor->text().isEmpty());
+		s->setEnabledSASL(m_pEnableSASLCheck->isChecked() && ((!m_pSaslNickEditor->text().isEmpty() && !m_pSaslPassEditor->text().isEmpty()) || (m_pSaslMethodComboBox->currentText() == QStringLiteral("EXTERNAL"))));
 	if(m_pIdEditor)
 		s->setId(m_pIdEditor->text());
 	if(s->id().isEmpty())

--- a/src/modules/options/OptionsWidget_servers.h
+++ b/src/modules/options/OptionsWidget_servers.h
@@ -154,6 +154,7 @@ protected:
 	QLineEdit * m_pPortEditor;
 	QStringList m_lstChannels;
 	KviChannelListSelector * m_pChannelListSelector;
+	QComboBox * m_pSaslMethodComboBox;
 
 	QComboBox * m_pProxyEditor;
 protected slots:


### PR DESCRIPTION
- Adds dynamic fallback from EXTERNAL to PLAIN if auth fails on the network.