### PR TITLE
Wayland fixes

### DIFF
--- a/src/kvirc/kernel/KviIpcSentinel.cpp
+++ b/src/kvirc/kernel/KviIpcSentinel.cpp
@@ -83,7 +83,7 @@ static void kvi_ipcSetRemoteCommand(Window w, const char * command)
 	::memcpy(buffer + 8, command, len);
 
 	XChangeProperty(kvi_ipc_get_xdisplay(), w, kvi_atom_ipc_remote_command,
-	    XA_STRING, 8, PropModeReplace, (const unsigned char *)buffer, len + 8);
+		XA_STRING, 8, PropModeReplace, (const unsigned char *)buffer, len + 8);
 
 	::free(buffer);
 }
@@ -172,6 +172,12 @@ bool kvi_sendIpcMessage(const char * message)
 	}
 #elif defined(COMPILE_X11_SUPPORT) && defined(COMPILE_QX11INFO_SUPPORT)
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
+	if (!QX11Info::isPlatformX11()) {
+		return false;
+	}
+#endif
+
 	kvi_ipcLoadAtoms();
 
 	Window sentinel = kvi_x11_findIpcSentinel(kvi_ipc_get_xrootwin());
@@ -196,10 +202,16 @@ KviIpcSentinel::KviIpcSentinel() : QWidget(nullptr)
 	setWindowFlags(Qt::FramelessWindowHint);
 	setWindowTitle("kvirc4_ipc_sentinel");
 #elif defined(COMPILE_X11_SUPPORT) && defined(COMPILE_QX11INFO_SUPPORT)
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
+	if (!QX11Info::isPlatformX11()) {
+		return;
+	}
+#endif
 	kvi_ipcLoadAtoms();
 
 	XChangeProperty(kvi_ipc_get_xdisplay(), winId(), kvi_atom_ipc_sentinel_window, XA_STRING, 8,
-	    PropModeReplace, (const unsigned char *)kvi_sentinel_id.ptr(), kvi_sentinel_id.len());
+		PropModeReplace, (const unsigned char *)kvi_sentinel_id.ptr(), kvi_sentinel_id.len());
 
 	kvi_ipcSetRemoteCommand(winId(), "");
 #endif //!COMPILE_NO_X && !COMPILE_ON_WINDOWS

--- a/src/kvirc/ui/KviMainWindow.cpp
+++ b/src/kvirc/ui/KviMainWindow.cpp
@@ -105,7 +105,10 @@ KviMainWindow::KviMainWindow(QWidget * pParent)
 	// We try to avois this as much as possible, since it forces the use of the low-res 16x16 icon
 	setWindowIcon(*(g_pIconManager->getSmallIcon(KviIconManager::KVIrc)));
 #endif
-
+#if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+	// set name of the app desktop file; used by wayland to load the window icon
+	QGuiApplication::setDesktopFileName("kvirc");
+#endif
 	setWindowTitle(KVI_DEFAULT_FRAME_CAPTION);
 
 	m_pSplitter = new QSplitter(Qt::Horizontal, this);


### PR DESCRIPTION
The minimum needed fixes to run KVIrc on wayland.
Qt 5.2 is mandatory, >= 5.7 is preferable.

Changes:
 * disable X11 IPC at runtime to avoid crash on start (partially fixes #2479, but a proper IPC is still missing).
 * Correctly set main window icon
 * minor unrelated indentation changes 
