### PR TITLE
editor: Fix crash when editing empty network list

### DIFF
--- a/src/modules/editor/ScriptEditorImplementation.cpp
+++ b/src/modules/editor/ScriptEditorImplementation.cpp
@@ -173,6 +173,10 @@ void ScriptEditorWidget::asyncCompleterCreation()
 		m_pListModulesNames = new QStringList(d.entryList(QDir::Files | QDir::Readable));
 		iModulesCount = m_pListModulesNames->count();
 	}
+
+	if (iIndex <= m_pListModulesNames->size())
+		return;
+
 	QString szModuleName = m_pListModulesNames->at(iIndex);
 	iIndex++;
 


### PR DESCRIPTION
<!--
Describe the changes you're proposing.
If this pull request is intended to fix a bug, don't forget to mention its #number.
If there are changes in the GUI, include screenshots of the changes.
-->

sys info:
```
KVIrc 5.0.1 'Aria'

Runtime Info:
System name: CYGWIN_NT-10.0-19044 3.4.6-1.x86_64
System version: 2023-02-14 13:23 UTC
Architecture: x86_64
Qt version: 5.9.4
Qt theme: fusion

Build Info:
Build date: 2023-06-14 06:16:44 UTC
Sources date: 20230527
Revision number: 5.0.0-103-gb4405b0c3
CPU name: x86_64
Build command: /usr/bin/cmake.exe
Build flags: 
   MANDIR=share/man
   CMAKE_INSTALL_PREFIX=/usr/local
   LIB_SUFFIX=
   Threads=POSIX
Compiler name: /usr/bin/c++.exe
Compiler flags: N/A
Qt version: 5.9.4
Features: IRC, IPv6, Crypt, SSL, IfAddr, IPC, OSS, Transparency, Webkit, DCCVoice, Perl, Python, Qt5, KVS
OpenSSL version: OpenSSL 1.1.1u 30 May 2023
OpenSSL compiler flags: compiler: gcc -ggdb -O2 -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong --param=ssp-buffer-size=4 -fdebug-prefix-map=/mnt/share/packages/openssl/openssl.x86_64/build=/usr/src/debug/openssl-1.1.1u-1 -fdebug-prefix-map=/mnt/share/packages/openssl/openssl.x86_64/src/openssl-1.1.1u=/usr/src/debug/openssl-1.1.1u-1 -DTERMIOS -DL_ENDIAN -DOPENSSL_PIC -DOPENSSL_CPUID_OBJ -DOPENSSL_IA32_SSE2 -DOPENSSL_BN_ASM_MONT -DOPENSSL_BN_ASM_MONT5 -DOPENSSL_BN_ASM_GF2m -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DKECCAK1600_ASM -DRC4_ASM -DMD5_ASM -DAESNI_ASM -DVPAES_ASM -DGHASH_ASM -DECP_NISTZ256_ASM -DX25519_ASM -DPOLY1305_ASM -DZLIB -DNDEBUG -DDEVRANDOM="\"/dev/urandom\"" -DSYSTEM_CIPHERS_FILE="/etc/crypto-policies/back-ends/openssl.config"
OpenSSL built on: Mon Jun 5 13:32:27 2023 UTC
```

compiled on cygwin, experienced this after editing a network with 0 servers after a few seconds:

```
$ gdb /usr/local/bin/kvirc
GNU gdb (GDB) (Cygwin 12.1-1) 12.1
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-pc-cygwin".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /usr/local/bin/kvirc...
(gdb) run
Starting program: /usr/local/bin/kvirc
[New Thread 80480.0x187fc]
[New Thread 80480.0x186e4]
[New Thread 80480.0x18a34]
[New Thread 80480.0x91c4]
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-static'
[New Thread 80480.0x15ba4]
[New Thread 80480.0x136e0]
[New Thread 80480.0x11fb0]
[New Thread 80480.0x6f1c]
[New Thread 80480.0x18224]
[New Thread 80480.0x17748]
[New Thread 80480.0x14310]
      0 [main] kvirc 1805 child_info_fork::abort: \??\C:\cygwin64\bin\cygX11-xcb-1.dll: Loaded to different address: parent(0x1A0000) != child(0x170000)
                                                                                                                                                        [New Thread 80480.0x185d0]
[New Thread 80480.0xe53c]
[New Thread 80480.0x16430]
[New Thread 80480.0x18640]
[Thread 80480.0xe53c exited with code 0]
[Thread 80480.0x16430 exited with code 0]
[Thread 80480.0x18640 exited with code 0]
[New Thread 80480.0x7740]
[New Thread 80480.0x16008]
[New Thread 80480.0x1851c]
QXcbShmImage: shmget() failed (88: Function not implemented) for size 7810560 (1920x1017)
QXcbShmImage: shmget() failed (88: Function not implemented) for size 1224096 (622x492)
[New Thread 80480.0x161d4]
QXcbShmImage: shmget() failed (88: Function not implemented) for size 1415232 (702x504)
ASSERT failure in QList<T>::at: "index out of range", file /usr/include/qt5/QtCore/qlist.h, line 541

Thread 1 "kvirc" received signal SIGABRT, Aborted.
0x00007ffb4e86d0e4 in ntdll!ZwWaitForSingleObject () from /cygdrive/c/Windows/SYSTEM32/ntdll.dll
(gdb) bt
#0  0x00007ffb4e86d0e4 in ntdll!ZwWaitForSingleObject () from /cygdrive/c/Windows/SYSTEM32/ntdll.dll
#1  0x00007ffb4c2e30ce in WaitForSingleObjectEx () from /cygdrive/c/Windows/System32/KERNELBASE.dll
#2  0x00007ffb22fb00d0 in sig_send (p=<optimized out>, p@entry=0x0, si=..., tls=<optimized out>) at /usr/src/debug/cygwin-3.4.6-1/winsup/cygwin/sigproc.cc:763
#3  0x00007ffb22f9b04e in pthread_kill (thread=<optimized out>, sig=6) at /usr/src/debug/cygwin-3.4.6-1/winsup/cygwin/thread.cc:3270
#4  0x00007ffb22fac1a5 in raise (sig=sig@entry=6) at /usr/src/debug/cygwin-3.4.6-1/winsup/cygwin/signal.cc:310
#5  0x00007ffb231068d8 in abort () at /usr/src/debug/cygwin-3.4.6-1/winsup/cygwin/signal.cc:409
#6  0x00000003faccf220 in cygQt5Core-5!_ZNK14QMessageLogger5fatalEPKcz () from /usr/bin/cygQt5Core-5.dll
#7  0x00000003faccb4c1 in cygQt5Core-5!_Z11qt_assert_xPKcS0_S0_i () from /usr/bin/cygQt5Core-5.dll
#8  0x000000048163de70 in QList<QString>::at (this=0xa005601b0, i=0) at /usr/include/qt5/QtCore/qlist.h:541
#9  0x0000000481632850 in ScriptEditorWidget::asyncCompleterCreation (this=0xa0055e9a0) at /home/static/KVIrc/src/modules/editor/ScriptEditorImplementation.cpp:176
#10 0x0000000481631103 in ScriptEditorWidget::qt_static_metacall (_o=0xa0055e9a0, _c=QMetaObject::InvokeMetaMethod, _id=6, _a=0x7ffffa800) at /home/static/KVIrc/build/src/modules/editor/kvieditor_autogen/EWIEGA46WW/moc_ScriptEditorImplementation.cpp:108
#11 0x00000003fae7347a in cygQt5Core-5!_ZN11QMetaObject8activateEP7QObjectiiPPv () from /usr/bin/cygQt5Core-5.dll
#12 0x00000003fae7dfcb in cygQt5Core-5!_ZN6QTimer10timerEventEP11QTimerEvent () from /usr/bin/cygQt5Core-5.dll
#13 0x00000003fae74460 in cygQt5Core-5!_ZN7QObject5eventEP6QEvent () from /usr/bin/cygQt5Core-5.dll
#14 0x00000003f9fe7c1c in cygQt5Widgets-5!_ZN19QApplicationPrivate13notify_helperEP7QObjectP6QEvent () from /usr/bin/cygQt5Widgets-5.dll
#15 0x00000003f9fef40a in cygQt5Widgets-5!_ZN12QApplication6notifyEP7QObjectP6QEvent () from /usr/bin/cygQt5Widgets-5.dll
#16 0x00000003fae500f6 in cygQt5Core-5!_ZN16QCoreApplication15notifyInternal2EP7QObjectP6QEvent () from /usr/bin/cygQt5Core-5.dll
#17 0x00000003fae95d49 in cygQt5Core-5!_ZN14QTimerInfoList14activateTimersEv () from /usr/bin/cygQt5Core-5.dll
#18 0x00000003fae96201 in cygQt5Core-5!_ZN20QEventDispatcherGlib18qt_static_metacallEP7QObjectN11QMetaObject4CallEiPPv () from /usr/bin/cygQt5Core-5.dll
#19 0x00000003f86a0761 in g_main_context_dispatch () from /usr/bin/cygglib-2.0-0.dll
#20 0x00000003f86a0998 in g_main_context_dispatch () from /usr/bin/cygglib-2.0-0.dll
#21 0x00000003f86a0a4d in g_main_context_iteration () from /usr/bin/cygglib-2.0-0.dll
#22 0x00000003fae96668 in cygQt5Core-5!_ZN20QEventDispatcherGlib13processEventsE6QFlagsIN10QEventLoop17ProcessEventsFlagEE () from /usr/bin/cygQt5Core-5.dll
#23 0x00000003fae4efae in cygQt5Core-5!_ZN10QEventLoop4execE6QFlagsINS_17ProcessEventsFlagEE () from /usr/bin/cygQt5Core-5.dll
#24 0x00000003fa1c463c in cygQt5Widgets-5!_ZN7QDialog4execEv () from /usr/bin/cygQt5Widgets-5.dll
#25 0x00000005d297e31d in OptionsWidget_servers::detailsClicked (this=0xa0035a1c0) at /home/static/KVIrc/src/modules/options/OptionsWidget_servers.cpp:2181
#26 0x00000005d297b721 in OptionsWidget_servers::itemDoubleClicked (this=0xa0035a1c0) at /home/static/KVIrc/src/modules/options/OptionsWidget_servers.cpp:1689
#27 0x00000005d293683d in OptionsWidget_servers::qt_static_metacall (_o=0xa0035a1c0, _c=QMetaObject::InvokeMetaMethod, _id=14, _a=0x7ffffb320) at /home/static/KVIrc/build/src/modules/options/kvioptions_autogen/EWIEGA46WW/moc_OptionsWidget_servers.cpp:381
#28 0x00000003fae7347a in cygQt5Core-5!_ZN11QMetaObject8activateEP7QObjectiiPPv () from /usr/bin/cygQt5Core-5.dll
#29 0x00000003fa2868b5 in cygQt5Widgets-5!_ZrsR11QDataStreamR15QTreeWidgetItem () from /usr/bin/cygQt5Widgets-5.dll
#30 0x00000003fa28d2e1 in cygQt5Widgets-5!_ZN11QTreeWidget18qt_static_metacallEP7QObjectN11QMetaObject4CallEiPPv () from /usr/bin/cygQt5Widgets-5.dll
#31 0x00000003fae7347a in cygQt5Core-5!_ZN11QMetaObject8activateEP7QObjectiiPPv () from /usr/bin/cygQt5Core-5.dll
#32 0x00000003fa214a6c in cygQt5Widgets-5!_ZN17QAbstractItemView13doubleClickedERK11QModelIndex () from /usr/bin/cygQt5Widgets-5.dll
#33 0x00000003fa280f77 in cygQt5Widgets-5!_ZN9QTreeView21mouseDoubleClickEventEP11QMouseEvent () from /usr/bin/cygQt5Widgets-5.dll
#34 0x00000003fa0286e0 in cygQt5Widgets-5!_ZN7QWidget5eventEP6QEvent () from /usr/bin/cygQt5Widgets-5.dll
#35 0x00000003fa0c289e in cygQt5Widgets-5!_ZN6QFrame5eventEP6QEvent () from /usr/bin/cygQt5Widgets-5.dll
#36 0x00000003fa221ebe in cygQt5Widgets-5!_ZN17QAbstractItemView13viewportEventEP6QEvent () from /usr/bin/cygQt5Widgets-5.dll
#37 0x00000003fa283127 in cygQt5Widgets-5!_ZN9QTreeView13viewportEventEP6QEvent () from /usr/bin/cygQt5Widgets-5.dll
#38 0x00000003fae4fe92 in cygQt5Core-5!_ZN23QCoreApplicationPrivate29sendThroughObjectEventFiltersEP7QObjectP6QEvent () from /usr/bin/cygQt5Core-5.dll
#39 0x00000003f9fe7bf5 in cygQt5Widgets-5!_ZN19QApplicationPrivate13notify_helperEP7QObjectP6QEvent () from /usr/bin/cygQt5Widgets-5.dll
#40 0x00000003f9ff063e in cygQt5Widgets-5!_ZN12QApplication6notifyEP7QObjectP6QEvent () from /usr/bin/cygQt5Widgets-5.dll
#41 0x00000003fae500f6 in cygQt5Core-5!_ZN16QCoreApplication15notifyInternal2EP7QObjectP6QEvent () from /usr/bin/cygQt5Core-5.dll
#42 0x00000003f9fee853 in cygQt5Widgets-5!_ZN19QApplicationPrivate14sendMouseEventEP7QWidgetP11QMouseEventS1_S1_PS1_R8QPointerIS0_Eb () from /usr/bin/cygQt5Widgets-5.dll
#43 0x00000003fa03e87e in cygQt5Widgets-5!_ZN14QDesktopWidget11qt_metacallEN11QMetaObject4CallEiPPv () from /usr/bin/cygQt5Widgets-5.dll
#44 0x00000003fa0412fb in cygQt5Widgets-5!_ZN14QDesktopWidget11qt_metacallEN11QMetaObject4CallEiPPv () from /usr/bin/cygQt5Widgets-5.dll
#45 0x00000003f9fe7c1c in cygQt5Widgets-5!_ZN19QApplicationPrivate13notify_helperEP7QObjectP6QEvent () from /usr/bin/cygQt5Widgets-5.dll
#46 0x00000003f9fef40a in cygQt5Widgets-5!_ZN12QApplication6notifyEP7QObjectP6QEvent () from /usr/bin/cygQt5Widgets-5.dll
#47 0x00000003fae500f6 in cygQt5Core-5!_ZN16QCoreApplication15notifyInternal2EP7QObjectP6QEvent () from /usr/bin/cygQt5Core-5.dll
#48 0x00000003fa80b3b4 in cygQt5Gui-5!_ZN22QGuiApplicationPrivate17processMouseEventEPN29QWindowSystemInterfacePrivate10MouseEventE () from /usr/bin/cygQt5Gui-5.dll
#49 0x00000003fa80cf95 in cygQt5Gui-5!_ZN22QGuiApplicationPrivate24processWindowSystemEventEPN29QWindowSystemInterfacePrivate17WindowSystemEventE () from /usr/bin/cygQt5Gui-5.dll
#50 0x00000003fa7efbee in cygQt5Gui-5!_ZN22QWindowSystemInterface22sendWindowSystemEventsE6QFlagsIN10QEventLoop17ProcessEventsFlagEE () from /usr/bin/cygQt5Gui-5.dll
#51 0x00000003f9f458e1 in cygQt5XcbQpa-5!_ZN23QXcbGlIntegrationPlugin11qt_metacallEN11QMetaObject4CallEiPPv () from /usr/bin/cygQt5XcbQpa-5.dll
#52 0x00000003f86a0761 in g_main_context_dispatch () from /usr/bin/cygglib-2.0-0.dll
#53 0x00000003f86a0998 in g_main_context_dispatch () from /usr/bin/cygglib-2.0-0.dll
#54 0x00000003f86a0a4d in g_main_context_iteration () from /usr/bin/cygglib-2.0-0.dll
#55 0x00000003fae96668 in cygQt5Core-5!_ZN20QEventDispatcherGlib13processEventsE6QFlagsIN10QEventLoop17ProcessEventsFlagEE () from /usr/bin/cygQt5Core-5.dll
#56 0x00000003fae4efae in cygQt5Core-5!_ZN10QEventLoop4execE6QFlagsINS_17ProcessEventsFlagEE () from /usr/bin/cygQt5Core-5.dll
#57 0x00000003fae573b9 in cygQt5Core-5!_ZN16QCoreApplication4execEv () from /usr/bin/cygQt5Core-5.dll
#58 0x00000001005a6c51 in main (argc=1, argv=0x7ffffcc50) at /home/static/KVIrc/src/kvirc/kernel/KviMain.cpp:488
```