### PR TITLE
Add an option so a sunken frame is not drawn on our custom widgets.

### DIFF
--- a/src/kvirc/kernel/KviOptions.cpp
+++ b/src/kvirc/kernel/KviOptions.cpp
@@ -333,7 +333,8 @@ KviBoolOption g_boolOptionsTable[KVI_NUM_BOOL_OPTIONS] = {
 	BOOL_OPTION("MenuBarVisible", true, KviOption_sectFlagFrame | KviOption_resetUpdateGui),
 	BOOL_OPTION("WarnAboutHidingMenuBar", true, KviOption_sectFlagFrame),
 	BOOL_OPTION("WhoRepliesToActiveWindow", false, KviOption_sectFlagConnection),
-	BOOL_OPTION("DropConnectionOnSaslFailure", false, KviOption_sectFlagConnection)
+	BOOL_OPTION("DropConnectionOnSaslFailure", false, KviOption_sectFlagConnection),
+	BOOL_OPTION("DrawShadePanel", true, KviOption_sectFlagFrame | KviOption_resetUpdateGui),
 };
 
 // NOTICE: REUSE EQUIVALENT UNUSED KviOption_bool in KviOptions.h ENTRIES BEFORE ADDING NEW ENTRIES ABOVE

--- a/src/kvirc/kernel/KviOptions.h
+++ b/src/kvirc/kernel/KviOptions.h
@@ -355,10 +355,11 @@ DECLARE_OPTION_STRUCT(KviStringListOption, QStringList)
 #define KviOption_boolWarnAboutHidingMenuBar 262
 #define KviOption_boolWhoRepliesToActiveWindow 263                             /* irc::output */
 #define KviOption_boolDropConnectionOnSaslFailure 264                          /* connection::advanced */
+#define KviOption_boolDrawShadePanel 265
 
 // NOTICE: REUSE EQUIVALENT UNUSED BOOL_OPTION in KviOptions.cpp ENTRIES BEFORE ADDING NEW ENTRIES ABOVE
 
-#define KVI_NUM_BOOL_OPTIONS 265
+#define KVI_NUM_BOOL_OPTIONS 266
 
 #define KVI_STRING_OPTIONS_PREFIX "string"
 #define KVI_STRING_OPTIONS_PREFIX_LEN 6

--- a/src/kvirc/ui/KviInput.cpp
+++ b/src/kvirc/ui/KviInput.cpp
@@ -75,7 +75,14 @@ KviInput::KviInput(KviWindow * pPar, KviUserListView * pView)
 	setObjectName("input_widget");
 	m_pLayout = new QGridLayout(this);
 
-	m_pLayout->setMargin(0);
+	if(KVI_OPTION_BOOL(KviOption_boolDrawShadePanel))
+	{
+		m_pLayout->setMargin(0);
+	}
+	else
+	{
+		m_pLayout->setContentsMargins(0, 1, 0, 0);
+	}
 	m_pLayout->setSpacing(0);
 
 	m_pWindow = pPar;
@@ -382,7 +389,8 @@ void KviInput::focusInEvent(QFocusEvent *)
 
 int KviInput::heightHint() const
 {
-	return m_pMultiLineEditor ? (m_pInputEditor->heightHint() * 6) : m_pInputEditor->heightHint();
+	int iHint = m_pMultiLineEditor ? (m_pInputEditor->heightHint() * 6) : m_pInputEditor->heightHint();
+	return KVI_OPTION_BOOL(KviOption_boolDrawShadePanel) ? iHint : iHint + 1;
 }
 
 void KviInput::setText(const QString & szText)
@@ -428,6 +436,15 @@ void KviInput::applyOptions()
 			KviTalToolTip::add(m_pHistoryButton, __tr2qs("Input history disabled"));
 			m_pHistoryButton->disconnect(SIGNAL(clicked()));
 		}
+	}
+
+	if(KVI_OPTION_BOOL(KviOption_boolDrawShadePanel))
+	{
+		m_pLayout->setMargin(0);
+	}
+	else
+	{
+		m_pLayout->setContentsMargins(0, 1, 0, 0);
 	}
 
 	m_pInputEditor->applyOptions();

--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -819,8 +819,11 @@ void KviInputEditor::paintEvent(QPaintEvent *)
 	}
 #endif
 
-	// In Qt5 QStyle::drawPrimitive seems to always overwrite the background, no matter what.
-	qDrawShadePanel(&p, 0, 0, width(), height(), palette(), true, 1, nullptr);
+	if(KVI_OPTION_BOOL(KviOption_boolDrawShadePanel))
+	{
+		// In Qt5 QStyle::drawPrimitive seems to always overwrite the background, no matter what.
+		qDrawShadePanel(&p, 0, 0, width(), height(), palette(), true, 1, nullptr);
+	}
 
 	QRect r(1, 1, width() - 1, height() - 1);
 

--- a/src/kvirc/ui/KviIrcView.cpp
+++ b/src/kvirc/ui/KviIrcView.cpp
@@ -1671,14 +1671,17 @@ void KviIrcView::paintEvent(QPaintEvent * p)
 		}
 	}
 
-	// Need to draw the sunken rect around the view now...
-	pa.setPen(palette().dark().color());
-	pa.drawLine(0, 0, widgetWidth, 0);
-	pa.drawLine(0, 0, 0, widgetHeight);
-	pa.setPen(palette().light().color());
-	widgetWidth--;
-	pa.drawLine(1, widgetHeight - 1, widgetWidth, widgetHeight - 1);
-	pa.drawLine(widgetWidth, 1, widgetWidth, widgetHeight);
+	if(KVI_OPTION_BOOL(KviOption_boolDrawShadePanel))
+	{
+		// Need to draw the sunken rect around the view now...
+		pa.setPen(palette().dark().color());
+		pa.drawLine(0, 0, widgetWidth, 0);
+		pa.drawLine(0, 0, 0, widgetHeight);
+		pa.setPen(palette().light().color());
+		widgetWidth--;
+		pa.drawLine(1, widgetHeight - 1, widgetWidth, widgetHeight - 1);
+		pa.drawLine(widgetWidth, 1, widgetWidth, widgetHeight);
+	}
 }
 
 //

--- a/src/kvirc/ui/KviThemedLabel.cpp
+++ b/src/kvirc/ui/KviThemedLabel.cpp
@@ -77,8 +77,11 @@ void KviThemedLabel::paintEvent(QPaintEvent * e)
 #ifdef COMPILE_PSEUDO_TRANSPARENCY
 	QPainter * p = new QPainter(this);
 
-	// In Qt5 QStyle::drawPrimitive seems to always overwrite the background, no matter what.
-	qDrawShadePanel(p, 0, 0, width(), height(), palette(), true, 1, nullptr);
+	if(KVI_OPTION_BOOL(KviOption_boolDrawShadePanel))
+	{
+		// In Qt5 QStyle::drawPrimitive seems to always overwrite the background, no matter what.
+		qDrawShadePanel(p, 0, 0, width(), height(), palette(), true, 1, nullptr);
+	}
 
 	QRect r(1, 1, width() - 2, height() - 2);
 

--- a/src/kvirc/ui/KviThemedLineEdit.cpp
+++ b/src/kvirc/ui/KviThemedLineEdit.cpp
@@ -88,8 +88,11 @@ void KviThemedLineEdit::paintEvent(QPaintEvent * event)
 	QPainter * p = new QPainter(this);
 	QPalette pal = palette();
 
-	// In Qt5 QStyle::drawPrimitive seems to always overwrite the background, no matter what.
-	qDrawShadePanel(p, 0, 0, width(), height(), palette(), true, 1, nullptr);
+	if(KVI_OPTION_BOOL(KviOption_boolDrawShadePanel))
+	{
+		// In Qt5 QStyle::drawPrimitive seems to always overwrite the background, no matter what.
+		qDrawShadePanel(p, 0, 0, width(), height(), palette(), true, 1, nullptr);
+	}
 
 	QRect r(1, 1, width() - 2, height() - 2);
 

--- a/src/kvirc/ui/KviUserListView.cpp
+++ b/src/kvirc/ui/KviUserListView.cpp
@@ -2137,12 +2137,15 @@ void KviUserListViewArea::paintEvent(QPaintEvent * e)
 		pEntry = pEntry->m_pNext;
 	}
 
-	p.setPen(palette().dark().color());
-	p.drawLine(0, 0, width(), 0);
-	p.drawLine(0, 0, 0, height());
-	p.setPen(palette().light().color());
-	p.drawLine(1, height() - 1, width() - 1, height() - 1);
-	p.drawLine(width() - 1, 1, width() - 1, height());
+	if(KVI_OPTION_BOOL(KviOption_boolDrawShadePanel))
+	{
+		p.setPen(palette().dark().color());
+		p.drawLine(0, 0, width(), 0);
+		p.drawLine(0, 0, 0, height());
+		p.setPen(palette().light().color());
+		p.drawLine(1, height() - 1, width() - 1, height() - 1);
+		p.drawLine(width() - 1, 1, width() - 1, height());
+	}
 }
 
 void KviUserListViewArea::resizeEvent(QResizeEvent *)


### PR DESCRIPTION
Stanzilla's request. Helps with dark Qt themes.