### PR TITLE
Add "DarkScience" to default server list.

### DIFF
--- a/data/config/serverdb.kvc
+++ b/data/config/serverdb.kvc
@@ -176,6 +176,14 @@ NServers=10
 1_Port=6697
 1_SSL=true
 NServers=2
+[darkscience]
+0_Hostname=irc.darkscience.net
+0_Description=darkscience:%20Main%20address
+1_Hostname=irc.drk.sc
+1_Description=darkscience:%20Short%20address
+1_Port=6697
+1_SSL=true
+NServers=2
 [Deepspace]
 0_Hostname=irc.deepspace.org
 0_Description=Deepspace:%20Random%20server


### PR DESCRIPTION
Request: Addition to default servers list
Not a bug.


According to [netsplit.de's top 100 list](https://netsplit.de/networks/top100.php) "DarkScience" is ranked 66 for number of users.

Notably hosting the [Hak5](https://hak5.org) and [joinmarket](https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/293/files#diff-4f3c2beacd536175f30616463ddaeb33) communities, along with the social aspect of the network itself.

The environment surrounding the network is one of good standing and has a fair reputation of legal and ethical behaviour.

I think this is a fair addition to the list, please let me know if there are any concerns. :)