### PR TITLE
KVS quit command aborts delayed reconnect

### DIFF
--- a/src/kvirc/kernel/KviIrcContext.cpp
+++ b/src/kvirc/kernel/KviIrcContext.cpp
@@ -828,7 +828,7 @@ void KviIrcContext::abortReconnect()
 	if(m_eState == KviIrcContext::PendingReconnection)
 	{
 		delete m_pReconnectTimer;
-		m_pReconnectTimer = 0;
+		m_pReconnectTimer = nullptr;
 		destroyAsynchronousConnectionData();
 		m_pConsole->outputNoFmt(KVI_OUT_SYSTEMERROR,
 			__tr2qs("Reconnect attempt aborted"));

--- a/src/kvirc/kernel/KviIrcContext.cpp
+++ b/src/kvirc/kernel/KviIrcContext.cpp
@@ -825,13 +825,14 @@ void KviIrcContext::terminateConnectionRequest(bool bForce, const QString & szQu
 
 void KviIrcContext::abortReconnect()
 {
-	if(m_pReconnectTimer)
+	if(m_eState == KviIrcContext::PendingReconnection)
 	{
 		delete m_pReconnectTimer;
 		m_pReconnectTimer = 0;
 		destroyAsynchronousConnectionData();
 		m_pConsole->outputNoFmt(KVI_OUT_SYSTEMERROR,
 			__tr2qs("Reconnect attempt aborted"));
+		setState(KviIrcContext::Idle);
 	}
 }
 

--- a/src/kvirc/kernel/KviIrcContext.cpp
+++ b/src/kvirc/kernel/KviIrcContext.cpp
@@ -325,16 +325,7 @@ void KviIrcContext::connectButtonClicked()
 		if(m_pReconnectTimer)
 		{
 			// reconnection was in progress...
-			delete m_pReconnectTimer;
-			m_pReconnectTimer = nullptr;
-			destroyAsynchronousConnectionData();
-
-			m_pConsole->outputNoFmt(KVI_OUT_SYSTEMERROR,
-			    __tr2qs("Reconnect attempt aborted"));
-
-			if(m_eState == KviIrcContext::PendingReconnection)
-				setState(Idle);
-
+			abortReconnect();
 			return;
 		}
 
@@ -829,6 +820,18 @@ void KviIrcContext::terminateConnectionRequest(bool bForce, const QString & szQu
 			// should never end here!
 			KVI_ASSERT(false);
 			break;
+	}
+}
+
+void KviIrcContext::abortReconnect()
+{
+	if(m_pReconnectTimer)
+	{
+		delete m_pReconnectTimer;
+		m_pReconnectTimer = 0;
+		destroyAsynchronousConnectionData();
+		m_pConsole->outputNoFmt(KVI_OUT_SYSTEMERROR,
+			__tr2qs("Reconnect attempt aborted"));
 	}
 }
 

--- a/src/kvirc/kernel/KviIrcContext.h
+++ b/src/kvirc/kernel/KviIrcContext.h
@@ -157,6 +157,7 @@ public:
 	void unregisterDataStreamMonitor(KviIrcDataStreamMonitor * m);
 
 	void terminateConnectionRequest(bool bForce, const QString & szQuitMessage = QString(), bool bSimulateUnexpectedDisconnect = false);
+	void abortReconnect();
 public slots:
 	void closeAllDeadChannels();
 	void closeAllDeadQueries();

--- a/src/kvirc/kvs/KviKvsCoreSimpleCommands_mr.cpp
+++ b/src/kvirc/kvs/KviKvsCoreSimpleCommands_mr.cpp
@@ -1138,6 +1138,8 @@ namespace KviKvsCoreSimpleCommands
 			the -f switch is used. You can control all the [i]unexpected disconnection[/i]
 			options in the options dialog.
 			If the -q switch is specified, this command terminates KVIrc immediately.[br]
+			If the IRC context is disconnect but a delayed reconnect is pending,
+			the reconnect will be aborted.
 		@examples:
 			[example]
 				quit Time to sleep
@@ -1157,8 +1159,13 @@ namespace KviKvsCoreSimpleCommands
 		}
 		else
 		{
-			KVSCSC_REQUIRE_CONNECTION
-			KVSCSC_pWindow->context()->terminateConnectionRequest(KVSCSC_pSwitches->find('f', "force"), szReason, KVSCSC_pSwitches->find('u', "unexpected"));
+			if(!KVSCSC_pIrcContext) return KVSCSC_pContext->errorNoIrcContext();
+			if(KVSCSC_pConnection)
+				KVSCSC_pIrcContext->terminateConnectionRequest(KVSCSC_pSwitches->find('f',"force"),szReason,KVSCSC_pSwitches->find('u',"unexpected"));
+			else if(KVSCSC_pIrcContext->state() == KviIrcContext::PendingReconnection)
+				KVSCSC_pIrcContext->abortReconnect();
+			else
+				return KVSCSC_pContext->warningNoIrcConnection();
 		}
 		return true;
 	}

--- a/src/modules/context/libkvicontext.cpp
+++ b/src/modules/context/libkvicontext.cpp
@@ -401,7 +401,7 @@ STANDARD_IRC_CONNECTION_TARGET_PARAMETER(
 		<string> $context.state(<irc_context_id:uint>)
 	@description:
 		Returns a string describing the state of the specified IRC context.
-		The string will be either [i]idle[/i], [i]connecting[/i], [i]loggingin[/i] or [i]connected[/i].
+		The string will be either [i]idle[/i], [i]pending[/i], [i]connecting[/i], [i]loggingin[/i] or [i]connected[/i].
 		If no irc_context_id is specified then the current irc_context is used.
 		If the irc_context_id specification is not valid then this function
 		returns nothing.


### PR DESCRIPTION
This branch changes the KVS `quit` command so that it will abort a pending delayed reconnect if it exists, as the toolbar button does.
It also updates the documentation for `$context.state`, which can be used to check whether a reconnect is pending.