### PR TITLE
Rework the server list GUI filter. Fixes #2438.

### DIFF
--- a/src/modules/options/OptionsWidget_servers.h
+++ b/src/modules/options/OptionsWidget_servers.h
@@ -225,7 +225,7 @@ protected slots:
 	void newNetwork();
 	void removeCurrent();
 	void newServer();
-	void updateFavoritesFilter(bool bSet);
+	void updateFilter();
 	void favoriteServer();
 	void copyServer();
 	void pasteServer();
@@ -237,7 +237,6 @@ protected slots:
 	void recentServersPopupClicked(QAction * pAction);
 	void importPopupActivated(QAction * pAction);
 	void serverNetworkEditTextEdited(const QString & szNewText);
-	void filterTextEdited(const QString & szNewText);
 
 public:
 	virtual void commit();


### PR DESCRIPTION
This commit changes the filter to work as an AND arrangement: servers will be shown if they match both the text filter *and* the favourites filter (if applicable). Previously one was not respected when the other was updated. The favourites filter no longer hides empty networks when disabled.

![image](https://user-images.githubusercontent.com/6897624/63439557-a4fe7980-c471-11e9-985f-3c8b574ac652.png)
![image](https://user-images.githubusercontent.com/6897624/63439636-c2cbde80-c471-11e9-83f6-15258ba5912e.png)
