### PR TITLE
Fix #2478

### DIFF
--- a/src/kvirc/kernel/KviIrcConnection.cpp
+++ b/src/kvirc/kernel/KviIrcConnection.cpp
@@ -832,10 +832,11 @@ bool KviIrcConnection::sendData(const char * pcBuffer, int iBuflen)
 			m_pConsole->outputNoFmt(KVI_OUT_SOCKETWARNING, __tr2qs("[LINK WARNING]: Socket message truncated to 512 bytes."));
 	}
 
-	KviDataBuffer * pData = new KviDataBuffer(iBuflen + 2);
+	KviDataBuffer * pData = new KviDataBuffer(iBuflen + 3);
 	KviMemory::move(pData->data(), pcBuffer, iBuflen);
 	*(pData->data() + iBuflen) = '\r';
 	*(pData->data() + iBuflen + 1) = '\n';
+	*(pData->data() + iBuflen + 2) = '\0';
 
 	QString szMsg = (const char *)(pData->data());
 	szMsg.truncate(iBuflen);

--- a/src/kvirc/kernel/KviLagMeter.cpp
+++ b/src/kvirc/kernel/KviLagMeter.cpp
@@ -267,11 +267,17 @@ void KviLagMeter::lagCheckAbort(const char * key)
 
 	QList<KviLagCheck *> lAborted;
 
-	for(auto c : m_lCheckList)
+	auto c = m_lCheckList.begin();
+	while(c != m_lCheckList.end())
 	{
-		if(kvi_strEqualCS(c->szKey.ptr(), key))
-			lAborted.append(c);
+		if(kvi_strEqualCS((*c)->szKey.ptr(), key))
+		{
+			delete *c;
+			c = m_lCheckList.erase(c);
+		}
+		else
+		{
+			++c;
+		}
 	}
-	
-	qDeleteAll(lAborted);
 }


### PR DESCRIPTION
My client was crashing every day or two. Putting it through a debugger immediately revealed an access violation. I gave that a quick patch and then let it run again until it crashed. When it eventually did, the problem turned out to be #2478.

I fixed what appears to be the cause, but I can't be 100% sure it is as I'm not currently free to disable WAN access to reproduce the issue. Firewalling the client on my local machine turned out to be insufficient and I didn't want to bother trying to trigger it in the code. That said, I was able to run the client for a full week without another crash, so I'm pretty confident. And either way, both commits fix things that need to be fixed.
