### PR TITLE
kvilib: Fix format specifier

### DIFF
--- a/src/kvilib/core/KviMemory.cpp
+++ b/src/kvilib/core/KviMemory.cpp
@@ -174,7 +174,7 @@ namespace KviMemory
 		}
 		fprintf(stderr, "|====|====|====|====|====|====|====|====\n");
 		fprintf(stderr, "| Memory profile for KVIrc\n");
-		fprintf(stderr, "| Unfreed chunks : %d\n", countUnfreed);
+		fprintf(stderr, "| Unfreed chunks : %u\n", countUnfreed);
 		fprintf(stderr, "| Total unfreed memory : %u bytes\n", g_iTotalMemAllocated);
 		fprintf(stderr, "|====|====|====|====|====|====|====|====\n");
 		fprintf(stderr, "| Possible unfreed chunks dump:\n");


### PR DESCRIPTION
<!--
Describe the changes you're proposing.
If this pull request is intended to fix a bug, don't forget to mention its #number.
If there are changes in the GUI, include screenshots of the changes.
-->
countUnfreed is unsigned int, correct type is %u
