### PR TITLE
Document the AVATAR negotiation protocol

### DIFF
--- a/src/kvilib/irc/KviAvatar.cpp
+++ b/src/kvilib/irc/KviAvatar.cpp
@@ -57,9 +57,9 @@
 		are two users: A and B.[br]
 		When user A wants to see the B's avatar he simply sends a CTCP AVATAR request
 		to B (the request is sent through a PRIVMSG IRC command). The presence of the avatar
-		is announced by the ASCII sequence ETX, '0'-'7', SI, which doesn't show up on IRC
-		clients, at the start of B's realname, where bit 2 (the fours place) of the ASCII
-		digit is set when an avatar is present. (Bits 0 and 1 are unrelated to avatar
+		is announced by the ASCII sequence ETX, one of '0'-'7', SI, which doesn't show up
+		on IRC clients, at the start of B's realname, where bit 2 (the fours place) of the
+		ASCII digit is set when an avatar is present. (Bits 0 and 1 are unrelated to avatar
 		negotiation and should be left unset if not being used.)[br]
 		User B replies with a CTCP AVATAR notification (sent through a NOTICE IRC command)
 		with the name or URL of his avatar.[br]

--- a/src/kvilib/irc/KviAvatar.cpp
+++ b/src/kvilib/irc/KviAvatar.cpp
@@ -57,8 +57,9 @@
 		are two users: A and B.[br]
 		When user A wants to see the B's avatar he simply sends a CTCP AVATAR request
 		to B (the request is sent through a PRIVMSG IRC command). This is negotiated by
-		hiding an U+0003 '4' U+000F sequence at the start of B's realname, which doesn't
-		show up on IRC clients.[br]
+		hiding an U+0003 '4' U+000F, U+0003 '5' U+000F, U+0003 '6' U+000F or
+		U+0003 '7' U+000F sequence (with values other than '4' being deprecated) at the
+		start of B's realname, which doesn't show up on IRC clients.[br]
 		User B replies with a CTCP AVATAR notification (sent through a NOTICE IRC command)
 		with the name or URL of his avatar.[br]
 		The actual syntax for the notification is:[br]

--- a/src/kvilib/irc/KviAvatar.cpp
+++ b/src/kvilib/irc/KviAvatar.cpp
@@ -57,9 +57,9 @@
 		are two users: A and B.[br]
 		When user A wants to see the B's avatar he simply sends a CTCP AVATAR request
 		to B (the request is sent through a PRIVMSG IRC command). This is negotiated by
-		hiding an U+0003 '4' U+000F, U+0003 '5' U+000F, U+0003 '6' U+000F or
-		U+0003 '7' U+000F sequence (with values other than '4' being deprecated) at the
-		start of B's realname, which doesn't show up on IRC clients.[br]
+		a hidden color-code bitfield at the start of B's realname, which doesn't show up
+		on IRC clients, where bit 2, that is U+0003 '4' U+000F, U+0003 '5' U+000F,
+		U+0003 '6' U+000F or U+0003 '7' U+000F, signals an avatar being present.[br]
 		User B replies with a CTCP AVATAR notification (sent through a NOTICE IRC command)
 		with the name or URL of his avatar.[br]
 		The actual syntax for the notification is:[br]

--- a/src/kvilib/irc/KviAvatar.cpp
+++ b/src/kvilib/irc/KviAvatar.cpp
@@ -56,11 +56,11 @@
 		Every IRC user has a client-side property called AVATAR. Let's say that there
 		are two users: A and B.[br]
 		When user A wants to see the B's avatar he simply sends a CTCP AVATAR request
-		to B (the request is sent through a PRIVMSG IRC command). This is negotiated by
-		the ASCII sequence ETX, '0'-'7', SI, which doesn't show up on IRC clients, at the
-		start of B's realname, where bit 2 of the ASCII digit is set when an avatar is
-		present. (Bits 0 and 1 are unrelated to avatar negotiation and should be left unset
-		if not being used.)[br]
+		to B (the request is sent through a PRIVMSG IRC command). The presence of the avatar
+		is announced by the ASCII sequence ETX, '0'-'7', SI, which doesn't show up on IRC
+		clients, at the start of B's realname, where bit 2 (the fours place) of the ASCII
+		digit is set when an avatar is present. (Bits 0 and 1 are unrelated to avatar
+		negotiation and should be left unset if not being used.)[br]
 		User B replies with a CTCP AVATAR notification (sent through a NOTICE IRC command)
 		with the name or URL of his avatar.[br]
 		The actual syntax for the notification is:[br]

--- a/src/kvilib/irc/KviAvatar.cpp
+++ b/src/kvilib/irc/KviAvatar.cpp
@@ -56,7 +56,9 @@
 		Every IRC user has a client-side property called AVATAR. Let's say that there
 		are two users: A and B.[br]
 		When user A wants to see the B's avatar he simply sends a CTCP AVATAR request
-		to B (the request is sent through a PRIVMSG IRC command).[br]
+		to B (the request is sent through a PRIVMSG IRC command). This is negotiated by
+		hiding an U+0003 '4' U+000F sequence at the start of B's realname, which doesn't
+		show up on IRC clients.[br]
 		User B replies with a CTCP AVATAR notification (sent through a NOTICE IRC command)
 		with the name or URL of his avatar.[br]
 		The actual syntax for the notification is:[br]

--- a/src/kvilib/irc/KviAvatar.cpp
+++ b/src/kvilib/irc/KviAvatar.cpp
@@ -57,9 +57,10 @@
 		are two users: A and B.[br]
 		When user A wants to see the B's avatar he simply sends a CTCP AVATAR request
 		to B (the request is sent through a PRIVMSG IRC command). This is negotiated by
-		a hidden color-code bitfield at the start of B's realname, which doesn't show up
-		on IRC clients, where bit 2, that is U+0003 '4' U+000F, U+0003 '5' U+000F,
-		U+0003 '6' U+000F or U+0003 '7' U+000F, signals an avatar being present.[br]
+		the ASCII sequence ETX, '0'-'7', SI, which doesn't show up on IRC clients, at the
+		start of B's realname, where bit 2 of the ASCII digit is set when an avatar is
+		present. (Bits 0 and 1 are unrelated to avatar negotiation and should be left unset
+		if not being used.)[br]
 		User B replies with a CTCP AVATAR notification (sent through a NOTICE IRC command)
 		with the name or URL of his avatar.[br]
 		The actual syntax for the notification is:[br]


### PR DESCRIPTION
<!--
Describe the changes you're proposing.
If this pull request is intended to fix a bug, don't forget to mention its #number.
If there are changes in the GUI, include screenshots of the changes.
-->

This could be better solved by somehow being able to add user/custom message tags to the WHO output, but the legacy protocol should still be documented.