### PR TITLE
Port to (and require) Qt 5.15. Drop KDE4 support, fix KDE5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -389,7 +389,7 @@ endif()
 # Check for Qt5
 ############################################################################
 
-find_package(Qt5Widgets)
+find_package(Qt5Widgets 5.15)
 if(Qt5Widgets_FOUND)
 	set(CMAKE_STATUS_QT_VERSION "${Qt5Widgets_VERSION_STRING}")
 	set(qt5_kvirc_modules)
@@ -521,17 +521,15 @@ if(WANT_KDE)
 				XmlGui          # KMainWindow
 				WindowSystem    # KWindowSystem
 				Notifications   # KNotification
-				Service         # KToolInvocation
+				Service         # KService, KApplicationTrader
+				KIO             # KTerminalLauncherJob, KIO/ApplicationLauncherJob
+				Parts           # KParts
 			)
 
 		if(KF5_FOUND)
 			set(CMAKE_RESULT_USING_KDE true)
-			#include_directories(${KDE4_INCLUDES})
-			#add_definitions(${KDE4_DEFINITIONS})
 			set(COMPILE_KDE_SUPPORT 1)
-			# There seems to be no portable way to figure out if KDE version is 4 or 5
-			set(COMPILE_KDE5_SUPPORT 1)
-			list(APPEND LIBS KF5::CoreAddons KF5::I18n KF5::XmlGui KF5::WindowSystem KF5::Notifications KF5::Service)
+			list(APPEND LIBS KF5::CoreAddons KF5::I18n KF5::XmlGui KF5::WindowSystem KF5::Notifications KF5::Service KF5::KIOCore KF5::KIOGui KF5::KIOWidgets KF5::Parts)
 			set(CMAKE_STATUS_KDE_SUPPORT "Yes")
 			if(DEFINED KF5_VERSION)
 				set(CMAKE_STATUS_KDE_VERSION ${KF5_VERSION})

--- a/cmake/kvi_sysconfig.h.cmake
+++ b/cmake/kvi_sysconfig.h.cmake
@@ -33,12 +33,7 @@
 #cmakedefine COMPILE_IPV6_SUPPORT 1
 #cmakedefine COMPILE_PSEUDO_TRANSPARENCY 1
 #cmakedefine COMPILE_ENCHANT_SUPPORT 1
-// Do we use KDE at all?
 #cmakedefine COMPILE_KDE_SUPPORT 1
-// Using KDE4 ? Implies COMPILE_KDE_SUPPORT
-#cmakedefine COMPILE_KDE4_SUPPORT 1
-// Using KDE5 ? Implies COMPILE_KDE_SUPPORT
-#cmakedefine COMPILE_KDE5_SUPPORT 1
 #cmakedefine COMPILE_WEBKIT_SUPPORT 1
 #cmakedefine COMPILE_DBUS_SUPPORT 1
 #cmakedefine COMPILE_ZLIB_SUPPORT 1

--- a/src/kvilib/ext/KviCommandFormatter.cpp
+++ b/src/kvilib/ext/KviCommandFormatter.cpp
@@ -135,7 +135,7 @@ namespace KviCommandFormatter
 
 	void unindent(QString & szBuffer)
 	{
-		QStringList list = szBuffer.split("\n", QString::KeepEmptyParts);
+		QStringList list = szBuffer.split("\n", Qt::KeepEmptyParts);
 
 		while(hasLeadingChars(list, QChar('\t')) || hasLeadingChars(list, QChar(' ')))
 			trimLeading(list);
@@ -199,7 +199,7 @@ namespace KviCommandFormatter
 
 	void indent(QString & szBuffer)
 	{
-		QStringList list = szBuffer.split("\n", QString::KeepEmptyParts);
+		QStringList list = szBuffer.split("\n", Qt::KeepEmptyParts);
 
 		addLeading(list, QChar('\t'));
 		//szBuffer = list.join("\n"); join implementation sux :D

--- a/src/kvilib/ext/KviStringConversion.cpp
+++ b/src/kvilib/ext/KviStringConversion.cpp
@@ -145,7 +145,7 @@ namespace KviStringConversion
 
 	void toString(const QRect & rValue, QString & szBuffer)
 	{
-		szBuffer.sprintf("%d,%d,%d,%d", rValue.x(), rValue.y(), rValue.width(), rValue.height());
+		szBuffer.asprintf("%d,%d,%d,%d", rValue.x(), rValue.y(), rValue.width(), rValue.height());
 	}
 
 	bool fromString(const QString & szValue, QRect & buffer)
@@ -195,7 +195,7 @@ namespace KviStringConversion
 
 	void toString(const KviMessageTypeSettings & mValue, QString & szBuffer)
 	{
-		szBuffer.sprintf("%d,%u,%u,%d,%d", mValue.m_iPixId, mValue.m_cForeColor, mValue.m_cBackColor, mValue.m_bLogEnabled, mValue.m_iLevel);
+		szBuffer.asprintf("%d,%u,%u,%d,%d", mValue.m_iPixId, mValue.m_cForeColor, mValue.m_cBackColor, mValue.m_bLogEnabled, mValue.m_iLevel);
 	}
 
 	bool fromString(const QString & szValue, KviMessageTypeSettings & buffer)
@@ -226,7 +226,7 @@ namespace KviStringConversion
 	void toString(const QFont & font, QString & szBuffer)
 	{
 		QString szFamily(font.family());
-		szBuffer.sprintf("%s,%d,%d,%d", szFamily.toUtf8().data(), font.pointSize(), font.styleHint(), font.weight());
+		szBuffer.asprintf("%s,%d,%d,%d", szFamily.toUtf8().data(), font.pointSize(), font.styleHint(), font.weight());
 		QString szOptions;
 		if(font.bold())
 			szOptions.append('b');

--- a/src/kvilib/ext/KviStringConversion.cpp
+++ b/src/kvilib/ext/KviStringConversion.cpp
@@ -145,7 +145,7 @@ namespace KviStringConversion
 
 	void toString(const QRect & rValue, QString & szBuffer)
 	{
-		szBuffer.asprintf("%d,%d,%d,%d", rValue.x(), rValue.y(), rValue.width(), rValue.height());
+		szBuffer = QString::asprintf("%d,%d,%d,%d", rValue.x(), rValue.y(), rValue.width(), rValue.height());
 	}
 
 	bool fromString(const QString & szValue, QRect & buffer)
@@ -195,7 +195,7 @@ namespace KviStringConversion
 
 	void toString(const KviMessageTypeSettings & mValue, QString & szBuffer)
 	{
-		szBuffer.asprintf("%d,%u,%u,%d,%d", mValue.m_iPixId, mValue.m_cForeColor, mValue.m_cBackColor, mValue.m_bLogEnabled, mValue.m_iLevel);
+		szBuffer = QString::asprintf("%d,%u,%u,%d,%d", mValue.m_iPixId, mValue.m_cForeColor, mValue.m_cBackColor, mValue.m_bLogEnabled, mValue.m_iLevel);
 	}
 
 	bool fromString(const QString & szValue, KviMessageTypeSettings & buffer)
@@ -226,7 +226,7 @@ namespace KviStringConversion
 	void toString(const QFont & font, QString & szBuffer)
 	{
 		QString szFamily(font.family());
-		szBuffer.asprintf("%s,%d,%d,%d", szFamily.toUtf8().data(), font.pointSize(), font.styleHint(), font.weight());
+		szBuffer = QString::asprintf("%s,%d,%d,%d", szFamily.toUtf8().data(), font.pointSize(), font.styleHint(), font.weight());
 		QString szOptions;
 		if(font.bold())
 			szOptions.append('b');

--- a/src/kvilib/net/KviNetUtils.cpp
+++ b/src/kvilib/net/KviNetUtils.cpp
@@ -274,7 +274,7 @@ namespace KviNetUtils
 #ifndef HAVE_INET_ATON
 		QString szAddr = szStringIp.simplified();
 		quint32 iAddr = 0;
-		QStringList ipv4 = szAddr.split(".", QString::KeepEmptyParts, Qt::CaseInsensitive);
+		QStringList ipv4 = szAddr.split(".", Qt::KeepEmptyParts, Qt::CaseInsensitive);
 		if(ipv4.count() == 4)
 		{
 			int i = 0;

--- a/src/kvilib/tal/KviTalApplication.cpp
+++ b/src/kvilib/tal/KviTalApplication.cpp
@@ -24,19 +24,12 @@
 
 #include "KviTalApplication.h"
 
-#if defined(COMPILE_KDE4_SUPPORT)
-KviTalApplication::KviTalApplication(int &, char **)
-    : KApplication()
-{
-}
-#else  //!defined(COMPILE_KDE4_SUPPORT)
 KviTalApplication::KviTalApplication(int & iArgc, char ** ppcArgv)
     : QApplication(iArgc, ppcArgv)
 {
 	// Session management has been broken by source incompatible changes.
 	QObject::connect(this, SIGNAL(commitDataRequest(QSessionManager &)), this, SLOT(commitData(QSessionManager &)));
 }
-#endif //!defined(COMPILE_KDE4_SUPPORT)
 
 KviTalApplication::~KviTalApplication()
     = default;
@@ -44,7 +37,4 @@ KviTalApplication::~KviTalApplication()
 void KviTalApplication::commitData(QSessionManager & manager)
 {
 	saveConfiguration();
-#if defined(COMPILE_KDE4_SUPPORT)
-	KApplication::commitData(manager);
-#endif //defined(COMPILE_KDE4_SUPPORT)
 }

--- a/src/kvilib/tal/KviTalApplication.h
+++ b/src/kvilib/tal/KviTalApplication.h
@@ -41,18 +41,8 @@
 * \brief Toolkit Abstraction Layer: application class
 */
 
-#if defined(COMPILE_KDE4_SUPPORT)
-
-#include <KApplication>
-class KVILIB_API KviTalApplication : public KApplication
-
-#else //!defined(COMPILE_KDE4_SUPPORT)
-
-// Either no KDE or KDE5 (which uses QApplication)
 #include <QApplication>
 class KVILIB_API KviTalApplication : public QApplication
-
-#endif //!defined(COMPILE_KDE4_SUPPORT)
 {
 	Q_OBJECT
 public:

--- a/src/kvilib/tal/KviTalFileDialog.cpp
+++ b/src/kvilib/tal/KviTalFileDialog.cpp
@@ -24,23 +24,11 @@
 
 #include "KviTalFileDialog.h"
 
-#if defined(COMPILE_KDE4_SUPPORT)
-
-KviTalFileDialog::KviTalFileDialog(const QString & szDirName, const QString & szFilter, QWidget * pParent, const char *, bool)
-    : KFileDialog(KUrl(szDirName), szFilter, pParent)
-{
-	//clearWFlags(WDestructiveClose);
-}
-
-#else //!defined(COMPILE_KDE4_SUPPORT))
-
 KviTalFileDialog::KviTalFileDialog(const QString & szDirName, const QString & szFilter, QWidget * pParent, const char *, bool bModal)
     : QFileDialog(pParent, "", szDirName, szFilter)
 {
 	setModal(bModal);
 }
-
-#endif //!defined(COMPILE_KDE4_SUPPORT))
 
 KviTalFileDialog::~KviTalFileDialog()
     = default;
@@ -49,30 +37,6 @@ void KviTalFileDialog::setFileMode(FileMode m)
 {
 	switch(m)
 	{
-#if defined(COMPILE_KDE4_SUPPORT)
-		case AnyFile:
-			setMode(KFile::File | KFile::LocalOnly);
-			setOperationMode(Saving);
-			break;
-		case ExistingFile:
-			setMode(KFile::File | KFile::ExistingOnly | KFile::LocalOnly);
-			setOperationMode(Opening);
-			break;
-		case ExistingFiles:
-			setMode(KFile::Files | KFile::ExistingOnly | KFile::LocalOnly);
-			setOperationMode(Opening);
-			break;
-		case Directory:
-			setMode(KFile::Directory);
-			break;
-		case DirectoryOnly:
-			setMode(KFile::Directory);
-			break;
-		default:
-			setMode(KFile::File | KFile::LocalOnly);
-			setOperationMode(Saving);
-			break;
-#else  //!defined(COMPILE_KDE4_SUPPORT)
 		case AnyFile:
 			QFileDialog::setFileMode(QFileDialog::AnyFile);
 			setAcceptMode(QFileDialog::AcceptSave);
@@ -87,21 +51,11 @@ void KviTalFileDialog::setFileMode(FileMode m)
 			QFileDialog::setFileMode(QFileDialog::Directory);
 			break;
 		case DirectoryOnly:
-			QFileDialog::setFileMode(QFileDialog::DirectoryOnly);
+			QFileDialog::setOption(ShowDirsOnly, true);
 			break;
 		default:
 			QFileDialog::setFileMode(QFileDialog::AnyFile);
 			setAcceptMode(QFileDialog::AcceptSave);
 			break;
-#endif //!defined(COMPILE_KDE4_SUPPORT)
 	}
-}
-
-void KviTalFileDialog::setDirectory(const QString & szDirectory)
-{
-#if defined(COMPILE_KDE4_SUPPORT)
-	setUrl(KUrl(szDirectory));
-#else  //!defined(COMPILE_KDE4_SUPPORT)
-	QFileDialog::setDirectory(szDirectory);
-#endif //!defined(COMPILE_KDE4_SUPPORT)
 }

--- a/src/kvilib/tal/KviTalFileDialog.h
+++ b/src/kvilib/tal/KviTalFileDialog.h
@@ -41,19 +41,8 @@
 * \brief Toolkit Abstraction Layer: filedialog class
 */
 
-#if defined(COMPILE_KDE4_SUPPORT)
-
-#include <KFileDialog>
-class KVILIB_API KviTalFileDialog : public KFileDialog
-
-#else //!defined(COMPILE_KDE4_SUPPORT)
-
-// no KDE or KDE5 (which has no KFileDialog)
-
 #include <QFileDialog>
 class KVILIB_API KviTalFileDialog : public QFileDialog
-
-#endif //!defined(COMPILE_KDE4_SUPPORT)
 {
 	Q_OBJECT
 public:
@@ -95,13 +84,6 @@ public:
 	void setFileMode(FileMode m);
 
 	/**
-	* \brief Sets the current directory
-	* \param szDirectory The directory
-	* \return void
-	*/
-	void setDirectory(const QString & szDirectory);
-
-	/**
 	* \brief Returns an existing directory selected by the user
 	* \param szDir The directory to display
 	* \param szCaption The caption of the dialog
@@ -110,13 +92,7 @@ public:
 	*/
 	static QString getExistingDirectoryPath(const QString & szDir = QString(), const QString & szCaption = QString(), QWidget * pParent = nullptr)
 	{
-#if defined(COMPILE_KDE4_SUPPORT)
-		// QFileDialog allows making new directories...kfiledialog not :/
-		return KFileDialog::getExistingDirectory(KUrl(szDir), pParent, szCaption);
-//return getExistingDirectory(dir,parent,caption);
-#else  //!defined(COMPILE_KDE4_SUPPORT)
 		return getExistingDirectory(pParent, szCaption, szDir);
-#endif //!defined(COMPILE_KDE4_SUPPORT)
 	};
 };
 

--- a/src/kvilib/tal/KviTalListWidget.cpp
+++ b/src/kvilib/tal/KviTalListWidget.cpp
@@ -110,7 +110,7 @@ int KviTalListWidgetText::height(const KviTalListWidget * lb) const
 
 int KviTalListWidgetText::width(const KviTalListWidget * lb) const
 {
-	int w = lb ? lb->fontMetrics().width(text()) + 6 : 0;
+	int w = lb ? lb->fontMetrics().horizontalAdvance(text()) + 6 : 0;
 	return qMax(w, QApplication::globalStrut().width());
 }
 
@@ -183,7 +183,7 @@ int KviTalListWidgetPixmap::width(const KviTalListWidget * lb) const
 {
 	if(text().isEmpty())
 		return qMax(pm.width() + 6, QApplication::globalStrut().width());
-	return qMax(pm.width() + lb->fontMetrics().width(text()) + 6,
+	return qMax(pm.width() + lb->fontMetrics().horizontalAdvance(text()) + 6,
 	    QApplication::globalStrut().width());
 }
 

--- a/src/kvilib/tal/KviTalMenuBar.cpp
+++ b/src/kvilib/tal/KviTalMenuBar.cpp
@@ -24,16 +24,6 @@
 
 #include "KviTalMenuBar.h"
 
-#ifdef COMPILE_KDE4_SUPPORT
-
-KviTalMenuBar::KviTalMenuBar(QWidget * pParent, const char * pcName)
-    : KMenuBar(pParent)
-{
-	setWindowTitle(pcName);
-}
-
-#else //!COMPILE_KDE4_SUPPORT
-
 KviTalMenuBar::KviTalMenuBar(QWidget * pParent, const char * pcName)
 #ifdef COMPILE_ON_MAC
     // global menubar must have 0 as its parent
@@ -43,8 +33,6 @@ KviTalMenuBar::KviTalMenuBar(QWidget * pParent, const char * pcName)
 #endif
 {
 }
-
-#endif //!COMPILE_KDE4_SUPPORT
 
 KviTalMenuBar::~KviTalMenuBar()
     = default;

--- a/src/kvilib/tal/KviTalMenuBar.h
+++ b/src/kvilib/tal/KviTalMenuBar.h
@@ -37,19 +37,9 @@
 * \brief Toolkit Abstraction Layer: menubar class
 */
 
-#ifdef COMPILE_KDE4_SUPPORT
-
-#include <kmenubar.h>
-
-class KVILIB_API KviTalMenuBar : public KMenuBar
-
-#else //!COMPILE_KDE4_SUPPORT
-
 #include <QMenuBar>
 
 class KVILIB_API KviTalMenuBar : public QMenuBar
-
-#endif //!COMPILE_KDE4_SUPPORT
 {
 	Q_OBJECT
 public:

--- a/src/kvirc/kernel/KviApplication.cpp
+++ b/src/kvirc/kernel/KviApplication.cpp
@@ -842,7 +842,7 @@ void KviApplication::notifierMessage(KviWindow * pWnd, int iIconId, const QStrin
 
 			KviNotifierMessageParam s;
 			s.pWindow = pWnd;
-			s.szIcon.asprintf("%d", iIconId);
+			s.szIcon = QString::asprintf("%d", iIconId);
 			s.szMessage = szMsg;
 			s.uMessageLifetime = uMessageLifetime;
 

--- a/src/kvirc/kernel/KviApplication.cpp
+++ b/src/kvirc/kernel/KviApplication.cpp
@@ -123,11 +123,7 @@
 #endif
 
 #ifdef COMPILE_KDE_SUPPORT
-#ifdef COMPILE_KDE4_SUPPORT
-#include <KStandardDirs>
-#else
 #include <QStandardPaths>
-#endif
 #include <KNotification>
 #endif
 
@@ -189,7 +185,6 @@ KVIRC_API QPixmap * g_pShadedParentGlobalDesktopBackground = nullptr; // the pix
 KVIRC_API QPixmap * g_pShadedChildGlobalDesktopBackground = nullptr;  // the pixmap that we use for MdiChild
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
 #include <winuser.h>
-#include <QDesktopWidget>
 #endif
 #endif
 
@@ -691,11 +686,7 @@ void KviApplication::notifierMessage(KviWindow * pWnd, int iIconId, const QStrin
 
 		if(!bKNotifyConfigFileChecked)
 		{
-#ifdef COMPILE_KDE4_SUPPORT
-			QString szFileName = KStandardDirs::locateLocal("data", QString::fromUtf8("kvirc/kvirc.notifyrc"));
-#else
 			QString szFileName = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/" + QString::fromUtf8("kvirc/kvirc.notifyrc");
-#endif
 			if(szFileName.isEmpty())
 				szFileName = QString::fromUtf8("%1/.kde/share/apps/kvirc/kvirc.notifyrc").arg(QDir::homePath());
 
@@ -797,26 +788,14 @@ void KviApplication::notifierMessage(KviWindow * pWnd, int iIconId, const QStrin
 			pIcon = g_pIconManager->getSmallIcon(eIcon);
 
 		KNotification * pNotify = nullptr;
-#if defined(COMPILE_KDE4_SUPPORT)
-#if KDE_IS_VERSION(4, 4, 0)
-		pNotify = new KNotification("incomingMessage", KNotification::CloseWhenWidgetActivated, this);
-#else
-		pNotify = new KNotification("incomingMessage", g_pMainWindow, KNotification::CloseWhenWidgetActivated);
-#endif
-#else
-		pNotify = new KNotification("incomingMessage", g_pMainWindow, KNotification::CloseWhenWidgetActivated);
-#endif
-		pNotify->setFlags(KNotification::Persistent);
+		pNotify = new KNotification("incomingMessage");
+		pNotify->setWidget(g_pMainWindow);
+		pNotify->setFlags(KNotification::CloseWhenWidgetActivated|KNotification::Persistent);
 		pNotify->setTitle(szTitle);
 		pNotify->setText(szText);
 		pNotify->setActions(actions);
 		pNotify->setPixmap(*pIcon);
-
-#if defined(COMPILE_KDE4_SUPPORT)
-		pNotify->setComponentData(KComponentData(aboutData()));
-#else
 		pNotify->setComponentName("kvirc");
-#endif
 
 		connect(pNotify, SIGNAL(activated()), this, SLOT(showParentFrame()));
 		connect(pNotify, SIGNAL(action1Activated()), this, SLOT(showParentFrame()));
@@ -863,7 +842,7 @@ void KviApplication::notifierMessage(KviWindow * pWnd, int iIconId, const QStrin
 
 			KviNotifierMessageParam s;
 			s.pWindow = pWnd;
-			s.szIcon.sprintf("%d", iIconId);
+			s.szIcon.asprintf("%d", iIconId);
 			s.szMessage = szMsg;
 			s.uMessageLifetime = uMessageLifetime;
 
@@ -1277,7 +1256,7 @@ void KviApplication::updatePseudoTransparency()
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
 		if(KVI_OPTION_BOOL(KviOption_boolUseWindowsDesktopForTransparency))
 		{
-			QSize size = g_pApp->desktop()->screenGeometry(g_pApp->desktop()->primaryScreen()).size();
+			QSize size = g_pApp->primaryScreen()->size();
 			// get the Program Manager
 			HWND hWnd = FindWindow(TEXT("Progman"), TEXT("Program Manager"));
 			// Create and setup bitmap

--- a/src/kvirc/kernel/KviIconManager.cpp
+++ b/src/kvirc/kernel/KviIconManager.cpp
@@ -494,15 +494,16 @@ bool KviIconWidget::eventFilter(QObject * pObject, QEvent * pEvent)
 			}
 			else
 			{
-				if(const QPixmap * pPix = ((QLabel *)pObject)->pixmap())
+				const QPixmap pPix = ((QLabel *)pObject)->pixmap(Qt::ReturnByValue);
+				if(!pPix.isNull())
 				{
 					QDrag * pDrag = new QDrag(this);
 					QMimeData * pMime = new QMimeData;
 
 					pMime->setText(pObject->objectName());
-					pMime->setImageData(*pPix);
+					pMime->setImageData(pPix);
 					pDrag->setMimeData(pMime);
-					pDrag->setPixmap(*pPix);
+					pDrag->setPixmap(pPix);
 				}
 			}
 		}

--- a/src/kvirc/kernel/KviIpcSentinel.cpp
+++ b/src/kvirc/kernel/KviIpcSentinel.cpp
@@ -172,11 +172,9 @@ bool kvi_sendIpcMessage(const char * message)
 	}
 #elif defined(COMPILE_X11_SUPPORT) && defined(COMPILE_QX11INFO_SUPPORT)
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
 	if (!QX11Info::isPlatformX11()) {
 		return false;
 	}
-#endif
 
 	kvi_ipcLoadAtoms();
 
@@ -203,11 +201,9 @@ KviIpcSentinel::KviIpcSentinel() : QWidget(nullptr)
 	setWindowTitle("kvirc4_ipc_sentinel");
 #elif defined(COMPILE_X11_SUPPORT) && defined(COMPILE_QX11INFO_SUPPORT)
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
 	if (!QX11Info::isPlatformX11()) {
 		return;
 	}
-#endif
 	kvi_ipcLoadAtoms();
 
 	XChangeProperty(kvi_ipc_get_xdisplay(), winId(), kvi_atom_ipc_sentinel_window, XA_STRING, 8,

--- a/src/kvirc/kernel/KviIrcConnection.cpp
+++ b/src/kvirc/kernel/KviIrcConnection.cpp
@@ -1570,7 +1570,7 @@ void KviIrcConnection::loginToIrcServer()
 		int iBack = KVI_OPTION_UINT(KviOption_uintUserIrcViewOwnBackground);
 		if(iBack != KviControlCodes::Transparent)
 		{
-			szTags.sprintf("%c%d,%d%c",
+			szTags.asprintf("%c%d,%d%c",
 			    KviControlCodes::Color,
 			    KVI_OPTION_UINT(KviOption_uintUserIrcViewOwnForeground),
 			    iBack,
@@ -1582,7 +1582,7 @@ void KviIrcConnection::loginToIrcServer()
 	if(iGenderAvatarTag != 0)
 	{
 		QString szTags;
-		szTags.sprintf("%c%d%c",
+		szTags.asprintf("%c%d%c",
 		    KviControlCodes::Color,
 		    iGenderAvatarTag,
 		    KviControlCodes::Reset);

--- a/src/kvirc/kernel/KviIrcConnection.cpp
+++ b/src/kvirc/kernel/KviIrcConnection.cpp
@@ -1570,7 +1570,7 @@ void KviIrcConnection::loginToIrcServer()
 		int iBack = KVI_OPTION_UINT(KviOption_uintUserIrcViewOwnBackground);
 		if(iBack != KviControlCodes::Transparent)
 		{
-			szTags.asprintf("%c%d,%d%c",
+			szTags = QString::asprintf("%c%d,%d%c",
 			    KviControlCodes::Color,
 			    KVI_OPTION_UINT(KviOption_uintUserIrcViewOwnForeground),
 			    iBack,
@@ -1582,7 +1582,7 @@ void KviIrcConnection::loginToIrcServer()
 	if(iGenderAvatarTag != 0)
 	{
 		QString szTags;
-		szTags.asprintf("%c%d%c",
+		szTags = QString::asprintf("%c%d%c",
 		    KviControlCodes::Color,
 		    iGenderAvatarTag,
 		    KviControlCodes::Reset);

--- a/src/kvirc/kernel/KviIrcConnectionServerInfo.cpp
+++ b/src/kvirc/kernel/KviIrcConnectionServerInfo.cpp
@@ -53,7 +53,7 @@ void KviIrcConnectionServerInfo::addSupportedCaps(const QString & szCapList)
 {
 	m_bSupportsCap = true;
 
-	QStringList lTmp = szCapList.split(' ', QString::SkipEmptyParts);
+	QStringList lTmp = szCapList.split(' ', Qt::SkipEmptyParts);
 	foreach(QString szCap, lTmp)
 	{
 		// cap modifiers are:
@@ -85,7 +85,7 @@ void KviIrcConnectionServerInfo::addSupportedCaps(const QString & szCapList)
 
 void KviIrcConnectionServerInfo::setSupportedChannelModes(const QString & szSupportedChannelModes)
 {
-	QStringList szAllModes = szSupportedChannelModes.split(',', QString::KeepEmptyParts);
+	QStringList szAllModes = szSupportedChannelModes.split(',', Qt::KeepEmptyParts);
 
 	if(szAllModes.count() != 4)
 	{

--- a/src/kvirc/kernel/KviIrcConnectionStateData.cpp
+++ b/src/kvirc/kernel/KviIrcConnectionStateData.cpp
@@ -35,7 +35,7 @@ KviIrcConnectionStateData::~KviIrcConnectionStateData()
 
 void KviIrcConnectionStateData::changeEnabledCapList(const QString & szCapList)
 {
-	for(auto szCap : szCapList.split(' ', QString::SkipEmptyParts))
+	for(auto szCap : szCapList.split(' ', Qt::SkipEmptyParts))
 	{
 		// cap modifiers are:
 		//  '-' : disable a capability (should not be present in a LS message...)

--- a/src/kvirc/kernel/KviIrcSocket.cpp
+++ b/src/kvirc/kernel/KviIrcSocket.cpp
@@ -181,7 +181,7 @@ void KviIrcSocket::outputSSLError(const QString & szMsg)
 
 void KviIrcSocket::outputProxyMessage(const QString & szMsg)
 {
-	for(const auto & it : szMsg.split('\n', QString::SkipEmptyParts))
+	for(const auto & it : szMsg.split('\n', Qt::SkipEmptyParts))
 	{
 		QString szTemporary = it.trimmed();
 		m_pConsole->output(KVI_OUT_SOCKETMESSAGE, __tr2qs("[PROXY]: %Q"), &szTemporary);
@@ -190,7 +190,7 @@ void KviIrcSocket::outputProxyMessage(const QString & szMsg)
 
 void KviIrcSocket::outputProxyError(const QString & szMsg)
 {
-	for(const auto & it : szMsg.split('\n', QString::SkipEmptyParts))
+	for(const auto & it : szMsg.split('\n', Qt::SkipEmptyParts))
 	{
 		QString szTemporary = it.trimmed();
 		m_pConsole->output(KVI_OUT_SOCKETERROR, __tr2qs("[PROXY ERROR]: %Q"), &szTemporary);

--- a/src/kvirc/kernel/KviIrcUrl.cpp
+++ b/src/kvirc/kernel/KviIrcUrl.cpp
@@ -142,7 +142,7 @@ void KviIrcUrl::split(const QString & url, KviIrcUrlParts & result)
 	if(result.szHost.isEmpty())
 		result.iError |= InvalidUrl;
 
-	result.chanList = rx.cap(8).isEmpty() ? QStringList() : rx.cap(8).split(',', QString::SkipEmptyParts);
+	result.chanList = rx.cap(8).isEmpty() ? QStringList() : rx.cap(8).split(',', Qt::SkipEmptyParts);
 }
 
 void KviIrcUrl::join(QString & uri, KviIrcServer * server)

--- a/src/kvirc/kernel/KviMain.cpp
+++ b/src/kvirc/kernel/KviMain.cpp
@@ -43,11 +43,7 @@ extern bool kvi_sendIpcMessage(const char * message); // KviIpcSentinel.cpp
 #include <QMessageBox>
 
 #ifdef COMPILE_KDE_SUPPORT
-#ifdef COMPILE_KDE4_SUPPORT
-#include <KCmdLineArgs>
-#else
 #include <KLocalizedString>
-#endif
 #include <KAboutData>
 #endif
 
@@ -361,26 +357,6 @@ int main(int argc, char ** argv)
 	}
 
 #ifdef COMPILE_KDE_SUPPORT
-#ifdef COMPILE_KDE4_SUPPORT
-	// KDE4
-	KAboutData * pAboutData = new KAboutData( // FIXME: this is never deleted ? Should it be ?
-	    "kvirc",                              // internal program name
-	    "kvirc",                              // message catalogue name
-	    ki18n("KVIrc"),                       // user-visible program name
-	    KVI_VERSION,                          // program version
-	    ki18n("Visual IRC Client"),           // description
-	    KAboutData::License_GPL,              // license
-	    ki18n("(c) 1998-2016 The KVIrc Development Team"),
-	    ki18n("???"),                           // *some other text* ????
-	    "http://www.kvirc.net",                 // homepage
-	    "https://github.com/kvirc/KVIrc/issues" // bug address
-	    );
-
-	//fake argc/argv initialization: kde will use argv[0] as out appName in some dialogs
-	// (eg: kdebase/workspace/kwin/killer/killer.cpp)
-	KCmdLineArgs::init(1, &argv[0], pAboutData);
-#else  //!COMPILE_KDE4_SUPPORT
-	// KDE5
 	KAboutData * pAboutData = new KAboutData(  // FIXME: this is never deleted ? Should it be ?
 	    "kvirc",                               // internal program name
 	    "KVIrc",                               // user-visible program name
@@ -392,7 +368,6 @@ int main(int argc, char ** argv)
 	    "http://www.kvirc.net",                 // homepage
 	    "https://github.com/kvirc/KVIrc/issues" // bug address
 	    );
-#endif //!COMPILE_KDE4_SUPPORT
 #endif
 
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
@@ -402,12 +377,8 @@ int main(int argc, char ** argv)
 	KviApplication * pTheApp = new KviApplication(argc, argv);
 
 #ifdef COMPILE_KDE_SUPPORT
-#ifdef COMPILE_KDE4_SUPPORT
-	pTheApp->setAboutData(pAboutData);
-#else
 	KAboutData::setApplicationData(*pAboutData);
 	delete pAboutData;
-#endif
 #endif
 
 #ifdef COMPILE_DBUS_SUPPORT

--- a/src/kvirc/kernel/KviNotifyList.cpp
+++ b/src/kvirc/kernel/KviNotifyList.cpp
@@ -175,7 +175,7 @@ void KviNotifyListManager::notifyOnLine(const QString & szNick, const QString & 
 	while(KviRegisteredUser * pUser = it.current())
 	{
 		QString szProp = pUser->getProperty("notify");
-		if(!szProp.isEmpty() && szProp.split(',', QString::SkipEmptyParts).contains(szNick))
+		if(!szProp.isEmpty() && szProp.split(',', Qt::SkipEmptyParts).contains(szNick))
 		{
 			QString szComment = pUser->getProperty("comment");
 			if(!szComment.isEmpty())
@@ -236,7 +236,7 @@ void KviNotifyListManager::notifyOffLine(const QString & szNick, const QString &
 		while(KviRegisteredUser * pUser = it.current())
 		{
 			QString szProp = pUser->getProperty("notify");
-			if(!szProp.isEmpty() && szProp.split(',', QString::SkipEmptyParts).contains(szNick))
+			if(!szProp.isEmpty() && szProp.split(',', Qt::SkipEmptyParts).contains(szNick))
 			{
 				QString szComment = pUser->getProperty("comment");
 				if(!szComment.isEmpty())
@@ -363,7 +363,7 @@ void KviIsOnNotifyListManager::buildRegUserDict()
 		QString notify;
 		if(u->getProperty("notify", notify))
 		{
-			for(const auto & single : notify.trimmed().split(' ', QString::SkipEmptyParts))
+			for(const auto & single : notify.trimmed().split(' ', Qt::SkipEmptyParts))
 				m_pRegUserDict.emplace(single, u->name());
 		}
 		++it;
@@ -992,7 +992,7 @@ bool KviStupidNotifyListManager::handleIsOn(KviIrcMessage * msg)
 		}
 	}
 	// ok... check the users that have left irc now...
-	QStringList sl = m_szLastIsOnMsg.isEmpty() ? QStringList() : m_szLastIsOnMsg.split(' ', QString::SkipEmptyParts);
+	QStringList sl = m_szLastIsOnMsg.isEmpty() ? QStringList() : m_szLastIsOnMsg.split(' ', Qt::SkipEmptyParts);
 
 	for(auto & it : sl)
 	{
@@ -1088,7 +1088,7 @@ void KviWatchNotifyListManager::buildRegUserDict()
 		if(u->getProperty("notify", notify))
 		{
 			notify = notify.trimmed();
-			QStringList sl = notify.split(' ', QString::SkipEmptyParts);
+			QStringList sl = notify.split(' ', Qt::SkipEmptyParts);
 			for(auto & slit : sl)
 				m_pRegUserDict.emplace(slit, u->name());
 		}

--- a/src/kvirc/kvs/KviKvsCoreSimpleCommands.cpp
+++ b/src/kvirc/kvs/KviKvsCoreSimpleCommands.cpp
@@ -164,7 +164,7 @@ namespace KviKvsCoreSimpleCommands
 			return true;
 		}
 
-		QStringList sl = szTokens.split(QRegExp("[, ]+"), QString::SkipEmptyParts);
+		QStringList sl = szTokens.split(QRegExp("[, ]+"), Qt::SkipEmptyParts);
 
 		QByteArray szFlags;
 		QByteArray szTarget = KVSCSC_pConnection->encodeText(KVSCSC_pWindow->windowName());

--- a/src/kvirc/kvs/KviKvsCoreSimpleCommands_gl.cpp
+++ b/src/kvirc/kvs/KviKvsCoreSimpleCommands_gl.cpp
@@ -380,7 +380,7 @@ namespace KviKvsCoreSimpleCommands
 
 		KVSCSC_REQUIRE_CONNECTION
 
-		QStringList slChans = szChans.split(",", QString::SkipEmptyParts);
+		QStringList slChans = szChans.split(",", Qt::SkipEmptyParts);
 
 		QString szChanTypes = KVSCSC_pConnection->serverInfo()->supportedChannelTypes();
 		for(auto & slChan : slChans)

--- a/src/kvirc/kvs/KviKvsCoreSimpleCommands_mr.cpp
+++ b/src/kvirc/kvs/KviKvsCoreSimpleCommands_mr.cpp
@@ -814,7 +814,7 @@ namespace KviKvsCoreSimpleCommands
 
 		QByteArray szEncodedChans = KVSCSC_pConnection->encodeText(szChans);
 
-		QStringList sl = szChans.split(",", QString::SkipEmptyParts);
+		QStringList sl = szChans.split(",", Qt::SkipEmptyParts);
 
 		if(szMsg.isEmpty())
 			szMsg = KVI_OPTION_STRING(KviOption_stringPartMessage);
@@ -1065,7 +1065,7 @@ namespace KviKvsCoreSimpleCommands
 
 		KviQueryWindow * query;
 
-		QStringList sl = szTargets.split(",", QString::SkipEmptyParts);
+		QStringList sl = szTargets.split(",", Qt::SkipEmptyParts);
 		for(auto szNick : sl)
 		{
 			if(szNick.isEmpty())

--- a/src/kvirc/kvs/KviKvsProcessManager.cpp
+++ b/src/kvirc/kvs/KviKvsProcessManager.cpp
@@ -69,7 +69,7 @@ bool KviKvsProcessAsyncOperation::start()
 
 	if(m_pData->iFlags & KVI_KVS_PROCESSDESCRIPTOR_NOSHELL)
 	{
-		args = m_pData->szCommandline.split(" ", QString::SkipEmptyParts);
+		args = m_pData->szCommandline.split(" ", Qt::SkipEmptyParts);
 	}
 	else
 	{
@@ -90,7 +90,7 @@ bool KviKvsProcessAsyncOperation::start()
 			szShell = "sh -c";
 #endif
 		}
-		args = szShell.split(" ", QString::SkipEmptyParts);
+		args = szShell.split(" ", Qt::SkipEmptyParts);
 		args.append(m_pData->szCommandline);
 	}
 
@@ -316,7 +316,7 @@ void KviKvsProcessAsyncOperation::processStarted()
 		return;
 
 	QString szPid;
-	szPid.setNum((intptr_t)(m_pProcess->pid()));
+	szPid.setNum(m_pProcess->processId());
 	if(trigger(EventStarted, szPid))
 	{
 		triggerSelfDelete();

--- a/src/kvirc/kvs/parser/KviKvsParser_specialCommands.cpp
+++ b/src/kvirc/kvs/parser/KviKvsParser_specialCommands.cpp
@@ -83,7 +83,7 @@ python.begin <python code> python.end
                                                                                                                           \
 		const QChar * pInterpreterBegin = KVSP_curCharPointer;                                                            \
 		QString szName;                                                                                                   \
-		szName.sprintf("%s", #__name);                                                                                    \
+		szName.asprintf("%s", #__name);                                                                                    \
 		szName = szName.toLower();                                                                                        \
                                                                                                                           \
 		/* now look for [interpreter].end[terminator] */                                                                  \

--- a/src/kvirc/kvs/parser/KviKvsParser_specialCommands.cpp
+++ b/src/kvirc/kvs/parser/KviKvsParser_specialCommands.cpp
@@ -83,7 +83,7 @@ python.begin <python code> python.end
                                                                                                                           \
 		const QChar * pInterpreterBegin = KVSP_curCharPointer;                                                            \
 		QString szName;                                                                                                   \
-		szName.asprintf("%s", #__name);                                                                                    \
+		szName = QString::asprintf("%s", #__name);                                                                                    \
 		szName = szName.toLower();                                                                                        \
                                                                                                                           \
 		/* now look for [interpreter].end[terminator] */                                                                  \

--- a/src/kvirc/sparser/KviIrcServerParser_ctcp.cpp
+++ b/src/kvirc/sparser/KviIrcServerParser_ctcp.cpp
@@ -1382,7 +1382,7 @@ void KviIrcServerParser::parseCtcpRequestTime(KviCtcpMessage * msg)
 					szTmp = date.toString(Qt::ISODate);
 					break;
 				case 2:
-					szTmp = date.toString(Qt::SystemLocaleShortDate);
+					szTmp = QLocale().toString(date, QLocale::ShortFormat);
 					break;
 			}
 			replyCtcp(msg, szTmp);

--- a/src/kvirc/sparser/KviIrcServerParser_literalHandlers.cpp
+++ b/src/kvirc/sparser/KviIrcServerParser_literalHandlers.cpp
@@ -1610,7 +1610,7 @@ void KviIrcServerParser::parseLiteralNotice(KviIrcMessage * msg)
 			// OFTC replaced RPL_HOSTHIDDEN with a server notice
 			if(version == "Hybrid+Oftc")
 			{
-				QStringList parts = szMsgText.split(" ", QString::SkipEmptyParts);
+				QStringList parts = szMsgText.split(" ", Qt::SkipEmptyParts);
 				if(parts.count() == 3)
 				{
 					if(parts[0] == "Activating" && parts[1] == "Cloak:")
@@ -1729,7 +1729,7 @@ void KviIrcServerParser::parseLiteralTopic(KviIrcMessage * msg)
 			szTmp = date.toString(Qt::ISODate);
 			break;
 		case 2:
-			szTmp = date.toString(Qt::SystemLocaleShortDate);
+			szTmp = QLocale().toString(date, QLocale::ShortFormat);
 			break;
 	}
 	chan->topicWidget()->setTopicSetAt(szTmp);

--- a/src/kvirc/sparser/KviIrcServerParser_numericHandlers.cpp
+++ b/src/kvirc/sparser/KviIrcServerParser_numericHandlers.cpp
@@ -680,7 +680,7 @@ void KviIrcServerParser::parseNumericTopicWhoTime(KviIrcMessage * msg)
 			szDate = date.toString(Qt::ISODate);
 			break;
 		case 2:
-			szDate = date.toString(Qt::SystemLocaleShortDate);
+			szDate = QLocale().toString(date, QLocale::ShortFormat);
 			break;
 	}
 
@@ -771,7 +771,7 @@ void getDateTimeStringFromCharTimeT(QString & szBuffer, const char * time_t_stri
 				szBuffer = date.toString(Qt::ISODate);
 				break;
 			case 2:
-				szBuffer = date.toString(Qt::SystemLocaleShortDate);
+				szBuffer = QLocale().toString(date, QLocale::ShortFormat);
 				break;
 		}
 	}
@@ -1656,7 +1656,7 @@ void KviIrcServerParser::parseNumericWhoisChannels(KviIrcMessage * msg)
 	{
 		KviWindow * pOut = KVI_OPTION_BOOL(KviOption_boolWhoisRepliesToActiveWindow) ? msg->console()->activeWindow() : static_cast<KviWindow *>(msg->console());
 
-		QStringList sl = szChans.split(" ", QString::SkipEmptyParts);
+		QStringList sl = szChans.split(" ", Qt::SkipEmptyParts);
 		QString szChanList;
 
 		for(auto szCur : sl)
@@ -1767,7 +1767,7 @@ void KviIrcServerParser::parseNumericWhoisIdle(KviIrcMessage * msg)
 					szTmp = date.toString(Qt::ISODate);
 					break;
 				case 2:
-					szTmp = date.toString(Qt::SystemLocaleShortDate);
+					szTmp = QLocale().toString(date, QLocale::ShortFormat);
 					break;
 			}
 
@@ -2100,7 +2100,7 @@ void KviIrcServerParser::parseNumericCreationTime(KviIrcMessage * msg)
 			szDate = date.toString(Qt::ISODate);
 			break;
 		case 2:
-			szDate = date.toString(Qt::SystemLocaleShortDate);
+			szDate = QLocale().toString(date, QLocale::ShortFormat);
 			break;
 	}
 

--- a/src/kvirc/ui/KviChannelWindow.cpp
+++ b/src/kvirc/ui/KviChannelWindow.cpp
@@ -1091,7 +1091,7 @@ void KviChannelWindow::getWindowListTipText(QString & szBuffer)
 	if(cas.dActionsPerMinute >= 0.1)
 	{
 		QString szNum;
-		szNum.asprintf(" [%u%% ", cas.uHotActionPercent);
+		szNum = QString::asprintf(" [%u%% ", cas.uHotActionPercent);
 		szBuffer += szNum;
 		szBuffer += __tr2qs("human");
 		szBuffer += "]";

--- a/src/kvirc/ui/KviChannelWindow.cpp
+++ b/src/kvirc/ui/KviChannelWindow.cpp
@@ -1091,7 +1091,7 @@ void KviChannelWindow::getWindowListTipText(QString & szBuffer)
 	if(cas.dActionsPerMinute >= 0.1)
 	{
 		QString szNum;
-		szNum.sprintf(" [%u%% ", cas.uHotActionPercent);
+		szNum.asprintf(" [%u%% ", cas.uHotActionPercent);
 		szBuffer += szNum;
 		szBuffer += __tr2qs("human");
 		szBuffer += "]";
@@ -2092,7 +2092,7 @@ void KviChannelWindow::preprocessMessage(QString & szMessage)
 	if(szMessage.contains(szNonStandardLinkPrefix))
 		return; // contains a non standard link that may contain spaces, do not break it.
 
-	QStringList strings = szMessage.split(" ", QString::KeepEmptyParts);
+	QStringList strings = szMessage.split(" ", Qt::KeepEmptyParts);
 	for(auto & it : strings)
 	{
 		if(it.contains('\r'))

--- a/src/kvirc/ui/KviConsoleWindow.cpp
+++ b/src/kvirc/ui/KviConsoleWindow.cpp
@@ -102,7 +102,6 @@ KviConsoleWindow::KviConsoleWindow(int iFlags) : KviWindow(KviWindow::Console, _
 	m_pButtonBox->setMargin(0);
 	new QLabel(__tr2qs("Address:"), m_pButtonBox);
 	m_pAddressEdit = new KviThemedComboBox(m_pButtonBox, this, "url_editor");
-	m_pAddressEdit->setAutoCompletion(true);
 	m_pAddressEdit->setDuplicatesEnabled(false);
 	m_pAddressEdit->setEditable(true);
 	m_pAddressEdit->addItem(QIcon(*(g_pIconManager->getSmallIcon(KviIconManager::Url))), "");
@@ -1282,7 +1281,7 @@ void KviConsoleWindow::getWindowListTipText(QString & buffer)
 				szTmp = date.toString(Qt::ISODate);
 				break;
 			case 2:
-				szTmp = date.toString(Qt::SystemLocaleShortDate);
+				szTmp = QLocale().toString(date, QLocale::ShortFormat);
 				break;
 		}
 

--- a/src/kvirc/ui/KviCtcpPageDialog.cpp
+++ b/src/kvirc/ui/KviCtcpPageDialog.cpp
@@ -32,7 +32,7 @@
 #include <QLayout>
 #include <QLabel>
 #include <QPixmap>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QStackedWidget>
 #include <QPushButton>
 #include <QTabWidget>
@@ -70,7 +70,7 @@ KviCtcpPageDialog::~KviCtcpPageDialog()
 
 void KviCtcpPageDialog::center()
 {
-	QRect rect = g_pApp->desktop()->screenGeometry(g_pApp->desktop()->primaryScreen());
+	QRect rect = g_pApp->primaryScreen()->availableGeometry();
 	move((rect.width() - width()) / 2, (rect.height() - height()) / 2);
 }
 
@@ -95,7 +95,7 @@ void KviCtcpPageDialog::addPage(const QString & szNick, const QString & szUser, 
 			szDate = date.toString(Qt::ISODate);
 			break;
 		case 2:
-			szDate = date.toString(Qt::SystemLocaleShortDate);
+			szDate = QLocale().toString(date, QLocale::ShortFormat);
 			break;
 	}
 

--- a/src/kvirc/ui/KviFileDialog.cpp
+++ b/src/kvirc/ui/KviFileDialog.cpp
@@ -136,9 +136,6 @@ bool KviFileDialog::askForSaveFileName(QString & szBuffer, const QString & szCap
 	// 190
 	pDialog->setFileMode(KviTalFileDialog::AnyFile);
 //pDialog->setShowHiddenFiles(showHidden);
-#ifdef COMPILE_KDE4_SUPPORT
-	pDialog->setKeepLocation(true);
-#endif
 	while(pDialog->exec() == QDialog::Accepted)
 	{
 		QStringList szFiles = pDialog->selectedFiles();
@@ -200,11 +197,6 @@ bool KviFileDialog::askForDirectoryName(QString & szBuffer, const QString & szCa
 #else
 bool KviFileDialog::askForDirectoryName(QString & szBuffer, const QString & szCaption, const QString & szInitial, const QString & szFilter, bool, bool, QWidget * pParent)
 {
-#ifdef COMPILE_KDE4_SUPPORT
-	// the KDE based dir selection dialog is now quite nice
-	szBuffer = KFileDialog::getExistingDirectory(szInitial, pParent, szCaption);
-	return !szBuffer.isEmpty();
-#endif
 #endif
 
 	KviFileDialog * pDialog = new KviFileDialog(szInitial,

--- a/src/kvirc/ui/KviImageDialog.cpp
+++ b/src/kvirc/ui/KviImageDialog.cpp
@@ -43,7 +43,7 @@ int KviImageDialogItem::height(const KviTalListWidget * lb) const
 
 int KviImageDialogItem::width(const KviTalListWidget * lb) const
 {
-	int w = lb->fontMetrics().width(text()) + 4;
+	int w = lb->fontMetrics().horizontalAdvance(text()) + 4;
 	if(w > 100)
 		w = 100;
 	else if(w < 24)
@@ -75,7 +75,7 @@ void KviImageDialogItem::paint(QPainter * p)
 
 	QFontMetrics fm(p->fontMetrics());
 
-	int wdth = fm.width(t);
+	int wdth = fm.horizontalAdvance(t);
 
 	int idx = t.length();
 	while(wdth > (daRect.width() - 6) && idx > 3)
@@ -83,7 +83,7 @@ void KviImageDialogItem::paint(QPainter * p)
 		t = text();
 		t.truncate(idx);
 		t.append("...");
-		wdth = fm.width(t);
+		wdth = fm.horizontalAdvance(t);
 		idx--;
 	}
 
@@ -202,9 +202,9 @@ void KviImageDialog::startJob(int type, const QString & szInitialPath)
 	{
 		QDir d(szInitialPath);
 		if(!d.exists())
-			d = QDir::homePath();
+			d.setPath(QDir::homePath());
 		if(!d.exists())
-			d = QDir::rootPath();
+			d.setPath(QDir::rootPath());
 		m_szJobPath = d.absolutePath();
 		KVI_OPTION_STRING(KviOption_stringLastImageDialogPath) = m_szJobPath;
 		m_lJobFileList = d.entryList(QDir::Hidden | QDir::AllEntries, QDir::DirsFirst | QDir::Name | QDir::IgnoreCase);

--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -90,7 +90,7 @@ extern QPixmap * g_pShadedChildGlobalDesktopBackground;
 
 //static members initialization
 int KviInputEditor::g_iInputInstances = 0;
-QFontMetricsF * KviInputEditor::g_pLastFontMetrics = nullptr;
+QFontMetrics * KviInputEditor::g_pLastFontMetrics = nullptr;
 int KviInputEditor::g_iCachedHeight = 0;
 
 #define KVI_INPUT_MAX_UNDO_SIZE 256
@@ -220,7 +220,6 @@ void KviInputEditor::applyOptions(bool bRefreshCachedMetrics)
 	//set the font
 	QFont newFont(KVI_OPTION_FONT(KviOption_fontInput));
 	newFont.setKerning(false);
-	newFont.setStyleStrategy(QFont::StyleStrategy(newFont.styleStrategy() | QFont::ForceIntegerMetrics));
 	setFont(newFont);
 
 	//set cursor custom width
@@ -288,18 +287,18 @@ void KviInputEditor::dropEvent(QDropEvent * e)
 	}
 }
 
-QFontMetricsF * KviInputEditor::getLastFontMetrics(const QFont & font)
+QFontMetrics * KviInputEditor::getLastFontMetrics(const QFont & font)
 {
 	if(g_pLastFontMetrics)
 		return g_pLastFontMetrics;
 
-	g_pLastFontMetrics = new QFontMetricsF(font);
+	g_pLastFontMetrics = new QFontMetrics(font);
 
-	m_p->fFontElisionWidth = g_pLastFontMetrics->width(m_p->szFontElision);
+	m_p->fFontElisionWidth = g_pLastFontMetrics->horizontalAdvance(m_p->szFontElision);
 
 	//height calculation
 
-	int h = qMax(g_pLastFontMetrics->height(), 14.0) + 2 * (KVI_INPUT_MARGIN + KVI_INPUT_XTRAPADDING);
+	int h = qMax(g_pLastFontMetrics->height(), 14) + 2 * (KVI_INPUT_MARGIN + KVI_INPUT_XTRAPADDING);
 	int w = 100;
 	QStyleOptionFrame option;
 	option.initFrom(this);
@@ -534,7 +533,7 @@ void KviInputEditor::rebuildTextBlocks()
 	    (c > 32) || ((c != KviControlCodes::Color) && (c != KviControlCodes::Bold) && (c != KviControlCodes::Italic) && (c != KviControlCodes::Underline) && (c != KviControlCodes::Reset) && (c != KviControlCodes::Reverse) && (c != KviControlCodes::CryptEscape) && (c != KviControlCodes::Icon)))
 
 	// FIXME: get rid of getLastFontMetrics() ?
-	QFontMetricsF * fm = getLastFontMetrics(font());
+	QFontMetrics * fm = getLastFontMetrics(font());
 
 	unsigned int uFlags = 0;
 	unsigned char uCurFore = KVI_INPUT_DEF_FORE;
@@ -573,7 +572,7 @@ void KviInputEditor::rebuildTextBlocks()
 				pBlock->uForeground = uCurFore;
 				pBlock->uBackground = uCurBack;
 				pBlock->uFlags = uFlags;
-				pBlock->fWidth = fm->width(pBlock->szText);
+				pBlock->fWidth = fm->horizontalAdvance(pBlock->szText);
 				pBlock->iLength = pBlock->szText.length();
 				m_p->lTextBlocks.append(pBlock);
 				continue;
@@ -647,7 +646,7 @@ void KviInputEditor::rebuildTextBlocks()
 
 			QChar cSubstitute = getSubstituteChar(c);
 			pBlock = new KviInputEditorTextBlock(QString(cSubstitute));
-			pBlock->fWidth = fm->width(pBlock->szText) + 4;
+			pBlock->fWidth = fm->horizontalAdvance(pBlock->szText) + 4;
 			pBlock->uFlags = uFlags | KviInputEditorTextBlock::IsControlBlock;
 			pBlock->uForeground = uCurFore;
 			pBlock->uBackground = uCurBack;
@@ -707,11 +706,11 @@ void KviInputEditor::rebuildTextBlocks()
 					pBlock2->uForeground = pBlock->uForeground;
 					pBlock2->uBackground = pBlock->uBackground;
 					pBlock2->uFlags = pBlock->uFlags;
-					pBlock2->fWidth = fm->width(pBlock2->szText);
+					pBlock2->fWidth = fm->horizontalAdvance(pBlock2->szText);
 					pBlock2->iLength = iLeft;
 					m_p->lTextBlocks.insert(idx, pBlock2);
 					pBlock->szText.remove(0, iLeft);
-					pBlock->fWidth = fm->width(pBlock->szText);
+					pBlock->fWidth = fm->horizontalAdvance(pBlock->szText);
 					pBlock->iLength -= iLeft;
 					pBlock->uFlags |= KviInputEditorTextBlock::IsSelected;
 					iCurStart += iLeft;
@@ -731,11 +730,11 @@ void KviInputEditor::rebuildTextBlocks()
 					pBlock2->uForeground = pBlock->uForeground;
 					pBlock2->uBackground = pBlock->uBackground;
 					pBlock2->uFlags = pBlock->uFlags;
-					pBlock2->fWidth = fm->width(pBlock2->szText);
+					pBlock2->fWidth = fm->horizontalAdvance(pBlock2->szText);
 					pBlock2->iLength = iLeft;
 					m_p->lTextBlocks.insert(idx, pBlock2);
 					pBlock->szText.remove(0, iLeft);
-					pBlock->fWidth = fm->width(pBlock->szText);
+					pBlock->fWidth = fm->horizontalAdvance(pBlock->szText);
 					pBlock->iLength = pBlock->szText.length();
 					pBlock->uFlags &= ~KviInputEditorTextBlock::IsSelected;
 					break;
@@ -833,7 +832,7 @@ void KviInputEditor::paintEvent(QPaintEvent *)
 void KviInputEditor::drawContents(QPainter * p)
 {
 	QRect rect = p->clipRegion().boundingRect();
-	QFontMetricsF * fm = getLastFontMetrics(font());
+	QFontMetrics * fm = getLastFontMetrics(font());
 
 	if(m_p->bTextBlocksDirty)
 		rebuildTextBlocks();
@@ -2523,7 +2522,7 @@ int KviInputEditor::charIndexFromXPosition(qreal fXPos)
 
 	qreal fWidth = fXPos - fCurX;
 
-	QFontMetricsF * fm = getLastFontMetrics(font());
+	QFontMetrics * fm = getLastFontMetrics(font());
 
 	QString szPart = fm->elidedText(pBlock->szText, Qt::ElideRight, fWidth + m_p->fFontElisionWidth);
 
@@ -2532,7 +2531,7 @@ int KviInputEditor::charIndexFromXPosition(qreal fXPos)
 
 	// OK, now we have a good starting point
 
-	qreal fPrevWidth = fm->width(szPart);
+	qreal fPrevWidth = fm->horizontalAdvance(szPart);
 	int iBlockLength = pBlock->szText.length();
 
 	if(fPrevWidth <= fWidth)
@@ -2546,7 +2545,7 @@ int KviInputEditor::charIndexFromXPosition(qreal fXPos)
 
 			szPart = pBlock->szText.left(iPartLength + 1);
 
-			qreal fNextWidth = fm->width(szPart);
+			qreal fNextWidth = fm->horizontalAdvance(szPart);
 
 			if(fNextWidth >= fWidth)
 			{
@@ -2573,7 +2572,7 @@ int KviInputEditor::charIndexFromXPosition(qreal fXPos)
 
 			szPart = pBlock->szText.left(iPartLength - 1);
 
-			qreal fNextWidth = fm->width(szPart);
+			qreal fNextWidth = fm->horizontalAdvance(szPart);
 
 			if(fNextWidth <= fWidth)
 			{
@@ -2603,7 +2602,7 @@ qreal KviInputEditor::xPositionFromCharIndex(int iChIdx)
 	if(m_p->lTextBlocks.isEmpty())
 		return fCurX;
 
-	QFontMetricsF * fm = getLastFontMetrics(font());
+	QFontMetrics * fm = getLastFontMetrics(font());
 	int iCurChar = 0;
 
 	foreach(KviInputEditorTextBlock * pBlock, m_p->lTextBlocks)
@@ -2613,7 +2612,7 @@ qreal KviInputEditor::xPositionFromCharIndex(int iChIdx)
 		{
 			if(iChIdx == iCurChar)
 				return fCurX;
-			return fCurX + fm->width(pBlock->szText.left(iChIdx - iCurChar));
+			return fCurX + fm->horizontalAdvance(pBlock->szText.left(iChIdx - iCurChar));
 		}
 		iCurChar = iNextChar;
 		fCurX += pBlock->fWidth;

--- a/src/kvirc/ui/KviInputEditor.h
+++ b/src/kvirc/ui/KviInputEditor.h
@@ -55,7 +55,7 @@
 class KviUserListView;
 class QDragEnterEvent;
 class QKeyEvent;
-class QFontMetricsF;
+class QFontMetrics;
 
 #define KVI_INPUT_MAX_BUFFER_SIZE 400
 #define KVI_INPUT_XTRAPADDING 1
@@ -109,7 +109,7 @@ public:
 
 protected:
 	static int g_iInputFontCharWidth[256];
-	static QFontMetricsF * g_pLastFontMetrics;
+	static QFontMetrics * g_pLastFontMetrics;
 	static int g_iInputInstances;
 	static int g_iCachedHeight;
 	QString m_szTextBuffer; // original buffer
@@ -521,9 +521,9 @@ private:
 	/**
 	* \brief Returns the current input editor font metrics (globally shared)
 	* \param font The current input editor font
-	* \return QFontMetricsF *
+	* \return QFontMetrics *
 	*/
-	QFontMetricsF * getLastFontMetrics(const QFont & font);
+	QFontMetrics * getLastFontMetrics(const QFont & font);
 
 public slots:
 	/**

--- a/src/kvirc/ui/KviIrcView.cpp
+++ b/src/kvirc/ui/KviIrcView.cpp
@@ -409,7 +409,6 @@ void KviIrcView::setFont(const QFont & f)
 
 	QFont newFont(f);
 	newFont.setKerning(false);
-	newFont.setStyleStrategy(QFont::StyleStrategy(newFont.styleStrategy() | QFont::ForceIntegerMetrics));
 	QWidget::setFont(newFont);
 	update();
 }
@@ -1685,7 +1684,7 @@ void KviIrcView::paintEvent(QPaintEvent * p)
 // The IrcView : calculate line wraps
 //
 
-#define IRCVIEW_WCHARWIDTH(c) (((c).unicode() < 0xff) ? m_iFontCharacterWidth[(c).unicode()] : m_pFm->width(c))
+#define IRCVIEW_WCHARWIDTH(c) (((c).unicode() < 0xff) ? m_iFontCharacterWidth[(c).unicode()] : m_pFm->horizontalAdvance(c))
 
 void KviIrcView::calculateLineWraps(KviIrcViewLine * ptr, int maxWidth)
 {
@@ -2100,7 +2099,7 @@ void KviIrcView::recalcFontVariables(const QFont & font, const QFontInfo & fi)
 
 	// cache the first 256 characters
 	for(unsigned short i = 0; i < 256; i++)
-		m_iFontCharacterWidth[i] = m_pFm->width(QChar(i));
+		m_iFontCharacterWidth[i] = m_pFm->horizontalAdvance(QChar(i));
 
 	// Currently KviIrcView requires that the bold font variant has the same metrics as the non-bold one.
 	// To ensure this, we check if the width of the bold and non-bold variants of the first 256 characters match.
@@ -2111,9 +2110,9 @@ void KviIrcView::recalcFontVariables(const QFont & font, const QFontInfo & fi)
 		fontBold.setBold(true);
 		QFontMetrics fmBold = QFontMetrics(fontBold);
 		for(unsigned short i = 32; i < 256; i++)
-			if (m_iFontCharacterWidth[i] && fmBold.width(QChar(i)) != m_iFontCharacterWidth[i])
+			if (m_iFontCharacterWidth[i] && fmBold.horizontalAdvance(QChar(i)) != m_iFontCharacterWidth[i])
 			{
-				//printf("Char %d: %d != %d\n", i, fmBold.width(QChar(i)), m_iFontCharacterWidth[i]);
+				//printf("Char %d: %d != %d\n", i, fmBold.horizontalAdvance(QChar(i)), m_iFontCharacterWidth[i]);
 				m_bUseRealBold = false;
 				break;
 			}
@@ -2121,7 +2120,7 @@ void KviIrcView::recalcFontVariables(const QFont & font, const QFontInfo & fi)
 	}
 
 	// fix for #489 (horizontal tabulations)
-	m_iFontCharacterWidth[9] = m_pFm->width("\t");
+	m_iFontCharacterWidth[9] = m_pFm->horizontalAdvance("\t");
 
 	if(m_iFontLineWidth < 1)
 		m_iFontLineWidth = 1;
@@ -2132,20 +2131,20 @@ void KviIrcView::recalcFontVariables(const QFont & font, const QFontInfo & fi)
 		QDateTime datetime = KVI_OPTION_BOOL(KviOption_boolIrcViewTimestampUTC) ? QDateTime::currentDateTime().toUTC() : QDateTime::currentDateTime();
 		szTimestamp = datetime.toString(KVI_OPTION_STRING(KviOption_stringIrcViewTimestampFormat));
 		szTimestamp.append(' ');
-		m_iWrapMargin = m_pFm->width(szTimestamp);
+		m_iWrapMargin = m_pFm->horizontalAdvance(szTimestamp);
 	}
 	else
 	{
-		m_iWrapMargin = m_pFm->width("wwww");
+		m_iWrapMargin = m_pFm->horizontalAdvance("wwww");
 	}
 
-	m_iMinimumPaintWidth = (((int)(m_pFm->width('w'))) << 1);
+	m_iMinimumPaintWidth = (((int)(m_pFm->horizontalAdvance('w'))) << 1);
 	if(KVI_OPTION_BOOL(KviOption_boolIrcViewWrapMargin))
 		m_iMinimumPaintWidth += m_iWrapMargin;
 
 	m_iRelativePixmapY = (int)(m_iFontLineSpacing + KVI_IRCVIEW_PIXMAP_SIZE) >> 1;
 
-	m_iIconWidth = (int)m_pFm->width("w");
+	m_iIconWidth = (int)m_pFm->horizontalAdvance("w");
 
 	if(fi.fixedPitch() && (m_iIconWidth > 0))
 	{
@@ -2665,12 +2664,12 @@ int KviIrcView::getVisibleCharIndexAt(KviIrcViewLine *, int xPos, int yPos)
 					curChar = l->szText.at(l->pBlocks[i].block_start + retValue);
 					if (curChar >= 0xD800 && curChar <= 0xDC00) // Surrogate pair
 					{
-						iLeft += m_pFm->width(l->szText.mid(retValue), 2);
+						iLeft += m_pFm->horizontalAdvance(l->szText.mid(retValue), 2);
 						retValue+=2;
 					}
 					else
 					{
-						iLeft += (curChar < 0xff) ? m_iFontCharacterWidth[curChar.unicode()] : m_pFm->width(curChar);
+						iLeft += (curChar < 0xff) ? m_iFontCharacterWidth[curChar.unicode()] : m_pFm->horizontalAdvance(curChar);
 						retValue++;
 					}
 				}

--- a/src/kvirc/ui/KviIrcView_events.cpp
+++ b/src/kvirc/ui/KviIrcView_events.cpp
@@ -419,7 +419,7 @@ void KviIrcView::triggerMouseRelatedKvsEvents(QMouseEvent * e)
 		else if(e->button() & Qt::RightButton)
 			emit rightClicked();
 	}
-	else if((e->button() & Qt::MidButton) || ((e->button() & Qt::RightButton) && (e->modifiers() & Qt::ControlModifier)))
+	else if((e->button() & Qt::MiddleButton) || ((e->button() & Qt::RightButton) && (e->modifiers() & Qt::ControlModifier)))
 	{
 		QString tmp;
 		getLinkEscapeCommand(tmp, linkCmd, QString("[!mbt]"));

--- a/src/kvirc/ui/KviIrcView_loghandling.cpp
+++ b/src/kvirc/ui/KviIrcView_loghandling.cpp
@@ -272,7 +272,7 @@ void KviIrcView::add2Log(const QString & szBuffer, const QDateTime & aDate, int 
 				szDate += " ";
 				break;
 			case 2:
-				szDate = date.toString(Qt::SystemLocaleShortDate);
+				szDate = QLocale().toString(date, QLocale::ShortFormat);
 				szDate += " ";
 				break;
 		}

--- a/src/kvirc/ui/KviMainWindow.cpp
+++ b/src/kvirc/ui/KviMainWindow.cpp
@@ -61,13 +61,13 @@
 
 #include <QCheckBox>
 #include <QCloseEvent>
-#include <QDesktopWidget>
 #include <QEvent>
 #include <QFile>
 #include <QLayout>
 #include <QLineEdit>
 #include <QMenu>
 #include <QMessageBox>
+#include <QScreen>
 #include <QShortcut>
 #include <QSplitter>
 #include <QString>
@@ -105,10 +105,8 @@ KviMainWindow::KviMainWindow(QWidget * pParent)
 	// We try to avois this as much as possible, since it forces the use of the low-res 16x16 icon
 	setWindowIcon(*(g_pIconManager->getSmallIcon(KviIconManager::KVIrc)));
 #endif
-#if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
 	// set name of the app desktop file; used by wayland to load the window icon
 	QGuiApplication::setDesktopFileName("kvirc");
-#endif
 	setWindowTitle(KVI_DEFAULT_FRAME_CAPTION);
 
 	m_pSplitter = new QSplitter(Qt::Horizontal, this);
@@ -143,12 +141,11 @@ KviMainWindow::KviMainWindow(QWidget * pParent)
 
 	createWindowList();
 
-	if((KVI_OPTION_RECT(KviOption_rectFrameGeometry).width() < 100) || (KVI_OPTION_RECT(KviOption_rectFrameGeometry).height() < 100) || (KVI_OPTION_RECT(KviOption_rectFrameGeometry).x() > g_pApp->desktop()->width()) || (KVI_OPTION_RECT(KviOption_rectFrameGeometry).y() > g_pApp->desktop()->height()))
+	if((KVI_OPTION_RECT(KviOption_rectFrameGeometry).width() < 100) || (KVI_OPTION_RECT(KviOption_rectFrameGeometry).height() < 100) || (KVI_OPTION_RECT(KviOption_rectFrameGeometry).x() > g_pMainWindow->screen()->availableSize().width()) || (KVI_OPTION_RECT(KviOption_rectFrameGeometry).y() > g_pMainWindow->screen()->availableSize().height()))
 	{
 		// Try to find some reasonable defaults
 		// prefer primary screen for first startup
-		int primary_screen = g_pApp->desktop()->primaryScreen();
-		QRect r = g_pApp->desktop()->screenGeometry(primary_screen);
+		QRect r = g_pApp->primaryScreen()->availableGeometry();
 		r.setLeft(r.left() + 10);
 		r.setRight(r.right() - 100);
 		r.setTop(r.top() + 10);

--- a/src/kvirc/ui/KviMaskEditor.cpp
+++ b/src/kvirc/ui/KviMaskEditor.cpp
@@ -55,7 +55,7 @@ KviMaskItem::KviMaskItem(QTreeWidget * pParent, KviMaskEntry * pEntry)
 			szDate = date.toString(Qt::ISODate);
 			break;
 		case 2:
-			szDate = date.toString(Qt::SystemLocaleShortDate);
+			szDate = QLocale().toString(date, QLocale::ShortFormat);
 			break;
 	}
 	setText(0, mask()->szMask);

--- a/src/kvirc/ui/KviMenuBar.cpp
+++ b/src/kvirc/ui/KviMenuBar.cpp
@@ -351,7 +351,7 @@ void KviMenuBar::setupToolsPopup(QMenu * pop)
 
 	// moved the old tools here
 	m->addAction(*(g_pIconManager->getSmallIcon(KviIconManager::IconManager)), __tr2qs("Show &Icon Table"), g_pIconManager, SLOT(showIconWidget()));
-#ifdef COMPILE_KDE4_SUPPORT
+#ifdef COMPILE_KDE_SUPPORT
 	QAction * pAction = m->addAction(*(g_pIconManager->getSmallIcon(KviIconManager::Terminal)), __tr2qs("Open &Terminal"), this, SLOT(actionTriggeredBool(bool)));
 	pAction->setData(KVI_INTERNALCOMMAND_TERM_OPEN);
 #endif

--- a/src/kvirc/ui/KviMessageBox.cpp
+++ b/src/kvirc/ui/KviMessageBox.cpp
@@ -75,7 +75,9 @@ namespace KviMessageBox
 		kvi_va_end(list);
 		bool bRet;
 #ifdef COMPILE_KDE_SUPPORT
-		bRet = (KMessageBox::questionYesNo(nullptr, s, caption) == KMessageBox::Yes);
+    	bRet = (KMessageBox::questionTwoActions(nullptr, s, caption,
+    				KStandardGuiItem::cont(), KStandardGuiItem::stop())
+	  		== KMessageBox::PrimaryAction);
 #else
 		bRet = (QMessageBox::information(0, caption, s,
 		            QMessageBox::Yes | QMessageBox::Default,

--- a/src/kvirc/ui/KviModeEditor.cpp
+++ b/src/kvirc/ui/KviModeEditor.cpp
@@ -49,7 +49,7 @@ KviModeEditor::KviModeEditor(QWidget * par, KviWindowToolPageButton * button, co
 	setFocusPolicy(Qt::ClickFocus);
 
 	QScrollArea * pScrollArea = new QScrollArea(this);
-	pScrollArea->viewport()->setBackgroundRole(QPalette::Background);
+	pScrollArea->viewport()->setBackgroundRole(QPalette::Window);
 	pMasterLayout->addWidget(pScrollArea, 0, 0);
 
 	pMasterLayout->setRowStretch(1, 1);

--- a/src/kvirc/ui/KviModeWidget.cpp
+++ b/src/kvirc/ui/KviModeWidget.cpp
@@ -174,7 +174,7 @@ std::map<QChar, QString> KviModeWidget::parseChannelModeString(const QString& sz
 {
 	std::map<QChar, QString> modeDict;
 
-	for(const auto & szSubstring : szModes.split(QChar(' '), QString::SkipEmptyParts))
+	for(const auto & szSubstring : szModes.split(QChar(' '), Qt::SkipEmptyParts))
 	{
 		if(szSubstring.size() >= 3 && szSubstring.at(1) == QChar(':'))
 		{

--- a/src/kvirc/ui/KviStatusBar.cpp
+++ b/src/kvirc/ui/KviStatusBar.cpp
@@ -534,7 +534,7 @@ void KviStatusBar::mousePressEvent(QMouseEvent * e)
 			dr->setPixmap(pixmap);
 			// Start the drag and drop operation
 			m_pAppletList->sort();
-			dr->start();
+			dr->exec();
 		}
 	}
 }

--- a/src/kvirc/ui/KviStatusBarApplet.cpp
+++ b/src/kvirc/ui/KviStatusBarApplet.cpp
@@ -133,7 +133,7 @@ KviStatusBarAwayIndicator::KviStatusBarAwayIndicator(KviStatusBar * pParent, Kvi
 
 	updateDisplay();
 
-	if(!pixmap())
+	if(pixmap(Qt::ReturnByValue).isNull())
 		setPixmap(*(g_pIconManager->getSmallIcon(KviIconManager::NotAway)));
 }
 
@@ -383,16 +383,16 @@ void KviStatusBarClock::adjustMinWidth()
 	if(m_b24h)
 	{
 		if(m_iType == KviStatusBarClock::HMS)
-			setFixedWidth(fm.width("00:00:00"));
+			setFixedWidth(fm.horizontalAdvance("00:00:00"));
 		else
-			setFixedWidth(fm.width("00:00"));
+			setFixedWidth(fm.horizontalAdvance("00:00"));
 	}
 	else
 	{
 		if(m_iType == KviStatusBarClock::HMS)
-			setFixedWidth(fm.width("00:00:00 AM"));
+			setFixedWidth(fm.horizontalAdvance("00:00:00 AM"));
 		else
-			setFixedWidth(fm.width("00:00 AM"));
+			setFixedWidth(fm.horizontalAdvance("00:00 AM"));
 	}
 }
 
@@ -504,7 +504,7 @@ KviStatusBarConnectionTimer::KviStatusBarConnectionTimer(KviStatusBar * pParent,
 	m_bTotal = false;
 
 	QFontMetrics fm(font());
-	setFixedWidth(fm.width("000 d 00 h 00 m 00 s"));
+	setFixedWidth(fm.horizontalAdvance("000 d 00 h 00 m 00 s"));
 }
 
 KviStatusBarConnectionTimer::~KviStatusBarConnectionTimer()
@@ -615,7 +615,7 @@ KviStatusBarUpdateIndicator::KviStatusBarUpdateIndicator(KviStatusBar * pParent,
 
 	updateDisplay();
 
-	if(!pixmap())
+	if(pixmap(Qt::ReturnByValue).isNull())
 		setPixmap(*(g_pIconManager->getSmallIcon(KviIconManager::NotUpdate)));
 }
 

--- a/src/kvirc/ui/KviThemedComboBox.cpp
+++ b/src/kvirc/ui/KviThemedComboBox.cpp
@@ -116,12 +116,11 @@ void KviThemedComboBox::paintEvent(QPaintEvent * event)
 		style()->drawPrimitive(QStyle::PE_FrameLineEdit, &option, p, this);
 
 		r = style()->subElementRect(QStyle::SE_LineEditContents, &option, le);
-		int left, right, top, bottom;
-		le->getTextMargins(&left, &top, &right, &bottom);
-		r.setX(r.x() + left);
-		r.setY(r.y() + top);
-		r.setRight(r.right() - right);
-		r.setBottom(r.bottom() - bottom);
+		QMargins m = le->textMargins();
+		r.setX(r.x() + m.left());
+		r.setY(r.y() + m.top());
+		r.setRight(r.right() - m.right());
+		r.setBottom(r.bottom() - m.bottom());
 		p->setClipRect(r);
 	} // else not editable
 

--- a/src/kvirc/ui/KviThemedLineEdit.cpp
+++ b/src/kvirc/ui/KviThemedLineEdit.cpp
@@ -49,13 +49,12 @@ KviThemedLineEdit::KviThemedLineEdit(QWidget * par, KviWindow * pWindow, const c
 
 	setFrame(false);
 
-	int l, t, r, b;
-	getTextMargins(&l, &t, &r, &b);
-	if(l < 4)
-		l = 4;
-	if(r < 4)
-		r = 4;
-	setTextMargins(l, t, r, b);
+	QMargins m = textMargins();
+	if(m.left() < 4)
+		m.setLeft(4);
+	if(m.right() < 4)
+		m.setRight(4);
+	setTextMargins(m);
 
 	setAutoFillBackground(false);
 	applyOptions();

--- a/src/kvirc/ui/KviTopicWidget.cpp
+++ b/src/kvirc/ui/KviTopicWidget.cpp
@@ -93,7 +93,7 @@ KviTopicListBoxItem::~KviTopicListBoxItem()
 
 int KviTopicListBoxItem::width(const KviTalListWidget * lb) const
 {
-	return lb->fontMetrics().width(KviControlCodes::stripControlBytes(text()));
+	return lb->fontMetrics().horizontalAdvance(KviControlCodes::stripControlBytes(text()));
 }
 
 KviTopicWidget::KviTopicWidget(QWidget * par, KviChannelWindow * pChannel, const char * name)
@@ -177,7 +177,6 @@ void KviTopicWidget::applyOptions()
 	m_pLabel->applyOptions();
 	QFont newFont(KVI_OPTION_FONT(KviOption_fontLabel));
 	newFont.setKerning(false);
-	newFont.setStyleStrategy(QFont::StyleStrategy(newFont.styleStrategy() | QFont::ForceIntegerMetrics));
 	setFont(newFont);
 	if(m_pCompletionBox)
 		m_pCompletionBox->setFont(newFont);
@@ -221,7 +220,7 @@ void KviTopicWidget::paintColoredText(QPainter * p, QString text, const QPalette
 		{
 			QString szText = text.mid(start, len);
 
-			wdth = fm.width(szText);
+			wdth = fm.horizontalAdvance(szText);
 
 			if(curFore == KVI_LABEL_DEF_FORE)
 			{
@@ -230,7 +229,7 @@ void KviTopicWidget::paintColoredText(QPainter * p, QString text, const QPalette
 			else
 			{
 				if(curFore > KVI_EXTCOLOR_MAX)
-					p->setPen(cg.background().color());
+					p->setPen(cg.window().color());
 				else
 					p->setPen(getMircColor(curFore));
 			}
@@ -441,7 +440,7 @@ QSize KviTopicWidget::sizeHint() const
 {
 	QFontMetrics fm(font());
 	int h = qMax(fm.height(), 14) + 2 * (KVI_INPUT_MARGIN + KVI_INPUT_XTRAPADDING);
-	int w = fm.width(QLatin1Char('x')) * 17 + 2 * (KVI_INPUT_MARGIN + KVI_INPUT_XTRAPADDING);
+	int w = fm.horizontalAdvance(QLatin1Char('x')) * 17 + 2 * (KVI_INPUT_MARGIN + KVI_INPUT_XTRAPADDING);
 	QStyleOptionFrame option;
 	option.initFrom(this);
 	option.rect = rect();

--- a/src/kvirc/ui/KviTreeWindowList.cpp
+++ b/src/kvirc/ui/KviTreeWindowList.cpp
@@ -173,22 +173,22 @@ QString KviTreeWindowListItem::key() const
 			QString szText;
 			KviWindowListBase::getTextForConsole(szText, (KviConsoleWindow *)m_pWindow);
 
-			ret.sprintf("%2d%s", iType, szText.toLower().toUtf8().data());
+			ret.asprintf("%2d%s", iType, szText.toLower().toUtf8().data());
 		}
 		else
 		{
-			ret.sprintf("%2d%s", iType, m_pWindow->windowName().toLower().toUtf8().data());
+			ret.asprintf("%2d%s", iType, m_pWindow->windowName().toLower().toUtf8().data());
 		}
 	}
 	else
 	{
 		if(iType == KviWindow::Console)
 		{
-			ret.sprintf("%2d%4u", iType, ((KviConsoleWindow *)m_pWindow)->context() ? ((KviConsoleWindow *)m_pWindow)->context()->id() : 9999);
+			ret.asprintf("%2d%4u", iType, ((KviConsoleWindow *)m_pWindow)->context() ? ((KviConsoleWindow *)m_pWindow)->context()->id() : 9999);
 		}
 		else
 		{
-			ret.sprintf("%2d%4d", iType, parent() ? parent()->indexOfChild((QTreeWidgetItem *)this) : 9999);
+			ret.asprintf("%2d%4d", iType, parent() ? parent()->indexOfChild((QTreeWidgetItem *)this) : 9999);
 		}
 	}
 	return ret;
@@ -230,9 +230,9 @@ void KviTreeWindowListTreeWidget::wheelEvent(QWheelEvent * e)
 
 	if(KVI_OPTION_BOOL(KviOption_boolWheelScrollsWindowsList))
 	{
-		if(e->delta() < 0)
+		if(e->pixelDelta().x() < 0)
 			((KviTreeWindowList *)parent())->switchWindow(true, false);
-		else if(e->delta() > 0)
+		else if(e->pixelDelta().x() > 0)
 			((KviTreeWindowList *)parent())->switchWindow(false, false);
 	}
 	else
@@ -245,7 +245,7 @@ void KviTreeWindowListTreeWidget::wheelEvent(QWheelEvent * e)
 			return;
 
 		if(
-		    ((e->delta() < 0) && (pBar->value() < pBar->maximum())) || ((e->delta() > 0) && (pBar->value() > pBar->minimum())))
+		    ((e->pixelDelta().x() < 0) && (pBar->value() < pBar->maximum())) || ((e->pixelDelta().x() > 0) && (pBar->value() > pBar->minimum())))
 			QApplication::sendEvent(pBar, e);
 	}
 }
@@ -283,7 +283,7 @@ void KviTreeWindowListTreeWidget::mousePressEvent(QMouseEvent * e)
 			//right click: open popup
 			wnd->contextPopup();
 		}
-		else if(e->button() & Qt::MidButton)
+		else if(e->button() & Qt::MiddleButton)
 		{
 			//mid click: close window
 			wnd->delayedClose();

--- a/src/kvirc/ui/KviTreeWindowList.cpp
+++ b/src/kvirc/ui/KviTreeWindowList.cpp
@@ -230,9 +230,9 @@ void KviTreeWindowListTreeWidget::wheelEvent(QWheelEvent * e)
 
 	if(KVI_OPTION_BOOL(KviOption_boolWheelScrollsWindowsList))
 	{
-		if(e->pixelDelta().x() < 0)
+		if(e->angleDelta().y() < 0)
 			((KviTreeWindowList *)parent())->switchWindow(true, false);
-		else if(e->pixelDelta().x() > 0)
+		else if(e->angleDelta().y() > 0)
 			((KviTreeWindowList *)parent())->switchWindow(false, false);
 	}
 	else
@@ -245,7 +245,7 @@ void KviTreeWindowListTreeWidget::wheelEvent(QWheelEvent * e)
 			return;
 
 		if(
-		    ((e->pixelDelta().x() < 0) && (pBar->value() < pBar->maximum())) || ((e->pixelDelta().x() > 0) && (pBar->value() > pBar->minimum())))
+		    ((e->angleDelta().y() < 0) && (pBar->value() < pBar->maximum())) || ((e->angleDelta().y() > 0) && (pBar->value() > pBar->minimum())))
 			QApplication::sendEvent(pBar, e);
 	}
 }

--- a/src/kvirc/ui/KviTreeWindowList.cpp
+++ b/src/kvirc/ui/KviTreeWindowList.cpp
@@ -173,22 +173,22 @@ QString KviTreeWindowListItem::key() const
 			QString szText;
 			KviWindowListBase::getTextForConsole(szText, (KviConsoleWindow *)m_pWindow);
 
-			ret.asprintf("%2d%s", iType, szText.toLower().toUtf8().data());
+			ret = QString::asprintf("%2d%s", iType, szText.toLower().toUtf8().data());
 		}
 		else
 		{
-			ret.asprintf("%2d%s", iType, m_pWindow->windowName().toLower().toUtf8().data());
+			ret = QString::asprintf("%2d%s", iType, m_pWindow->windowName().toLower().toUtf8().data());
 		}
 	}
 	else
 	{
 		if(iType == KviWindow::Console)
 		{
-			ret.asprintf("%2d%4u", iType, ((KviConsoleWindow *)m_pWindow)->context() ? ((KviConsoleWindow *)m_pWindow)->context()->id() : 9999);
+			ret = QString::asprintf("%2d%4u", iType, ((KviConsoleWindow *)m_pWindow)->context() ? ((KviConsoleWindow *)m_pWindow)->context()->id() : 9999);
 		}
 		else
 		{
-			ret.asprintf("%2d%4d", iType, parent() ? parent()->indexOfChild((QTreeWidgetItem *)this) : 9999);
+			ret = QString::asprintf("%2d%4d", iType, parent() ? parent()->indexOfChild((QTreeWidgetItem *)this) : 9999);
 		}
 	}
 	return ret;

--- a/src/kvirc/ui/KviUserListView.cpp
+++ b/src/kvirc/ui/KviUserListView.cpp
@@ -1693,7 +1693,7 @@ void KviUserListView::maybeTip(KviUserListToolTip * pTip, const QPoint & pnt)
 						szTmp = date.toString(Qt::ISODate);
 						break;
 					case 2:
-						szTmp = date.toString(Qt::SystemLocaleShortDate);
+						szTmp = QLocale().toString(date, QLocale::ShortFormat);
 						break;
 				}
 

--- a/src/kvirc/ui/KviWebPackageManagementDialog.cpp
+++ b/src/kvirc/ui/KviWebPackageManagementDialog.cpp
@@ -37,7 +37,7 @@
 #include "KviMainWindow.h"
 #include "KviNetworkAccessManager.h"
 
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QToolButton>
 #include <QLineEdit>
 #include <QToolTip>
@@ -265,7 +265,7 @@ void KviWebPackageManagementDialog::slotCommandFinished()
 void KviWebPackageManagementDialog::showEvent(QShowEvent *)
 {
 	m_pProgressBar->hide();
-	QRect rect = g_pApp->desktop()->screenGeometry(g_pMainWindow);
+	QRect rect = g_pMainWindow->screen()->availableGeometry();
 	move(rect.x() + ((rect.width() - width()) / 2), rect.y() + ((rect.height() - height()) / 2));
 }
 

--- a/src/kvirc/ui/KviWindow.cpp
+++ b/src/kvirc/ui/KviWindow.cpp
@@ -63,7 +63,6 @@
 #include <QDateTime>
 #include <QTextCodec>
 #include <QPushButton>
-#include <QDesktopWidget>
 #include <QVariant>
 #include <QMessageBox>
 #include <QEvent>
@@ -211,9 +210,8 @@ bool KviWindow::hasAttention(AttentionLevel eLevel)
 
 void KviWindow::demandAttention()
 {
-	[[maybe_unused]] WId windowId = isDocked() ? g_pMainWindow->winId() : winId();
-
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
+	[[maybe_unused]] WId windowId = isDocked() ? g_pMainWindow->winId() : winId();
 	FLASHWINFO fwi;
 	fwi.cbSize = sizeof(fwi);
 	fwi.hwnd = (HWND)windowId;
@@ -221,8 +219,8 @@ void KviWindow::demandAttention()
 	fwi.uCount = 20;
 	fwi.dwTimeout = 500;
 	FlashWindowEx(&fwi);
-#elif defined(COMPILE_KDE_SUPPORT)
-	KWindowSystem::demandAttention(windowId, true);
+#else
+	g_pApp->alert(g_pMainWindow, 10000);
 #endif
 }
 
@@ -537,7 +535,7 @@ void KviWindow::getDefaultLogFileName(QString & szBuffer, QDate date, bool bGzip
 			szDate = date.toString(Qt::ISODate);
 			break;
 		case 2:
-			szDate = date.toString(Qt::SystemLocaleShortDate);
+			szDate = QLocale().toString(date, QLocale::ShortFormat);
 			break;
 		case 0:
 		default:
@@ -1481,10 +1479,10 @@ enough:
 				static int iSpaceCount = -1;
 				if (iSpaceCount == -1)
 				{
-					QString szTypicalDate = QDateTime::currentDateTime().toString(Qt::SystemLocaleShortDate);
+					QString szTypicalDate = QLocale().toString(QDateTime::currentDateTime(), QLocale::ShortFormat);
 					iSpaceCount = szTypicalDate.count(' ');
 				}
-				date = QDateTime::fromString(szLine.section(' ', 0, iSpaceCount), Qt::SystemLocaleShortDate);
+				date = QLocale().toDateTime(szLine.section(' ', 0, iSpaceCount), QLocale::ShortFormat);
 				if (date.isValid())
 				{
 					szLine = szLine.section(' ', iSpaceCount+1);

--- a/src/kvirc/ui/KviWindowListBase.cpp
+++ b/src/kvirc/ui/KviWindowListBase.cpp
@@ -165,7 +165,7 @@ void KviWindowListBase::switchWindow(bool bNext, bool bInContextOnly, bool bHigh
 
 void KviWindowListBase::wheelEvent(QWheelEvent * e)
 {
-	if(e->pixelDelta().x() > 0)
+	if(e->angleDelta().y() > 0)
 		switchWindow(false, false);
 	else
 		switchWindow(true, false);

--- a/src/kvirc/ui/KviWindowListBase.cpp
+++ b/src/kvirc/ui/KviWindowListBase.cpp
@@ -165,7 +165,7 @@ void KviWindowListBase::switchWindow(bool bNext, bool bInContextOnly, bool bHigh
 
 void KviWindowListBase::wheelEvent(QWheelEvent * e)
 {
-	if(e->delta() > 0)
+	if(e->pixelDelta().x() > 0)
 		switchWindow(false, false);
 	else
 		switchWindow(true, false);
@@ -366,7 +366,7 @@ void KviWindowListButton::drawButtonLabel(QPainter * pPainter)
 	if(KVI_OPTION_BOOL(KviOption_boolUseWindowListIrcContextIndicator))
 	{
 		iHeight -= KVI_WINDOWLISTBUTTON_CONTEXTINDICATORHEIGHT;
-		QColor base = palette().color(QPalette::Background);
+		QColor base = palette().color(QPalette::Window);
 		if(m_pWindow->console())
 		{
 			QColor cntx = KVI_OPTION_ICCOLOR(m_pWindow->console()->context()->id() % KVI_NUM_ICCOLOR_OPTIONS);
@@ -389,7 +389,7 @@ void KviWindowListButton::drawButtonLabel(QPainter * pPainter)
 			    iHeight - KVI_WINDOWLISTBUTTON_BOTTOM_MARGIN,
 			    iWidth - (KVI_WINDOWLISTBUTTON_LEFT_MARGIN + KVI_WINDOWLISTBUTTON_RIGHT_MARGIN),
 			    KVI_WINDOWLISTBUTTON_CONTEXTINDICATORHEIGHT,
-			    palette().brush(QPalette::Background));
+			    palette().brush(QPalette::Window));
 		}
 		iHeight -= KVI_WINDOWLISTBUTTON_CONTEXTINDICATORSPACING;
 	}
@@ -508,7 +508,7 @@ void KviWindowListButton::drawButtonLabel(QPainter * pPainter)
 	{
 		pPainter->setClipRect(cRect.right() - 15, cRect.y(), 10, cRect.height());
 		QColor base = pPainter->pen().color();
-		QColor bg = palette().color(QPalette::Background);
+		QColor bg = palette().color(QPalette::Window);
 		base.setRgb((base.red() + bg.red()) / 2, (base.green() + bg.green()) / 2, (base.blue() + bg.blue()) / 2);
 		pPainter->setPen(base);
 		pPainter->drawText(cRect, Qt::AlignLeft | Qt::AlignTop, szText);

--- a/src/modules/addon/AddonFunctions.cpp
+++ b/src/modules/addon/AddonFunctions.cpp
@@ -102,7 +102,7 @@ namespace AddonFunctions
 		// load its picture
 		pByteArray = r.binaryInfoFields()->find("Image");
 		if(pByteArray)
-			pix.loadFromData(*pByteArray, nullptr, nullptr);
+			pix.loadFromData(*pByteArray);
 
 		if(pix.isNull())
 		{

--- a/src/modules/addon/AddonManagementDialog.cpp
+++ b/src/modules/addon/AddonManagementDialog.cpp
@@ -48,7 +48,7 @@
 #include <QPushButton>
 #include <QLayout>
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QLineEdit>
 #include <QLabel>
 #include <QFrame>
@@ -192,7 +192,7 @@ AddonManagementDialog::AddonManagementDialog(QWidget * p)
 	resize(g_rectManagementDialogGeometry.width(),
 	    g_rectManagementDialogGeometry.height());
 
-	QRect rect = g_pApp->desktop()->screenGeometry(g_pMainWindow);
+	QRect rect = g_pMainWindow->screen()->availableGeometry();
 	move(rect.x() + ((rect.width() - g_rectManagementDialogGeometry.width()) / 2), rect.y() + ((rect.height() - g_rectManagementDialogGeometry.height()) / 2));
 
 	new QShortcut(Qt::Key_Escape, this, SLOT(closeClicked()));

--- a/src/modules/channelsjoin/ChannelsJoinDialog.cpp
+++ b/src/modules/channelsjoin/ChannelsJoinDialog.cpp
@@ -38,7 +38,6 @@
 
 #include <QCheckBox>
 #include <QCloseEvent>
-#include <QDesktopWidget>
 #include <QEvent>
 #include <QGroupBox>
 #include <QHeaderView>
@@ -47,6 +46,7 @@
 #include <QLineEdit>
 #include <QMouseEvent>
 #include <QPushButton>
+#include <QScreen>
 #include <QString>
 
 extern ChannelsJoinDialog * g_pChannelsWindow;
@@ -131,7 +131,7 @@ ChannelsJoinDialog::ChannelsJoinDialog(const char * name)
 
 	resize(g_rectChannelsJoinGeometry.width(), g_rectChannelsJoinGeometry.height());
 
-	QRect rect = g_pApp->desktop()->screenGeometry(g_pMainWindow);
+	QRect rect = g_pMainWindow->screen()->availableGeometry();
 	move(rect.x() + ((rect.width() - g_rectChannelsJoinGeometry.width()) / 2), rect.y() + ((rect.height() - g_rectChannelsJoinGeometry.height()) / 2));
 
 	enableJoin();

--- a/src/modules/dcc/DccCanvasWindow.cpp
+++ b/src/modules/dcc/DccCanvasWindow.cpp
@@ -134,7 +134,7 @@ DccCanvasWindow::~DccCanvasWindow()
 const QString & DccCanvasWindow::target()
 {
 	// This may change on the fly...
-	m_szTarget.sprintf("%s@%s:%s",
+	m_szTarget.asprintf("%s@%s:%s",
 	    m_pDescriptor->szNick.toUtf8().data(), m_pDescriptor->szIp.toUtf8().data(), m_pDescriptor->szPort.toUtf8().data());
 	return m_szTarget;
 }

--- a/src/modules/dcc/DccCanvasWindow.cpp
+++ b/src/modules/dcc/DccCanvasWindow.cpp
@@ -134,7 +134,7 @@ DccCanvasWindow::~DccCanvasWindow()
 const QString & DccCanvasWindow::target()
 {
 	// This may change on the fly...
-	m_szTarget.asprintf("%s@%s:%s",
+	m_szTarget = QString::asprintf("%s@%s:%s",
 	    m_pDescriptor->szNick.toUtf8().data(), m_pDescriptor->szIp.toUtf8().data(), m_pDescriptor->szPort.toUtf8().data());
 	return m_szTarget;
 }

--- a/src/modules/dcc/DccChatWindow.cpp
+++ b/src/modules/dcc/DccChatWindow.cpp
@@ -293,7 +293,7 @@ QPixmap * DccChatWindow::myIconPtr()
 
 void DccChatWindow::getBaseLogFileName(QString & buffer)
 {
-	buffer.sprintf("%s_%s_%s", m_pDescriptor->szNick.toUtf8().data(), m_pDescriptor->szIp.toUtf8().data(), m_pDescriptor->szPort.toUtf8().data());
+	buffer.asprintf("%s_%s_%s", m_pDescriptor->szNick.toUtf8().data(), m_pDescriptor->szIp.toUtf8().data(), m_pDescriptor->szPort.toUtf8().data());
 }
 
 void DccChatWindow::ownMessage(const QString & text, bool bUserFeedback)

--- a/src/modules/dcc/DccChatWindow.cpp
+++ b/src/modules/dcc/DccChatWindow.cpp
@@ -293,7 +293,7 @@ QPixmap * DccChatWindow::myIconPtr()
 
 void DccChatWindow::getBaseLogFileName(QString & buffer)
 {
-	buffer.asprintf("%s_%s_%s", m_pDescriptor->szNick.toUtf8().data(), m_pDescriptor->szIp.toUtf8().data(), m_pDescriptor->szPort.toUtf8().data());
+	buffer = QString::asprintf("%s_%s_%s", m_pDescriptor->szNick.toUtf8().data(), m_pDescriptor->szIp.toUtf8().data(), m_pDescriptor->szPort.toUtf8().data());
 }
 
 void DccChatWindow::ownMessage(const QString & text, bool bUserFeedback)

--- a/src/modules/dcc/DccDialog.cpp
+++ b/src/modules/dcc/DccDialog.cpp
@@ -33,11 +33,11 @@
 #include <QPushButton>
 #include <QLabel>
 #include <QStringList>
-#include <QDesktopWidget>
 #include <QEvent>
 #include <QCloseEvent>
 #include <QShowEvent>
 #include <QIcon>
+#include <QScreen>
 
 DccDialog::DccDialog(DccBroker * br, DccDescriptor * dcc)
 {
@@ -120,10 +120,10 @@ void DccAcceptDialog::closeEvent(QCloseEvent * e)
 
 void DccAcceptDialog::showEvent(QShowEvent * e)
 {
-	int iScreen = g_pApp->desktop()->screenNumber(g_pMainWindow);
-	if(iScreen < 0)
-		iScreen = g_pApp->desktop()->primaryScreen();
-	QRect rect = g_pApp->desktop()->screenGeometry(iScreen);
+	QScreen *pScreen = g_pMainWindow->screen();
+	if(!pScreen)
+		pScreen = g_pApp->primaryScreen();
+	QRect rect = pScreen->availableGeometry();
 	move(rect.x() + ((rect.width() - width()) / 2),rect.y() + ((rect.height() - height()) / 2));
 	QWidget::showEvent(e);
 }
@@ -186,10 +186,10 @@ void DccRenameDialog::closeEvent(QCloseEvent * e)
 
 void DccRenameDialog::showEvent(QShowEvent * e)
 {
-	int iScreen = g_pApp->desktop()->screenNumber(g_pMainWindow);
-	if(iScreen < 0)
-		iScreen = g_pApp->desktop()->primaryScreen();
-	QRect rect = g_pApp->desktop()->screenGeometry(iScreen);
+	QScreen *pScreen = g_pMainWindow->screen();
+	if(!pScreen)
+		pScreen = g_pApp->primaryScreen();
+	QRect rect = pScreen->availableGeometry();
 	move(rect.x() + ((rect.width() - width()) / 2),rect.y() + ((rect.height() - height()) / 2));
 	QWidget::showEvent(e);
 }

--- a/src/modules/dcc/DccFileTransfer.cpp
+++ b/src/modules/dcc/DccFileTransfer.cpp
@@ -2010,7 +2010,7 @@ void DccFileTransfer::addToTransferLog(const QString & s)
 {
 	QDateTime dt = QDateTime::currentDateTime();
 	QString ts;
-	ts.asprintf("[%4d.%2d.%2d %2d:%2d:%2d] ", dt.date().year(), dt.date().month(), dt.date().day(), dt.time().hour(), dt.time().minute(), dt.time().second());
+	ts = QString::asprintf("[%4d.%2d.%2d %2d:%2d:%2d] ", dt.date().year(), dt.date().month(), dt.date().day(), dt.time().hour(), dt.time().minute(), dt.time().second());
 	m_szTransferLog += ts + s;
 	m_szTransferLog += "<br>";
 }

--- a/src/modules/dcc/DccFileTransfer.cpp
+++ b/src/modules/dcc/DccFileTransfer.cpp
@@ -1676,8 +1676,8 @@ void DccFileTransfer::displayPaint(QPainter * p, int column, QRect rect)
 			QString szFrom = __tr2qs_ctx("From: ", "dcc");
 			QString szTo = __tr2qs_ctx("To: ", "dcc");
 
-			int daW1 = fm.width(szFrom);
-			int daW2 = fm.width(szTo);
+			int daW1 = fm.horizontalAdvance(szFrom);
+			int daW2 = fm.horizontalAdvance(szTo);
 			if(daW1 < daW2)
 				daW1 = daW2;
 			int iLineSpacing = fm.lineSpacing();
@@ -2010,7 +2010,7 @@ void DccFileTransfer::addToTransferLog(const QString & s)
 {
 	QDateTime dt = QDateTime::currentDateTime();
 	QString ts;
-	ts.sprintf("[%4d.%2d.%2d %2d:%2d:%2d] ", dt.date().year(), dt.date().month(), dt.date().day(), dt.time().hour(), dt.time().minute(), dt.time().second());
+	ts.asprintf("[%4d.%2d.%2d %2d:%2d:%2d] ", dt.date().year(), dt.date().month(), dt.date().day(), dt.time().hour(), dt.time().minute(), dt.time().second());
 	m_szTransferLog += ts + s;
 	m_szTransferLog += "<br>";
 }

--- a/src/modules/dcc/DccVideoWindow.cpp
+++ b/src/modules/dcc/DccVideoWindow.cpp
@@ -657,13 +657,13 @@ const QString & DccVideoWindow::target()
 	if(!m_pszTarget)
 		m_pszTarget = new QString();
 
-	m_pszTarget->asprintf("%s@%s:%s", m_pDescriptor->szNick.toUtf8().data(), m_pDescriptor->szIp.toUtf8().data(), m_pDescriptor->szPort.toUtf8().data());
+	m_pszTarget = QString::asprintf("%s@%s:%s", m_pDescriptor->szNick.toUtf8().data(), m_pDescriptor->szIp.toUtf8().data(), m_pDescriptor->szPort.toUtf8().data());
 	return *m_pszTarget;
 }
 
 void DccVideoWindow::getBaseLogFileName(QString & buffer)
 {
-	buffer.asprintf("dccvideo_%s_%s_%s", m_pDescriptor->szNick.toUtf8().data(), m_pDescriptor->szLocalFileName.toUtf8().data(), m_pDescriptor->szPort.toUtf8().data());
+	buffer = QString::asprintf("dccvideo_%s_%s_%s", m_pDescriptor->szNick.toUtf8().data(), m_pDescriptor->szLocalFileName.toUtf8().data(), m_pDescriptor->szPort.toUtf8().data());
 }
 
 void DccVideoWindow::fillCaptionBuffers()

--- a/src/modules/dcc/DccVideoWindow.cpp
+++ b/src/modules/dcc/DccVideoWindow.cpp
@@ -657,13 +657,13 @@ const QString & DccVideoWindow::target()
 	if(!m_pszTarget)
 		m_pszTarget = new QString();
 
-	m_pszTarget->sprintf("%s@%s:%s", m_pDescriptor->szNick.toUtf8().data(), m_pDescriptor->szIp.toUtf8().data(), m_pDescriptor->szPort.toUtf8().data());
+	m_pszTarget->asprintf("%s@%s:%s", m_pDescriptor->szNick.toUtf8().data(), m_pDescriptor->szIp.toUtf8().data(), m_pDescriptor->szPort.toUtf8().data());
 	return *m_pszTarget;
 }
 
 void DccVideoWindow::getBaseLogFileName(QString & buffer)
 {
-	buffer.sprintf("dccvideo_%s_%s_%s", m_pDescriptor->szNick.toUtf8().data(), m_pDescriptor->szLocalFileName.toUtf8().data(), m_pDescriptor->szPort.toUtf8().data());
+	buffer.asprintf("dccvideo_%s_%s_%s", m_pDescriptor->szNick.toUtf8().data(), m_pDescriptor->szLocalFileName.toUtf8().data(), m_pDescriptor->szPort.toUtf8().data());
 }
 
 void DccVideoWindow::fillCaptionBuffers()

--- a/src/modules/dcc/DccVoiceCodec.cpp
+++ b/src/modules/dcc/DccVoiceCodec.cpp
@@ -223,7 +223,7 @@ void DccVideoSJpegCodec::decode(KviDataBuffer * stream, KviDataBuffer * videoSig
 		if(!img.isNull())
 		{
 			videoSignal->clear();
-			videoSignal->append(img.bits(), img.byteCount());
+			videoSignal->append(img.bits(), img.sizeInBytes());
 		}
 		stream->remove(len);
 	}

--- a/src/modules/dcc/DccVoiceWindow.cpp
+++ b/src/modules/dcc/DccVoiceWindow.cpp
@@ -833,14 +833,14 @@ void DccVoiceWindow::connectionInProgress()
 const QString & DccVoiceWindow::target()
 {
 	// This may change on the fly...
-	m_szTarget.sprintf("%s@%s:%s",
+	m_szTarget.asprintf("%s@%s:%s",
 	    m_pDescriptor->szNick.toUtf8().data(), m_pDescriptor->szIp.toUtf8().data(), m_pDescriptor->szPort.toUtf8().data());
 	return m_szTarget;
 }
 
 void DccVoiceWindow::getBaseLogFileName(QString & buffer)
 {
-	buffer.sprintf("dccvoice_%s_%s_%s", m_pDescriptor->szNick.toUtf8().data(), m_pDescriptor->szLocalFileName.toUtf8().data(), m_pDescriptor->szPort.toUtf8().data());
+	buffer.asprintf("dccvoice_%s_%s_%s", m_pDescriptor->szNick.toUtf8().data(), m_pDescriptor->szLocalFileName.toUtf8().data(), m_pDescriptor->szPort.toUtf8().data());
 }
 
 void DccVoiceWindow::fillCaptionBuffers()

--- a/src/modules/dcc/DccVoiceWindow.cpp
+++ b/src/modules/dcc/DccVoiceWindow.cpp
@@ -833,14 +833,14 @@ void DccVoiceWindow::connectionInProgress()
 const QString & DccVoiceWindow::target()
 {
 	// This may change on the fly...
-	m_szTarget.asprintf("%s@%s:%s",
+	m_szTarget = QString::asprintf("%s@%s:%s",
 	    m_pDescriptor->szNick.toUtf8().data(), m_pDescriptor->szIp.toUtf8().data(), m_pDescriptor->szPort.toUtf8().data());
 	return m_szTarget;
 }
 
 void DccVoiceWindow::getBaseLogFileName(QString & buffer)
 {
-	buffer.asprintf("dccvoice_%s_%s_%s", m_pDescriptor->szNick.toUtf8().data(), m_pDescriptor->szLocalFileName.toUtf8().data(), m_pDescriptor->szPort.toUtf8().data());
+	buffer = QString::asprintf("dccvoice_%s_%s_%s", m_pDescriptor->szNick.toUtf8().data(), m_pDescriptor->szLocalFileName.toUtf8().data(), m_pDescriptor->szPort.toUtf8().data());
 }
 
 void DccVoiceWindow::fillCaptionBuffers()

--- a/src/modules/dialog/libkvidialog.cpp
+++ b/src/modules/dialog/libkvidialog.cpp
@@ -41,7 +41,7 @@
 #include <QLineEdit>
 #include <QLabel>
 #include <QPushButton>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QEvent>
 #include <QCloseEvent>
 
@@ -444,7 +444,7 @@ void KviKvsCallbackTextInput::done(int code)
 
 void KviKvsCallbackTextInput::showEvent(QShowEvent * e)
 {
-	QRect rect = g_pApp->desktop()->screenGeometry(g_pApp->desktop()->primaryScreen());
+	QRect rect = g_pApp->primaryScreen()->availableGeometry();
 	move((rect.width() - width()) / 2, (rect.height() - height()) / 2);
 
 	QDialog::showEvent(e);
@@ -583,11 +583,7 @@ void KviKvsCallbackFileDialog::done(int code)
 
 	if(code == QDialog::Accepted)
 	{
-#ifdef COMPILE_KDE4_SUPPORT
-		if(mode() == KFile::ExistingOnly)
-#else
 		if(fileMode() == QFileDialog::ExistingFiles)
-#endif
 		{
 			KviKvsArray * a = new KviKvsArray();
 			QStringList sl = selectedFiles();

--- a/src/modules/editor/ScriptEditorImplementation.cpp
+++ b/src/modules/editor/ScriptEditorImplementation.cpp
@@ -95,7 +95,7 @@ ScriptEditorWidget::ScriptEditorWidget(QWidget * pParent)
     : QTextEdit(pParent)
 {
 	m_pSyntaxHighlighter = nullptr;
-	setTabStopWidth(48);
+	setTabStopDistance(48);
 	setAcceptRichText(false);
 	setWordWrapMode(QTextOption::NoWrap);
 	m_pParent = pParent;

--- a/src/modules/file/libkvifile.cpp
+++ b/src/modules/file/libkvifile.cpp
@@ -761,7 +761,7 @@ static bool file_kvs_fnc_ls(KviKvsModuleFunctionCall * c)
 		return true;
 	}
 
-	QFlags<QDir::Filter> iFlags = nullptr;
+	QFlags<QDir::Filter> iFlags;
 	if(szFlags.isEmpty())
 		iFlags = QDir::Dirs | QDir::Files | QDir::NoSymLinks | QDir::Readable | QDir::Writable | QDir::Executable | QDir::Hidden | QDir::System;
 	else
@@ -784,7 +784,7 @@ static bool file_kvs_fnc_ls(KviKvsModuleFunctionCall * c)
 			iFlags |= QDir::System;
 	}
 
-	QFlags<QDir::SortFlag> iSort = nullptr;
+	QFlags<QDir::SortFlag> iSort;
 	if(szFlags.isEmpty())
 		iSort = QDir::Unsorted;
 	else
@@ -1666,7 +1666,7 @@ static bool file_kvs_fnc_time(KviKvsModuleFunctionCall * c)
 	}
 	else if(szType.toLower() == "c")
 	{
-		time = f.created();
+		time = f.birthTime();
 	}
 	else if(szType.toLower() == "m")
 	{

--- a/src/modules/filetransferwindow/FileTransferWindow.cpp
+++ b/src/modules/filetransferwindow/FileTransferWindow.cpp
@@ -847,7 +847,7 @@ void FileTransferWindow::clearTerminated()
 
 void FileTransferWindow::getBaseLogFileName(QString & buffer)
 {
-	buffer.asprintf("FILETRANSFER");
+	buffer = QString::asprintf("FILETRANSFER");
 }
 
 QPixmap * FileTransferWindow::myIconPtr()

--- a/src/modules/help/HelpWindow.cpp
+++ b/src/modules/help/HelpWindow.cpp
@@ -187,7 +187,7 @@ void HelpWindow::startSearch()
 	QString buf = str;
 	str = str.replace("-", " ");
 	str = str.replace(QRegExp(R"(\s[\S]?\s)"), " ");
-	m_terms = str.split(" ", QString::SkipEmptyParts);
+	m_terms = str.split(" ", Qt::SkipEmptyParts);
 	QStringList termSeq;
 	QStringList seqWords;
 	QStringList::iterator it = m_terms.begin();
@@ -218,7 +218,7 @@ void HelpWindow::startSearch()
 					    __tr2qs("Using a wildcard within phrases is not allowed."));
 					return;
 				}
-				seqWords += s.split(' ', QString::SkipEmptyParts);
+				seqWords += s.split(' ', Qt::SkipEmptyParts);
 				termSeq << s;
 				beg = str.indexOf('\"', end + 1);
 			}

--- a/src/modules/http/HttpFileTransfer.cpp
+++ b/src/modules/http/HttpFileTransfer.cpp
@@ -147,8 +147,8 @@ void HttpFileTransfer::displayPaint(QPainter * p, int column, QRect rect)
 			QString szFrom = __tr2qs_ctx("From: ", "http");
 			QString szTo = __tr2qs_ctx("To: ", "http");
 
-			int daW1 = fm.width(szFrom);
-			int daW2 = fm.width(szTo);
+			int daW1 = fm.horizontalAdvance(szFrom);
+			int daW2 = fm.horizontalAdvance(szTo);
 			if(daW1 < daW2)
 				daW1 = daW2;
 			int iLineSpacing = fm.lineSpacing();

--- a/src/modules/links/LinksWindow.cpp
+++ b/src/modules/links/LinksWindow.cpp
@@ -107,7 +107,7 @@ LinksWindow::~LinksWindow()
 
 void LinksWindow::getBaseLogFileName(QString & buffer)
 {
-	buffer.sprintf("LINKS_%d", context()->id());
+	buffer.asprintf("LINKS_%d", context()->id());
 }
 
 void LinksWindow::requestLinks()

--- a/src/modules/links/LinksWindow.cpp
+++ b/src/modules/links/LinksWindow.cpp
@@ -107,7 +107,7 @@ LinksWindow::~LinksWindow()
 
 void LinksWindow::getBaseLogFileName(QString & buffer)
 {
-	buffer.asprintf("LINKS_%d", context()->id());
+	buffer = QString::asprintf("LINKS_%d", context()->id());
 }
 
 void LinksWindow::requestLinks()

--- a/src/modules/list/ListWindow.cpp
+++ b/src/modules/list/ListWindow.cpp
@@ -275,7 +275,7 @@ ListWindow::~ListWindow()
 
 void ListWindow::getBaseLogFileName(QString & szBuffer)
 {
-	szBuffer.asprintf("LIST_%d", context()->id());
+	szBuffer = QString::asprintf("LIST_%d", context()->id());
 }
 
 void ListWindow::requestList()

--- a/src/modules/list/ListWindow.cpp
+++ b/src/modules/list/ListWindow.cpp
@@ -120,18 +120,18 @@ QSize ChannelTreeWidgetItemDelegate::sizeHint(const QStyleOptionViewItem & sovIt
 	{
 		case 0:
 			//channel
-			return QSize(fm.width(item->itemData()->m_szChan), iHeight);
+			return QSize(fm.horizontalAdvance(item->itemData()->m_szChan), iHeight);
 			break;
 		case 1:
 			//users
-			return QSize(fm.width(item->itemData()->m_szUsers.toInt()), iHeight);
+			return QSize(fm.horizontalAdvance(item->itemData()->m_szUsers.toInt()), iHeight);
 			break;
 		case 2:
 		default:
 			//topic
 			if(item->itemData()->m_szStrippedTopic.isEmpty())
 				item->itemData()->m_szStrippedTopic = KviControlCodes::stripControlBytes(item->itemData()->m_szTopic);
-			return QSize(fm.width(item->itemData()->m_szStrippedTopic), iHeight);
+			return QSize(fm.horizontalAdvance(item->itemData()->m_szStrippedTopic), iHeight);
 			break;
 	}
 	//make gcc happy
@@ -275,7 +275,7 @@ ListWindow::~ListWindow()
 
 void ListWindow::getBaseLogFileName(QString & szBuffer)
 {
-	szBuffer.sprintf("LIST_%d", context()->id());
+	szBuffer.asprintf("LIST_%d", context()->id());
 }
 
 void ListWindow::requestList()
@@ -382,7 +382,7 @@ void ListWindow::exportList()
 				szDate = date.toString(Qt::ISODate);
 				break;
 			case 2:
-				szDate = date.toString(Qt::SystemLocaleShortDate);
+				szDate = QLocale().toString(date, QLocale::ShortFormat);
 				break;
 		}
 		szFile = QString(__tr2qs("Channel list for %1 - %2")).arg(connection()->currentNetworkName(), szDate);

--- a/src/modules/logview/LogFile.cpp
+++ b/src/modules/logview/LogFile.cpp
@@ -30,6 +30,7 @@
 #include "KviFileUtils.h"
 
 #include <QFileInfo>
+#include <QLocale>
 
 #ifdef COMPILE_ZLIB_SUPPORT
 #include <zlib.h>
@@ -91,14 +92,14 @@ LogFile::LogFile(const QString & szName)
 			m_date = QDate::fromString(szDate, Qt::ISODate);
 			break;
 		case 2:
-			m_date = QDate::fromString(szDate, Qt::SystemLocaleShortDate);
+			m_date = QLocale().toDate(szDate, QLocale::ShortFormat);
 			if(!m_date.isValid())
 			{
 				// some locale date formats use '/' as a separator; we change them to '-'
 				// when creating log files. Try to reverse that change here
 				QString szUnescapedDate = szDate;
 				szUnescapedDate.replace('-', KVI_PATH_SEPARATOR_CHAR);
-				m_date = QDate::fromString(szUnescapedDate, Qt::SystemLocaleShortDate);
+				m_date = QLocale().toDate(szUnescapedDate, QLocale::ShortFormat);
 				if(m_date.isValid())
 				{
 					//qt4 defaults to 1900 for years. So "11" means "1911" instead of "2011".. what a pity
@@ -122,14 +123,14 @@ LogFile::LogFile(const QString & szName)
 			m_date = QDate::fromString(szDate, Qt::ISODate);
 			if(!m_date.isValid())
 			{
-				m_date = QDate::fromString(szDate, Qt::SystemLocaleShortDate);
+				m_date = QLocale().toDate(szDate, QLocale::ShortFormat);
 				if(!m_date.isValid())
 				{
 					// some locale date formats use '/' as a separator; we change them to '-'
 					// when creating log files. Try to reverse that change here
 					QString szUnescapedDate = szDate;
 					szUnescapedDate.replace('-', KVI_PATH_SEPARATOR_CHAR);
-					m_date = QDate::fromString(szUnescapedDate, Qt::SystemLocaleShortDate);
+					m_date = QLocale().toDate(szUnescapedDate, QLocale::ShortFormat);
 					if(m_date.isValid())
 					{
 						//qt4 defaults to 1900 for years. So "11" means "1911" instead of "2011".. what a pity

--- a/src/modules/my/Idle_x11.cpp
+++ b/src/modules/my/Idle_x11.cpp
@@ -30,7 +30,6 @@ int IdlePlatform::secondsIdle() const { return 0; }
 #else
 // COMPILE_XSS_SUPPORT implies COMPILE_QX11INFO_SUPPORT
 #include <QApplication>
-#include <QDesktopWidget>
 #include <QX11Info>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>

--- a/src/modules/notifier/NotifierWindow.cpp
+++ b/src/modules/notifier/NotifierWindow.cpp
@@ -38,7 +38,6 @@
 #include "KviThemedLineEdit.h"
 
 #include <QApplication>
-#include <QDesktopWidget>
 #include <QEvent>
 #include <QFontMetrics>
 #include <QImage>
@@ -47,6 +46,7 @@
 #include <QPaintEvent>
 #include <QPen>
 #include <QRegExp>
+#include <QScreen>
 #include <QToolTip>
 
 extern NotifierWindow * g_pNotifierWindow;
@@ -75,8 +75,7 @@ NotifierWindow::NotifierWindow()
 	hide();
 
 	// Positioning the notifier bottom-right
-	QDesktopWidget * pDesktop = QApplication::desktop();
-	QRect r = pDesktop->availableGeometry(pDesktop->primaryScreen());
+	QRect r = g_pApp->primaryScreen()->availableGeometry();
 
 	m_wndRect.setRect(
 	    r.x() + r.width() - (WDG_MIN_WIDTH + SPACING),
@@ -227,10 +226,11 @@ void NotifierWindow::stopAutoHideTimer()
 
 #if COMPILE_KDE_SUPPORT
 #include <kwindowsystem.h>
+#include <kx11extras.h>
 
 static bool active_window_is_full_screen()
 {
-	WId activeId = KWindowSystem::activeWindow();
+	WId activeId = KX11Extras::activeWindow();
 	KWindowInfo wi = KWindowInfo(activeId, NET::WMState);
 	return (wi.valid() && wi.hasState(NET::FullScreen));
 }

--- a/src/modules/objects/KvsObject_painter.cpp
+++ b/src/modules/objects/KvsObject_painter.cpp
@@ -887,7 +887,7 @@ KVSO_CLASS_FUNCTION(painter, drawRoundRect)
 	KVSO_PARAMETERS_END(c)
 	QString function = "$drawRoundRect";
 	KVSO_PARAMETERS_PAINTER(pXOrArray, iY, iW, iH)
-	m_pPainter->drawRoundRect(iX, iY, iW, iH, iXrnd, iYrnd);
+	m_pPainter->drawRoundedRect(iX, iY, iW, iH, iXrnd, iYrnd);
 	return true;
 }
 
@@ -1140,7 +1140,7 @@ KVSO_CLASS_FUNCTION(painter, fontMetricsWidth)
 	KVSO_PARAMETER("text", KVS_PT_STRING, 0, szText)
 	KVSO_PARAMETERS_END(c)
 	if(m_pPainter->isActive())
-		c->returnValue()->setInteger(m_pPainter->fontMetrics().width(szText));
+		c->returnValue()->setInteger(m_pPainter->fontMetrics().horizontalAdvance(szText));
 	else
 		c->warning(__tr2qs_ctx("$fontMetricsWidth: the painter is not active!", "objects"));
 	return true;
@@ -1193,7 +1193,7 @@ KVSO_CLASS_FUNCTION(painter, begin)
 				QPrintDialog printDialog(m_pPrinter, nullptr);
 				if(printDialog.exec() == QDialog::Accepted)
 				{
-					qDebug("papersize %d", m_pPrinter->paperSize());
+					qDebug("papersize %d", m_pPrinter->pageLayout().pageSize().id());
 					m_pPainter->begin(m_pPrinter);
 					return true;
 				}

--- a/src/modules/objects/KvsObject_pixmap.cpp
+++ b/src/modules/objects/KvsObject_pixmap.cpp
@@ -668,7 +668,7 @@ KVSO_CLASS_FUNCTION(pixmap, grabWidget)
 	}
 	if(!m_pPixmap)
 		m_pPixmap = new QPixmap();
-	*m_pPixmap = QPixmap::grabWidget(((KvsObject_widget *)pObject)->widget());
+	*m_pPixmap = ((KvsObject_widget *)pObject)->widget()->grab();
 	return true;
 
 }

--- a/src/modules/objects/KvsObject_webView.cpp
+++ b/src/modules/objects/KvsObject_webView.cpp
@@ -1115,7 +1115,7 @@ KVSO_CLASS_FUNCTION(webView, hitTestContent)
 		return true;
 	KviKvsHash * pHash = new KviKvsHash();
 	pHash->set("imageurl", new KviKvsVariant(res.imageUrl().toString()));
-	pHash->set("linktitle", new KviKvsVariant(res.linkTitle().toString()));
+	pHash->set("linktitle", new KviKvsVariant(res.linkTitleString()));
 	pHash->set("linktext", new KviKvsVariant(res.linkText()));
 	pHash->set("linkelement", new KviKvsVariant((kvs_int_t)insertElement(res.linkElement())));
 	pHash->set("enclosingelement", new KviKvsVariant((kvs_int_t)insertElement(res.enclosingBlockElement())));

--- a/src/modules/objects/KvsObject_widget.cpp
+++ b/src/modules/objects/KvsObject_widget.cpp
@@ -38,7 +38,6 @@
 #include "KvsObject_painter.h"
 
 #include <QKeyEvent>
-#include <QDesktopWidget>
 #include <QWidget>
 #include <QToolTip>
 #include <QFont>
@@ -54,11 +53,8 @@
 #include <QPainter>
 #include <QApplication>
 #include <QPoint>
+#include <QScreen>
 #include <QContextMenuEvent>
-
-#ifdef COMPILE_KDE4_SUPPORT
-#include <KStatusBar>
-#endif
 
 KviKvsWidget::KviKvsWidget(KvsObject_widget * object, QWidget * par)
     : QWidget(par), m_pObject(object)
@@ -104,9 +100,9 @@ const char * const widgetattributes_tbl[] = {
 
 const QPalette::ColorRole colorrole_cod[] = {
 	QPalette::Window,
-	QPalette::Background,
+	QPalette::Window,
 	QPalette::WindowText,
-	QPalette::Foreground,
+	QPalette::WindowText,
 	QPalette::Base,
 	QPalette::AlternateBase,
 	QPalette::Text,
@@ -1088,7 +1084,7 @@ KVSO_CLASS_FUNCTION(widget, fontMetricsWidth)
 	KVSO_PARAMETERS_BEGIN(c)
 	KVSO_PARAMETER("string", KVS_PT_STRING, 0, m_szStr)
 	KVSO_PARAMETERS_END(c)
-	c->returnValue()->setInteger(widget()->fontMetrics().width(m_szStr));
+	c->returnValue()->setInteger(widget()->fontMetrics().horizontalAdvance(m_szStr));
 	return true;
 }
 
@@ -1110,7 +1106,7 @@ KVSO_CLASS_FUNCTION(widget, screenResolution)
 {
 	CHECK_INTERNAL_POINTER(widget())
 	KviKvsArray * a = new KviKvsArray();
-	QRect rect = g_pApp->desktop()->screenGeometry(g_pApp->desktop()->primaryScreen());
+	QRect rect = g_pApp->primaryScreen()->availableGeometry();
 	a->set(0, new KviKvsVariant((kvs_int_t)rect.width()));
 	a->set(1, new KviKvsVariant((kvs_int_t)rect.height()));
 	c->returnValue()->setArray(a);
@@ -1241,7 +1237,7 @@ KVSO_CLASS_FUNCTION(widget, mapFromGlobal)
 KVSO_CLASS_FUNCTION(widget, centerToScreen)
 {
 	CHECK_INTERNAL_POINTER(widget())
-	QRect rect = g_pApp->desktop()->screenGeometry(g_pApp->desktop()->primaryScreen());
+	QRect rect = g_pApp->primaryScreen()->availableGeometry();
 	widget()->move((rect.width() - widget()->width()) / 2, (rect.height() - widget()->height()) / 2);
 	return true;
 }
@@ -1825,10 +1821,10 @@ KVSO_CLASS_FUNCTION(widget, setWFlags)
 	KVSO_PARAMETERS_BEGIN(c)
 	KVSO_PARAMETER("widget_flags", KVS_PT_STRINGLIST, KVS_PF_OPTIONAL, wflags)
 	KVSO_PARAMETERS_END(c)
-	Qt::WindowFlags flag, sum = nullptr;
+	Qt::WindowFlags flag, sum;
 	for(auto & it : wflags)
 	{
-		flag = nullptr;
+		flag = Qt::WindowFlags();
 		for(size_t j{}; j < widgettypes_num; j++)
 		{
 			if(KviQString::equalCI(it, widgettypes_tbl[j]))
@@ -2155,7 +2151,7 @@ KVSO_CLASS_FUNCTION(widget, grab)
 
 	QPixmap * pPixmap = new QPixmap();
 	qDebug("grabbing");
-	*pPixmap = QPixmap::grabWidget(((QWidget *)(ob->object())));
+	*pPixmap = ((QWidget *)(ob->object()))->grab();
 	KviKvsObjectClass * pClass = KviKvsKernel::instance()->objectController()->lookupClass("pixmap");
 	KviKvsVariantList params;
 	KviKvsObject * pObject = pClass->allocateInstance(nullptr, "internalpixmap", c->context(), &params);

--- a/src/modules/objects/qthttp/qhttpauthenticator.cpp
+++ b/src/modules/objects/qthttp/qhttpauthenticator.cpp
@@ -50,6 +50,7 @@
 #include <qendian.h>
 #include <qstring.h>
 #include <qdatetime.h>
+#include <QRandomGenerator>
 
 //#define NTLMV1_CLIENT
 
@@ -284,7 +285,7 @@ void QHttpAuthenticator::detach()
 	if(!d)
 	{
 		d = new QHttpAuthenticatorPrivate;
-		d->ref.store(1);
+		d->ref.storeRelaxed(1);
 		return;
 	}
 
@@ -351,7 +352,7 @@ bool QHttpAuthenticator::isNull() const
 QHttpAuthenticatorPrivate::QHttpAuthenticatorPrivate()
     : ref(0), method(None), hasFailed(false), phase(Start), nonceCount(0)
 {
-	cnonce = QCryptographicHash::hash(QByteArray::number(qrand(), 16) + QByteArray::number(qrand(), 16),
+	cnonce = QCryptographicHash::hash(QByteArray::number(QRandomGenerator::global()->generate(), 16) + QByteArray::number(QRandomGenerator::global()->generate(), 16),
 	             QCryptographicHash::Md5)
 	             .toHex();
 	nonceCount = 0;

--- a/src/modules/options/OptionsDialog.cpp
+++ b/src/modules/options/OptionsDialog.cpp
@@ -45,8 +45,8 @@
 #include <QEvent>
 #include <QCloseEvent>
 #include <QShortcut>
+#include <QScreen>
 #include <QHeaderView>
-#include <QDesktopWidget>
 #include <QStackedWidget>
 #include <QMenu>
 
@@ -289,7 +289,7 @@ OptionsDialog::~OptionsDialog()
 void OptionsDialog::showEvent(QShowEvent * e)
 {
 	// setup a minimum size and move to the screen the main kvirc window is
-	QRect r = g_pApp->desktop()->screenGeometry(g_pMainWindow);
+	QRect r = g_pMainWindow->screen()->availableGeometry();
 
 	int w = r.width();
 	int h = r.height();
@@ -466,7 +466,7 @@ void OptionsDialog::search(const QStringList & lKeywords)
 
 void OptionsDialog::search(const QString & szKeywords)
 {
-	QStringList lKeywords = szKeywords.split(" ", QString::SkipEmptyParts);
+	QStringList lKeywords = szKeywords.split(" ", Qt::SkipEmptyParts);
 	search(lKeywords);
 }
 

--- a/src/modules/options/OptionsWidgetContainer.cpp
+++ b/src/modules/options/OptionsWidgetContainer.cpp
@@ -33,11 +33,11 @@
 
 #include <QLayout>
 #include <QPushButton>
-#include <QDesktopWidget>
 #include <QEvent>
 #include <QGridLayout>
 #include <QCloseEvent>
 #include <QIcon>
+#include <QScreen>
 
 extern OptionsInstanceManager * g_pOptionsInstanceManager;
 
@@ -142,7 +142,7 @@ void OptionsWidgetContainer::showEvent(QShowEvent * e)
 {
 	if(!parent())
 	{
-		QRect rect = g_pApp->desktop()->screenGeometry(g_pMainWindow);
+		QRect rect = g_pMainWindow->screen()->availableGeometry();
 		move(rect.x() + ((rect.width() - width()) / 2), rect.y() + ((rect.height() - height()) / 2));
 	}
 

--- a/src/modules/options/OptionsWidget_message.cpp
+++ b/src/modules/options/OptionsWidget_message.cpp
@@ -657,29 +657,29 @@ void OptionsWidget_messageColors::load()
 		{
 			MessageListWidgetItem * it = (MessageListWidgetItem *)m_pListView->item(i);
 
-			tmp.sprintf("Fore%d", it->optionId());
+			tmp.asprintf("Fore%d", it->optionId());
 			int fore = cfg.readIntEntry(tmp, it->msgType()->fore());
 			if(fore < 0 || fore > 15)
 				fore = 0;
 			it->msgType()->setFore(fore);
 
-			tmp.sprintf("Back%d", it->optionId());
+			tmp.asprintf("Back%d", it->optionId());
 			int back = cfg.readIntEntry(tmp, it->msgType()->back());
 			if(back < 0 || back > 15)
 				back = KviControlCodes::Transparent;
 			it->msgType()->setBack(back);
 
-			tmp.sprintf("Icon%d", it->optionId());
+			tmp.asprintf("Icon%d", it->optionId());
 			int ico = cfg.readIntEntry(tmp, it->msgType()->pixId());
 			if(ico < 0 || ico >= KviIconManager::IconCount)
 				ico = 0;
 			it->msgType()->setPixId(ico);
 
-			tmp.sprintf("Log%d", it->optionId());
+			tmp.asprintf("Log%d", it->optionId());
 			bool bLog = cfg.readBoolEntry(tmp, it->msgType()->logEnabled());
 			it->msgType()->enableLogging(bLog);
 
-			tmp.sprintf("Level%d", it->optionId());
+			tmp.asprintf("Level%d", it->optionId());
 			int iLevel = cfg.readIntEntry(tmp, it->msgType()->level());
 			it->msgType()->setLevel(iLevel);
 

--- a/src/modules/options/OptionsWidget_message.cpp
+++ b/src/modules/options/OptionsWidget_message.cpp
@@ -657,29 +657,29 @@ void OptionsWidget_messageColors::load()
 		{
 			MessageListWidgetItem * it = (MessageListWidgetItem *)m_pListView->item(i);
 
-			tmp.asprintf("Fore%d", it->optionId());
+			tmp = QString::asprintf("Fore%d", it->optionId());
 			int fore = cfg.readIntEntry(tmp, it->msgType()->fore());
 			if(fore < 0 || fore > 15)
 				fore = 0;
 			it->msgType()->setFore(fore);
 
-			tmp.asprintf("Back%d", it->optionId());
+			tmp = QString::asprintf("Back%d", it->optionId());
 			int back = cfg.readIntEntry(tmp, it->msgType()->back());
 			if(back < 0 || back > 15)
 				back = KviControlCodes::Transparent;
 			it->msgType()->setBack(back);
 
-			tmp.asprintf("Icon%d", it->optionId());
+			tmp = QString::asprintf("Icon%d", it->optionId());
 			int ico = cfg.readIntEntry(tmp, it->msgType()->pixId());
 			if(ico < 0 || ico >= KviIconManager::IconCount)
 				ico = 0;
 			it->msgType()->setPixId(ico);
 
-			tmp.asprintf("Log%d", it->optionId());
+			tmp = QString::asprintf("Log%d", it->optionId());
 			bool bLog = cfg.readBoolEntry(tmp, it->msgType()->logEnabled());
 			it->msgType()->enableLogging(bLog);
 
-			tmp.asprintf("Level%d", it->optionId());
+			tmp = QString::asprintf("Level%d", it->optionId());
 			int iLevel = cfg.readIntEntry(tmp, it->msgType()->level());
 			it->msgType()->setLevel(iLevel);
 

--- a/src/modules/raweditor/RawEditorWindow.cpp
+++ b/src/modules/raweditor/RawEditorWindow.cpp
@@ -54,7 +54,7 @@ RawTreeWidgetItem::RawTreeWidgetItem(QTreeWidget * par, int idx, bool bEnabled)
 {
 	m_iIdx = idx;
 	QString szName;
-	szName.sprintf("%03d", idx);
+	szName.asprintf("%03d", idx);
 	setText(0, szName);
 	setEnabled(bEnabled);
 }

--- a/src/modules/raweditor/RawEditorWindow.cpp
+++ b/src/modules/raweditor/RawEditorWindow.cpp
@@ -54,7 +54,7 @@ RawTreeWidgetItem::RawTreeWidgetItem(QTreeWidget * par, int idx, bool bEnabled)
 {
 	m_iIdx = idx;
 	QString szName;
-	szName.asprintf("%03d", idx);
+	szName = QString::asprintf("%03d", idx);
 	setText(0, szName);
 	setEnabled(bEnabled);
 }

--- a/src/modules/reguser/RegisteredUsersDialog.cpp
+++ b/src/modules/reguser/RegisteredUsersDialog.cpp
@@ -53,7 +53,6 @@
 #include <QImageReader>
 #include <QImage>
 #include <QString>
-#include <QDesktopWidget>
 #include <QComboBox>
 #include <QToolTip>
 #include <QStyle>
@@ -64,6 +63,7 @@
 #include <QAbstractItemView>
 #include <QAbstractTextDocumentLayout>
 #include <QShortcut>
+#include <QScreen>
 
 #include <memory>
 
@@ -331,7 +331,7 @@ RegisteredUsersDialog::RegisteredUsersDialog(QWidget * par)
 		resize(KVI_OPTION_RECT(KviOption_rectRegisteredUsersDialogGeometry).width(),
 		    KVI_OPTION_RECT(KviOption_rectRegisteredUsersDialogGeometry).height());
 
-		QRect rect = g_pApp->desktop()->screenGeometry(g_pMainWindow);
+		QRect rect = g_pMainWindow->screen()->availableGeometry();
 		move(rect.x() + ((rect.width() - KVI_OPTION_RECT(KviOption_rectRegisteredUsersDialogGeometry).width()) / 2), rect.y() + ((rect.height() - KVI_OPTION_RECT(KviOption_rectRegisteredUsersDialogGeometry).height()) / 2));
 	}
 }

--- a/src/modules/reguser/RegistrationWizard.cpp
+++ b/src/modules/reguser/RegistrationWizard.cpp
@@ -33,7 +33,6 @@
 #include "KviRegisteredUserDataBase.h"
 #include "KviIconManager.h"
 
-#include <QDesktopWidget>
 #include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
@@ -41,6 +40,7 @@
 #include <QLayout>
 #include <QVariant>
 #include <QFrame>
+#include <QScreen>
 
 extern KVIRC_API KviRegisteredUserDataBase * g_pRegisteredUserDataBase;
 extern KviPointerList<RegistrationWizard> * g_pRegistrationWizardList;
@@ -404,7 +404,7 @@ void RegistrationWizard::showEvent(QShowEvent * e)
 	if(height() < 420)
 		resize(width(), 420);
 
-	QRect rect = g_pApp->desktop()->screenGeometry(g_pApp->desktop()->primaryScreen());
+	QRect rect = g_pApp->primaryScreen()->availableGeometry();
 	move((rect.width() - width()) / 2, (rect.height() - height()) / 2);
 	KviTalWizard::showEvent(e);
 }

--- a/src/modules/setup/SetupWizard.cpp
+++ b/src/modules/setup/SetupWizard.cpp
@@ -45,7 +45,7 @@ bool g_bFoundMirc;
 #include <QValidator>
 #include <QTextCodec>
 #include <QLayout>
-#include <QDesktopWidget>
+#include <QScreen>
 
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
 #include <winnls.h>  // for MultiByteToWideChar
@@ -608,8 +608,7 @@ SetupWizard::~SetupWizard()
 
 void SetupWizard::showEvent(QShowEvent * e)
 {
-	int primary_screen = g_pApp->desktop()->primaryScreen();
-	QRect r = g_pApp->desktop()->screenGeometry(primary_screen);
+	QRect r = g_pApp->primaryScreen()->availableGeometry();
 
 	int w = r.width();
 	int h = r.height();

--- a/src/modules/sharedfileswindow/SharedFilesWindow.cpp
+++ b/src/modules/sharedfileswindow/SharedFilesWindow.cpp
@@ -337,7 +337,7 @@ void SharedFilesWindow::sharedFileRemoved(KviSharedFile * f)
 
 void SharedFilesWindow::getBaseLogFileName(QString & buffer)
 {
-	buffer.sprintf("SHAREDFILES");
+	buffer.asprintf("SHAREDFILES");
 }
 
 QPixmap * SharedFilesWindow::myIconPtr()

--- a/src/modules/sharedfileswindow/SharedFilesWindow.cpp
+++ b/src/modules/sharedfileswindow/SharedFilesWindow.cpp
@@ -337,7 +337,7 @@ void SharedFilesWindow::sharedFileRemoved(KviSharedFile * f)
 
 void SharedFilesWindow::getBaseLogFileName(QString & buffer)
 {
-	buffer.asprintf("SHAREDFILES");
+	buffer = QString::asprintf("SHAREDFILES");
 }
 
 QPixmap * SharedFilesWindow::myIconPtr()

--- a/src/modules/socketspy/SocketSpyWindow.cpp
+++ b/src/modules/socketspy/SocketSpyWindow.cpp
@@ -74,7 +74,7 @@ QSize SocketSpyWindow::sizeHint() const
 
 void SocketSpyWindow::getBaseLogFileName(QString & buffer)
 {
-	buffer.asprintf("SOCKETSPY_%d", context()->id());
+	buffer = QString::asprintf("SOCKETSPY_%d", context()->id());
 }
 
 void SocketSpyWindow::fillCaptionBuffers()

--- a/src/modules/socketspy/SocketSpyWindow.cpp
+++ b/src/modules/socketspy/SocketSpyWindow.cpp
@@ -74,7 +74,7 @@ QSize SocketSpyWindow::sizeHint() const
 
 void SocketSpyWindow::getBaseLogFileName(QString & buffer)
 {
-	buffer.sprintf("SOCKETSPY_%d", context()->id());
+	buffer.asprintf("SOCKETSPY_%d", context()->id());
 }
 
 void SocketSpyWindow::fillCaptionBuffers()

--- a/src/modules/spaste/SlowPasteController.cpp
+++ b/src/modules/spaste/SlowPasteController.cpp
@@ -88,11 +88,11 @@ bool SlowPasteController::pasteClipboardInit()
 	QString tmp(g_pApp->clipboard()->text());
 	if(m_pClipBuff)
 	{
-		(*m_pClipBuff) += tmp.isEmpty() ? QStringList() : tmp.split("\n", QString::KeepEmptyParts);
+		(*m_pClipBuff) += tmp.isEmpty() ? QStringList() : tmp.split("\n", Qt::KeepEmptyParts);
 	}
 	else
 	{
-		m_pClipBuff = new QStringList(tmp.isEmpty() ? QStringList() : tmp.split("\n", QString::KeepEmptyParts));
+		m_pClipBuff = new QStringList(tmp.isEmpty() ? QStringList() : tmp.split("\n", Qt::KeepEmptyParts));
 	}
 	//avoid double connection
 	disconnect(m_pTimer, SIGNAL(timeout()), nullptr, nullptr);

--- a/src/modules/system/libkvisystem.cpp
+++ b/src/modules/system/libkvisystem.cpp
@@ -50,9 +50,7 @@
 #endif
 
 #ifdef COMPILE_KDE_SUPPORT
-// invokeTerminal() for system.runcmd
-// tools we need to work around the absence of
-#include <KToolInvocation>
+#include <KTerminalLauncherJob>
 #endif
 // invokeTerminal()
 #include <QProcess>
@@ -759,10 +757,10 @@ static bool system_kvs_cmd_runcmd(KviKvsModuleCommandCall * c)
 	}
 
 #ifdef COMPILE_KDE_SUPPORT // We have invokeTerminal().
-
-	KToolInvocation::invokeTerminal(szCommand.toLocal8Bit());
-
-#else                                                        // No invokeTerminal() for us, we'll use a
+	auto job = new KTerminalLauncherJob(szCommand);
+	job->start();
+#else
+	// No invokeTerminal() for us, we'll use a
 	// combination of QStringList and QProcess.
 	QStringList szTerminals;
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW) // Only »cmd.exe /k« in the list.

--- a/src/modules/term/TermWidget.h
+++ b/src/modules/term/TermWidget.h
@@ -26,13 +26,13 @@
 
 #include "kvi_settings.h"
 
-#ifdef COMPILE_KDE4_SUPPORT
+#ifdef COMPILE_KDE_SUPPORT
 #include <QFrame>
 #include <QLabel>
 #include <QPushButton>
 #include "KviTalHBox.h"
 
-#include "kparts/part.h"
+#include <KParts/Part>
 
 class KviMainWindow;
 

--- a/src/modules/term/TermWindow.cpp
+++ b/src/modules/term/TermWindow.cpp
@@ -25,7 +25,7 @@
 #include "TermWindow.h"
 #include "TermWidget.h"
 
-#ifdef COMPILE_KDE4_SUPPORT
+#ifdef COMPILE_KDE_SUPPORT
 #include "KviIconManager.h"
 #include "KviOptions.h"
 #include "KviLocale.h"

--- a/src/modules/term/TermWindow.h
+++ b/src/modules/term/TermWindow.h
@@ -26,7 +26,7 @@
 
 #include "kvi_settings.h"
 
-#ifdef COMPILE_KDE4_SUPPORT
+#ifdef COMPILE_KDE_SUPPORT
 #include "KviWindow.h"
 #include "KviCString.h"
 

--- a/src/modules/term/libkviterm.cpp
+++ b/src/modules/term/libkviterm.cpp
@@ -29,7 +29,7 @@
 
 #include <QSplitter>
 
-#ifdef COMPILE_KDE4_SUPPORT
+#ifdef COMPILE_KDE_SUPPORT
 #include "TermWidget.h"
 #include "TermWindow.h"
 
@@ -66,7 +66,7 @@ KviModule * g_pTermModule = nullptr;
 
 static bool term_kvs_cmd_open(KviKvsModuleCommandCall * c)
 {
-#ifdef COMPILE_KDE4_SUPPORT
+#ifdef COMPILE_KDE_SUPPORT
 	c->module()->lock(); // multiple locks are allowed
 	if(
 	    c->hasSwitch('m', "mdi") || // compat only
@@ -81,7 +81,7 @@ static bool term_kvs_cmd_open(KviKvsModuleCommandCall * c)
 		w->show();
 	}
 #else
-	c->warning("Terminal emulation service not supported (non-KDE4 compilation)");
+	c->warning("Terminal emulation service not supported (non-KDE compilation)");
 #endif
 	return true;
 }
@@ -96,9 +96,9 @@ static bool term_module_init(KviModule * m)
 
 static bool term_module_cleanup(KviModule *)
 {
-#ifdef COMPILE_KDE4_SUPPORT
+#ifdef COMPILE_KDE_SUPPORT
 	while(!g_pTermWidgetList.empty())
-		delete *g_pSocketSpyWindowList.begin();
+		delete *g_pTermWidgetList.begin();
 
 	while(!g_pTermWindowList.empty())
 		(*g_pTermWindowList.begin())->close();

--- a/src/modules/theme/ThemeFunctions.cpp
+++ b/src/modules/theme/ThemeFunctions.cpp
@@ -115,7 +115,7 @@ namespace ThemeFunctions
 		// load its picture
 		pByteArray = r.binaryInfoFields()->find("Image");
 		if(pByteArray)
-			pix.loadFromData(*pByteArray, nullptr, nullptr);
+			pix.loadFromData(*pByteArray);
 
 		if(pix.isNull())
 		{
@@ -182,7 +182,7 @@ namespace ThemeFunctions
 			QPixmap pixScreenshot;
 			pByteArray = r.binaryInfoFields()->find(szTmp);
 			if(pByteArray)
-				pixScreenshot.loadFromData(*pByteArray, nullptr, nullptr);
+				pixScreenshot.loadFromData(*pByteArray);
 
 			if(szThemeName.isEmpty() || szThemeVersion.isEmpty() || szThemeSubdirectory.isEmpty() || szThemeEngineVersion.isEmpty())
 				bValid = false;

--- a/src/modules/theme/ThemeManagementDialog.cpp
+++ b/src/modules/theme/ThemeManagementDialog.cpp
@@ -54,7 +54,6 @@
 #include <QRegExp>
 #include <QMessageBox>
 #include <QDir>
-#include <QDesktopWidget>
 #include <QStringList>
 #include <QDateTime>
 #include <QFileDialog>
@@ -68,6 +67,7 @@
 #include <QAbstractTextDocumentLayout>
 #include <QShortcut>
 #include <QMenu>
+#include <QScreen>
 
 extern QRect g_rectManagementDialogGeometry;
 
@@ -230,7 +230,7 @@ ThemeManagementDialog::ThemeManagementDialog(QWidget * parent)
 	resize(g_rectManagementDialogGeometry.width(),
 	    g_rectManagementDialogGeometry.height());
 
-	QRect rect = g_pApp->desktop()->screenGeometry(g_pMainWindow);
+	QRect rect = g_pMainWindow->screen()->availableGeometry();
 	move(rect.x() + ((rect.width() - g_rectManagementDialogGeometry.width()) / 2), rect.y() + ((rect.height() - g_rectManagementDialogGeometry.height()) / 2));
 
 	new QShortcut(Qt::Key_Escape, this, SLOT(closeClicked()));

--- a/src/modules/tip/libkvitip.cpp
+++ b/src/modules/tip/libkvitip.cpp
@@ -34,8 +34,8 @@
 #include <QPushButton>
 #include <QFont>
 #include <QPainter>
-#include <QDesktopWidget>
 #include <QCloseEvent>
+#include <QScreen>
 
 TipWindow * g_pTipWindow = nullptr;
 
@@ -115,7 +115,7 @@ TipWindow::~TipWindow()
 
 void TipWindow::showEvent(QShowEvent *)
 {
-	QRect rect = g_pApp->desktop()->screenGeometry(g_pApp->desktop()->primaryScreen());
+	QRect rect = g_pApp->primaryScreen()->availableGeometry();
 	move((rect.width() - width()) / 2, (rect.height() - height()) / 2);
 }
 

--- a/src/modules/toolbareditor/CustomizeToolBarsDialog.cpp
+++ b/src/modules/toolbareditor/CustomizeToolBarsDialog.cpp
@@ -53,8 +53,8 @@
 #include <QEvent>
 #include <QSplitter>
 #include <QDropEvent>
-#include <QDesktopWidget>
 #include <QMimeData>
+#include <QScreen>
 
 CustomizeToolBarsDialog * CustomizeToolBarsDialog::m_pInstance = nullptr;
 extern QRect g_rectToolBarEditorDialogGeometry;
@@ -376,7 +376,7 @@ void CustomizeToolBarsDialog::currentToolBarChanged()
 
 void CustomizeToolBarsDialog::showEvent(QShowEvent * e)
 {
-	QRect rect = g_pApp->desktop()->screenGeometry(g_pMainWindow);
+	QRect rect = g_pMainWindow->screen()->availableGeometry();
 	move(rect.x() + ((rect.width() - width()) / 2), rect.y() + ((rect.height() - height()) / 2));
 
 	QWidget::showEvent(e);

--- a/src/modules/upnp/Manager.cpp
+++ b/src/modules/upnp/Manager.cpp
@@ -62,7 +62,7 @@ namespace UPnP
 	// Initialize the manager, detect all devices
 	void Manager::initialize()
 	{
-		qDebug() << "UPnP::Manager: initiating a broadcast to detect UPnP devices..." << endl;
+		qDebug() << "UPnP::Manager: initiating a broadcast to detect UPnP devices..." << Qt::endl;
 
 		// Create the SSDP object to detect devices
 		m_pSsdpConnection = new SsdpConnection();
@@ -126,7 +126,7 @@ namespace UPnP
 	{
 		if(!m_bBroadcastFoundIt)
 		{
-			qDebug() << "UPnP::Manager: timeout, no broadcast response received!" << endl;
+			qDebug() << "UPnP::Manager: timeout, no broadcast response received!" << Qt::endl;
 
 			m_bBroadcastFailed = true;
 		}
@@ -135,7 +135,7 @@ namespace UPnP
 	// A device was discovered by the SSDP broadcast
 	void Manager::slotDeviceFound(const QString & hostname, int port, const QString & rootUrl)
 	{
-		qDebug() << "UPnP::Manager: device found, initializing IgdControlPoint to query it." << endl;
+		qDebug() << "UPnP::Manager: device found, initializing IgdControlPoint to query it." << Qt::endl;
 
 		// this blocks the action of our timeout timer
 		m_bBroadcastFoundIt = true;

--- a/src/modules/upnp/RootService.cpp
+++ b/src/modules/upnp/RootService.cpp
@@ -55,7 +55,7 @@ namespace UPnP
 	// Recursively add all devices and embedded devices to the deviceServices_ map
 	void RootService::addDeviceServices(const QDomNode & device)
 	{
-		qDebug() << "UPnP discovered device " << XmlFunctions::getNodeValue(device, "/UDN") << endl;
+		qDebug() << "UPnP discovered device " << XmlFunctions::getNodeValue(device, "/UDN") << Qt::endl;
 
 		if(XmlFunctions::getNodeValue(device, "/deviceType") == InternetGatewayDeviceType)
 		{
@@ -68,7 +68,7 @@ namespace UPnP
 			if(description.isNull())
 				description = __tr2qs("Unknown");
 
-			qDebug() << "Model: " << description << endl;
+			qDebug() << "Model: " << description << Qt::endl;
 
 			g_pApp->activeConsole()->output(KVI_OUT_GENERICSTATUS, __tr2qs_ctx("[UPNP]: found gateway device: %s", "upnp"), description.toUtf8().data());
 		}
@@ -174,7 +174,7 @@ namespace UPnP
 		else
 		{
 			qWarning() << "UPnP::RootService::getServiceByType -"
-			           << " type '" << serviceType << "' not found for device '" << deviceUdn << "'." << endl;
+			           << " type '" << serviceType << "' not found for device '" << deviceUdn << "'." << Qt::endl;
 
 			return false;
 		}

--- a/src/modules/upnp/Service.cpp
+++ b/src/modules/upnp/Service.cpp
@@ -57,20 +57,20 @@ namespace UPnP
 	    , m_iPort(port)
 	{
 		m_szInformationUrl = informationUrl;
-		qDebug() << "UPnP::Service: created information service url='" << m_szInformationUrl << "'." << endl;
+		qDebug() << "UPnP::Service: created information service url='" << m_szInformationUrl << "'." << Qt::endl;
 	}
 
 	// The constructor for action services
 	Service::Service(const ServiceParameters & params)
 	    : m_szControlUrl(params.controlUrl), m_szInformationUrl(params.scpdUrl), m_iPendingRequests(0), m_szServiceId(params.serviceId), m_szServiceType(params.serviceType), m_szBaseXmlPrefix("s"), m_szHostname(params.hostname), m_iPort(params.port)
 	{
-		qDebug() << "CREATED UPnP::Service: url='" << m_szControlUrl << "' id='" << m_szServiceId << "'." << endl;
+		qDebug() << "CREATED UPnP::Service: url='" << m_szControlUrl << "' id='" << m_szServiceId << "'." << Qt::endl;
 	}
 
 	// The destructor
 	Service::~Service()
 	{
-		qDebug() << "DESTROYED UPnP::Service [url=" << m_szControlUrl << ",  id=" << m_szServiceId << "]" << endl;
+		qDebug() << "DESTROYED UPnP::Service [url=" << m_szControlUrl << ",  id=" << m_szServiceId << "]" << Qt::endl;
 	}
 
 	// Makes a UPnP action request
@@ -89,7 +89,7 @@ namespace UPnP
 	// Makes a UPnP action request (keeps pointers from the external interface)
 	int Service::callActionInternal(const QString & actionName, const QMap<QString, QString> * arguments, const QString & prefix)
 	{
-		qDebug() << "UPnP::Service: calling remote procedure '" << actionName << "'." << endl;
+		qDebug() << "UPnP::Service: calling remote procedure '" << actionName << "'." << Qt::endl;
 
 		// Create the data message
 		//NOTE: we shouldm use serviceId_ instead of serviceType_, but it seems that my router
@@ -162,7 +162,7 @@ namespace UPnP
 	// TODO: rename to downloadFile()
 	int Service::callInformationUrl()
 	{
-		qDebug() << "UPnP::Service: requesting file '" << m_szInformationUrl << "'." << endl;
+		qDebug() << "UPnP::Service: requesting file '" << m_szInformationUrl << "'." << Qt::endl;
 
 		// Send the GET request
 		// TODO: User-Agent: Mozilla/4.0 (compatible; UPnP/1.0; Windows NT/5.1)
@@ -193,20 +193,20 @@ namespace UPnP
 		QString faultString = XmlFunctions::getNodeValue(response, "/faultstring");
 		QString errorCode = XmlFunctions::getNodeValue(response, "/detail/" + faultString + "/errorCode");
 		QString errorDescription = XmlFunctions::getNodeValue(response, "/detail/" + faultString + "/errorDescription");
-		qWarning() << "UPnP::Service - Action failed: " << errorCode << " " << errorDescription << endl;
+		qWarning() << "UPnP::Service - Action failed: " << errorCode << " " << errorDescription << Qt::endl;
 	}
 
 	// The control point received a response to callAction()
 	void Service::gotActionResponse(const QString & responseType, const QMap<QString, QString> & /*resultValues*/)
 	{
-		qWarning() << "UPnP::Service - Action response '" << responseType << "' is not handled." << endl;
+		qWarning() << "UPnP::Service - Action response '" << responseType << "' is not handled." << Qt::endl;
 	}
 
 	// The control point received a response to callInformationUrl()
 	void Service::gotInformationResponse(const QDomNode & response)
 	{
 		QString rootTagName = response.nodeName();
-		qWarning() << "UPnP::Service - Service response (with root '" << rootTagName << "') is not handled." << endl;
+		qWarning() << "UPnP::Service - Service response (with root '" << rootTagName << "') is not handled." << Qt::endl;
 	}
 
 	// The QHttp object retrieved data.
@@ -214,11 +214,11 @@ namespace UPnP
 	{
 		QNetworkReply * reply = qobject_cast<QNetworkReply *>(sender());
 
-		qDebug() << "UPnP::Service: received HTTP response for request " << endl;
+		qDebug() << "UPnP::Service: received HTTP response for request " << Qt::endl;
 
 		if(!reply)
 		{
-			qWarning() << "UPnP::Service - HTTP Request failed: " << reply->errorString() << endl;
+			qWarning() << "UPnP::Service - HTTP Request failed: " << reply->errorString() << Qt::endl;
 			m_iPendingRequests--;
 			emit queryFinished(true);
 			return;
@@ -226,7 +226,7 @@ namespace UPnP
 
 		if(reply->error() != QNetworkReply::NoError)
 		{
-			qWarning() << "UPnP::Service - HTTP Request failed: " << reply->errorString() << endl;
+			qWarning() << "UPnP::Service - HTTP Request failed: " << reply->errorString() << Qt::endl;
 			m_iPendingRequests--;
 			emit queryFinished(true);
 			reply->deleteLater();
@@ -254,7 +254,7 @@ namespace UPnP
 				if(cutAt > -1)
 				{
 					baseNamespace.truncate(cutAt);
-					qDebug() << "Device is using " << baseNamespace << " as XML namespace" << endl;
+					qDebug() << "Device is using " << baseNamespace << " as XML namespace" << Qt::endl;
 					m_szBaseXmlPrefix = baseNamespace;
 				}
 			}
@@ -262,13 +262,13 @@ namespace UPnP
 			// Determine how to process the data
 			if(xml.namedItem(m_szBaseXmlPrefix + ":Envelope").isNull())
 			{
-				qDebug() << "UPnP::Service: plain XML detected, calling gotInformationResponse()." << endl;
+				qDebug() << "UPnP::Service: plain XML detected, calling gotInformationResponse()." << Qt::endl;
 				// No SOAP envelope found, this is a normal response to callService()
 				gotInformationResponse(xml.lastChild());
 			}
 			else
 			{
-				qDebug() << xml.toString() << endl;
+				qDebug() << xml.toString() << Qt::endl;
 				// Got a SOAP message response to callAction()
 				QDomNode resultNode = XmlFunctions::getNode(xml, "/" + m_szBaseXmlPrefix + ":Envelope/" + m_szBaseXmlPrefix + ":Body").firstChild();
 
@@ -278,7 +278,7 @@ namespace UPnP
 				{
 					if(resultNode.nodeName().startsWith("m:") || resultNode.nodeName().startsWith("u:"))
 					{
-						qDebug() << "UPnP::Service: SOAP envelope detected, calling gotActionResponse()." << endl;
+						qDebug() << "UPnP::Service: SOAP envelope detected, calling gotActionResponse()." << Qt::endl;
 						// Action success, return SOAP body
 						QMap<QString, QString> resultValues;
 
@@ -298,7 +298,7 @@ namespace UPnP
 				}
 				else
 				{
-					qDebug() << "UPnP::Service: SOAP error detected, calling gotActionResponse()." << endl;
+					qDebug() << "UPnP::Service: SOAP error detected, calling gotActionResponse()." << Qt::endl;
 
 					// Action failed
 					gotActionErrorResponse(resultNode);
@@ -307,7 +307,7 @@ namespace UPnP
 		}
 		else
 		{
-			qWarning() << "UPnP::Service - XML parsing failed: " << errorMessage << endl;
+			qWarning() << "UPnP::Service - XML parsing failed: " << errorMessage << Qt::endl;
 		}
 
 		// Only emit when bytes>0

--- a/src/modules/upnp/SsdpConnection.cpp
+++ b/src/modules/upnp/SsdpConnection.cpp
@@ -62,7 +62,7 @@ namespace UPnP
 	// Data was received by the socket
 	void SsdpConnection::slotDataReceived()
 	{
-		qDebug() << "UPnP::SsdpConnection: received " << m_pSocket->bytesAvailable() << " bytes." << endl;
+		qDebug() << "UPnP::SsdpConnection: received " << m_pSocket->bytesAvailable() << " bytes." << Qt::endl;
 
 		// Response from Diederik's Acatel router:
 		//
@@ -114,7 +114,7 @@ namespace UPnP
 	// Send a broadcast to detect all devices
 	void SsdpConnection::queryDevices(int bindPort)
 	{
-		qDebug() << "UPnP::SsdpConnection: sending broadcast packet." << endl;
+		qDebug() << "UPnP::SsdpConnection: sending broadcast packet." << Qt::endl;
 
 		// Send a packet to a broadcast address
 		QHostAddress address("239.255.255.250");
@@ -130,7 +130,7 @@ namespace UPnP
 		bool success = m_pSocket->bind(bindPort);
 		if(!success)
 		{
-			qDebug() << "UPnP::SsdpConnection: failed to bind to port " << bindPort << "." << endl;
+			qDebug() << "UPnP::SsdpConnection: failed to bind to port " << bindPort << "." << Qt::endl;
 		}
 
 		// Send the data
@@ -139,7 +139,7 @@ namespace UPnP
 
 		if(bytesWritten == -1)
 		{
-			qDebug() << "UPnP::SsdpConnection: failed to send the UPnP broadcast packet." << endl;
+			qDebug() << "UPnP::SsdpConnection: failed to send the UPnP broadcast packet." << Qt::endl;
 		}
 	}
 

--- a/src/modules/upnp/WanConnectionService.cpp
+++ b/src/modules/upnp/WanConnectionService.cpp
@@ -96,7 +96,7 @@ namespace UPnP
 	void WanConnectionService::gotActionResponse(const QString & responseType, const QMap<QString, QString> & resultValues)
 	{
 		qDebug() << "UPnP::WanConnectionService: parsing action response:"
-		         << " type='" << responseType << "'." << endl;
+		         << " type='" << responseType << "'." << Qt::endl;
 
 		// Check the message type
 		if(responseType == "GetExternalIPAddressResponse")
@@ -104,14 +104,14 @@ namespace UPnP
 			// Get the external IP address from the response
 			m_szExternalIpAddress = resultValues["NewExternalIPAddress"];
 
-			qDebug() << "UPnP::WanConnectionService: externalIp='" << m_szExternalIpAddress << "'." << endl;
+			qDebug() << "UPnP::WanConnectionService: externalIp='" << m_szExternalIpAddress << "'." << Qt::endl;
 		}
 		else if(responseType == "GetNATRSIPStatusResponse")
 		{
 			// Get the nat status from the response
 			m_bNatEnabled = (resultValues["NewNATEnabled"] == "1");
 
-			qDebug() << "UPnP::WanConnectionService: natEnabled=" << m_bNatEnabled << "." << endl;
+			qDebug() << "UPnP::WanConnectionService: natEnabled=" << m_bNatEnabled << "." << Qt::endl;
 		}
 		else if(responseType == "GetGenericPortMappingEntryResponse")
 		{
@@ -133,20 +133,20 @@ namespace UPnP
 
 			qDebug() << "UPnP::WanConnectionService - Received mapping: " << map->protocol << " " << map->remoteHost << ":" << map->externalPort
 			         << " to " << map->internalClient << ":" << map->internalPort
-			         << "    max " << map->leaseDuration << "s '" << map->description << "' " << (map->enabled ? "enabled" : "disabled") << endl;
+			         << "    max " << map->leaseDuration << "s '" << map->description << "' " << (map->enabled ? "enabled" : "disabled") << Qt::endl;
 		}
 		else if(responseType == "AddPortMappingResponse")
 		{
-			qDebug() << "UPnP::WanConnectionService - Received mapping enabled" << endl;
+			qDebug() << "UPnP::WanConnectionService - Received mapping enabled" << Qt::endl;
 		}
 		else if(responseType == "DeletePortMappingResponse")
 		{
-			qDebug() << "UPnP::WanConnectionService - Received mapping disabled" << endl;
+			qDebug() << "UPnP::WanConnectionService - Received mapping disabled" << Qt::endl;
 		}
 		else
 		{
 			qDebug() << "UPnP::WanConnectionService - Unexpected response type"
-			         << " '" << responseType << "' encountered." << endl;
+			         << " '" << responseType << "' encountered." << Qt::endl;
 		}
 	}
 

--- a/src/modules/upnp/XmlFunctions.cpp
+++ b/src/modules/upnp/XmlFunctions.cpp
@@ -39,7 +39,7 @@
 QDomNode XmlFunctions::getNode(const QDomNode & rootNode, const QString & path)
 {
 
-	QStringList pathItems = path.split("/", QString::SkipEmptyParts);
+	QStringList pathItems = path.split("/", Qt::SkipEmptyParts);
 	QDomNode childNode = rootNode.namedItem(pathItems[0]); // can be a null node
 
 	int i = 1;
@@ -57,7 +57,7 @@ QDomNode XmlFunctions::getNode(const QDomNode & rootNode, const QString & path)
 	if(childNode.isNull())
 	{
 		qDebug() << "XmlFunctions::getNode() - Notice: node '" << pathItems[i - 1] << "'"
-		         << " does not exist (root=" << rootNode.nodeName() << " path=" << path << ")." << endl;
+		         << " does not exist (root=" << rootNode.nodeName() << " path=" << path << ")." << Qt::endl;
 	}
 
 	return childNode;
@@ -79,7 +79,7 @@ QDomNode XmlFunctions::getNodeChildByKey(const QDomNodeList & childNodes, const 
 	for(int i = 0; i < childNodes.count(); i++)
 	{
 		//    kdDebug() << "node " << childNodes.item(i).nodeName() << "/" << keyTagName
-		//              << "="     << childNodes.item(i).namedItem(keyTagName).toElement().text() << " == " << keyValue << "?" << endl;
+		//              << "="     << childNodes.item(i).namedItem(keyTagName).toElement().text() << " == " << keyValue << "?" << Qt::endl;
 
 		// If the node has an childname with a certain value... e.g. <childNodes> <item><name>value</name></item> .. </childNodes>
 		if(childNodes.item(i).namedItem(keyTagName).toElement().text() == keyValue)
@@ -100,7 +100,7 @@ QString XmlFunctions::getNodeValue(const QDomNode & rootNode, const QString & pa
 	// Added code to avoid more assertion errors, and trace the cause.
 	if(rootNode.isNull())
 	{
-		qWarning() << "XmlFunctions::getNodeValue: attempted to request '" << path << "' on null root node." << endl;
+		qWarning() << "XmlFunctions::getNodeValue: attempted to request '" << path << "' on null root node." << Qt::endl;
 		return QString();
 	}
 

--- a/src/modules/upnp/igdcontrolpoint.cpp
+++ b/src/modules/upnp/igdcontrolpoint.cpp
@@ -49,9 +49,9 @@ namespace UPnP
 	    : QObject(), m_bGatewayAvailable(false), m_iIgdPort(0), m_pRootService(nullptr), m_pWanConnectionService(nullptr)
 	{
 		qDebug() << "CREATED UPnP::IgdControlPoint: created control point"
-		         << " url='" << hostname << ":" << port << "/" << rootUrl << "'." << endl;
+		         << " url='" << hostname << ":" << port << "/" << rootUrl << "'." << Qt::endl;
 
-		qDebug() << "UPnP::IgdControlPoint: querying services..." << endl;
+		qDebug() << "UPnP::IgdControlPoint: querying services..." << Qt::endl;
 
 		// Store device url
 		m_szIgdHostname = hostname;
@@ -68,7 +68,7 @@ namespace UPnP
 		delete m_pRootService;
 		delete m_pWanConnectionService;
 
-		qDebug() << "DESTROYED UPnP::IgdControlPoint [host=" << m_szIgdHostname << ", port=" << m_iIgdPort << "]" << endl;
+		qDebug() << "DESTROYED UPnP::IgdControlPoint [host=" << m_szIgdHostname << ", port=" << m_iIgdPort << "]" << Qt::endl;
 	}
 
 	// Return the external IP address
@@ -113,7 +113,7 @@ namespace UPnP
 				m_bGatewayAvailable = true;
 
 				qDebug() << "UPnP::IgdControlPoint: WAN/IP connection service found, "
-				         << "querying service '" << params.serviceId << "' for external IP address..." << endl;
+				         << "querying service '" << params.serviceId << "' for external IP address..." << Qt::endl;
 
 				// Call the service
 				m_pWanConnectionService = new WanConnectionService(params);
@@ -122,7 +122,7 @@ namespace UPnP
 			}
 			else
 			{
-				qDebug() << "UPnP::IgdControlPoint: no PPP/IP connection service found :(" << endl;
+				qDebug() << "UPnP::IgdControlPoint: no PPP/IP connection service found :(" << Qt::endl;
 			}
 		}
 	}
@@ -132,12 +132,12 @@ namespace UPnP
 	{
 		if(!error)
 		{
-			qDebug() << "IgdControlPoint: UPnP gateway device found." << endl;
+			qDebug() << "IgdControlPoint: UPnP gateway device found." << Qt::endl;
 		}
 		else
 		{
 			// Just started, the request for the external IP failed. This should succeed, abort portation
-			qDebug() << "Requesting external IP address failed, leaving UPnP gateway device untouched." << endl;
+			qDebug() << "Requesting external IP address failed, leaving UPnP gateway device untouched." << Qt::endl;
 		}
 	}
 

--- a/src/modules/url/libkviurl.cpp
+++ b/src/modules/url/libkviurl.cpp
@@ -499,14 +499,14 @@ void saveUrlList()
 
 	QTextStream stream(&file);
 
-	stream << g_List.size() << endl;
+	stream << g_List.size() << Qt::endl;
 
 	for(auto tmp : g_List)
 	{
-		stream << tmp->url << endl;
-		stream << tmp->window << endl;
-		stream << tmp->count << endl;
-		stream << tmp->timestamp << endl;
+		stream << tmp->url << Qt::endl;
+		stream << tmp->window << Qt::endl;
+		stream << tmp->count << Qt::endl;
+		stream << tmp->timestamp << Qt::endl;
 	}
 	file.flush();
 	file.close();
@@ -569,10 +569,10 @@ void saveBanList()
 
 	QTextStream stream(&file);
 
-	stream << g_BanList.size() << endl;
+	stream << g_BanList.size() << Qt::endl;
 	for(auto tmp : g_BanList)
 	{
-		stream << *tmp << endl;
+		stream << *tmp << Qt::endl;
 	}
 	file.flush();
 	file.close();
@@ -749,7 +749,7 @@ bool urllist_module_event_onUrl(KviKvsModuleEventCall * c)
 		QString tmpTimestamp;
 		QDate d = QDate::currentDate();
 		QString date;
-		date.sprintf("%d-%d%d-%d%d", d.year(), d.month() / 10, d.month() % 10, d.day() / 10, d.day() % 10);
+		date.asprintf("%d-%d%d-%d%d", d.year(), d.month() / 10, d.month() % 10, d.day() / 10, d.day() % 10);
 		tmpTimestamp = "[" + date + "]" + " [";
 		tmpTimestamp += QTime::currentTime().toString() + "]";
 		tmp->url = szUrl;

--- a/src/modules/url/libkviurl.cpp
+++ b/src/modules/url/libkviurl.cpp
@@ -749,7 +749,7 @@ bool urllist_module_event_onUrl(KviKvsModuleEventCall * c)
 		QString tmpTimestamp;
 		QDate d = QDate::currentDate();
 		QString date;
-		date.asprintf("%d-%d%d-%d%d", d.year(), d.month() / 10, d.month() % 10, d.day() / 10, d.day() % 10);
+		date = QString::asprintf("%d-%d%d-%d%d", d.year(), d.month() / 10, d.month() % 10, d.day() / 10, d.day() % 10);
 		tmpTimestamp = "[" + date + "]" + " [";
 		tmpTimestamp += QTime::currentTime().toString() + "]";
 		tmp->url = szUrl;


### PR DESCRIPTION
This PR removes the usage of all deprecated classes and methods in Qt5, with a single exception.
Only KvsObject_xmlreader is still using a deprecated Qt class, but it needs to be completely rewritten or deprecated aswell.
KDE4 support has been removed, and KDE5 support has been integrated where missing (eg. the terminal widget and the filetransfer "open file" menu).
This actually requires Qt 5.15, any recent (decent) distro is shipping it since years.
It also requires a quite recent version of KDE Frameworks is KDE support is enabled. Please report any problem compiling, i'll be glad to implement workarounds where possible.

