### PR TITLE
Implement the UTF8ONLY IRCv3 specification

### DIFF
--- a/src/kvirc/sparser/KviIrcServerParser_numericHandlers.cpp
+++ b/src/kvirc/sparser/KviIrcServerParser_numericHandlers.cpp
@@ -269,6 +269,7 @@ void KviIrcServerParser::parseNumeric005(KviIrcMessage * msg)
 			 * CALLERID -> The server supports server side ignores via the +g user mode
 			 * ACCEPT -> The server supports server side ignore (deprecated by CALLERID)
 			 * LANGUAGE -> The server supports the LANGUAGE command (experimental, e.g. LANGUAGE=2,en,i-klingon)
+			 * UTF8ONLY -> The server supports only UTF-8 messages in both directions https://ircv3.net/specs/extensions/utf8-only
 			 */
 			if(kvi_strEqualCIN("PREFIX=(", p, 8))
 			{
@@ -374,6 +375,10 @@ void KviIrcServerParser::parseNumeric005(KviIrcMessage * msg)
 				msg->connection()->serverInfo()->setSupportsWhox(true);
 				if((!_OUTPUT_MUTE) && (!msg->haltOutput()) && KVI_OPTION_BOOL(KviOption_boolShowExtendedServerInfo))
 					msg->console()->outputNoFmt(KVI_OUT_SERVERINFO, __tr2qs("This server supports the WHOX, extra information will be retrieved"));
+			}
+			else if(kvi_strEqualCIN("UTF8ONLY", p, 4))
+			{
+				msg->connection()->setEncoding("UTF-8");
 			}
 		}
 		if((!_OUTPUT_MUTE) && (!msg->haltOutput()))

--- a/src/kvirc/sparser/KviIrcServerParser_numericHandlers.cpp
+++ b/src/kvirc/sparser/KviIrcServerParser_numericHandlers.cpp
@@ -376,7 +376,7 @@ void KviIrcServerParser::parseNumeric005(KviIrcMessage * msg)
 				if((!_OUTPUT_MUTE) && (!msg->haltOutput()) && KVI_OPTION_BOOL(KviOption_boolShowExtendedServerInfo))
 					msg->console()->outputNoFmt(KVI_OUT_SERVERINFO, __tr2qs("This server supports the WHOX, extra information will be retrieved"));
 			}
-			else if(kvi_strEqualCIN("UTF8ONLY", p, 4))
+			else if(kvi_strEqualCIN("UTF8ONLY", p, 8))
 			{
 				msg->connection()->setEncoding("UTF-8");
 			}


### PR DESCRIPTION
When the server sends a `UTF8ONLY` isupport token, override the user configuration and use UTF-8 to send and receive messages.

Relevant bits from https://ircv3.net/specs/extensions/utf8-only:

> Servers publishing this token MUST NOT relay content [...] containing non-UTF-8 data to clients.

> Clients implementing this specification MUST NOT send non-UTF-8 data to the server once they have seen this token.

> If a client implementing this specification sees this token, they MUST set their outgoing encoding to UTF-8 without requiring any user intervention