### PR TITLE
Avoid compilation warning on Python >=3.7

### DIFF
--- a/src/modules/pythoncore/libkvipythoncore.cpp
+++ b/src/modules/pythoncore/libkvipythoncore.cpp
@@ -213,7 +213,9 @@ static bool pythoncore_module_init(KviModule *)
 {
 #ifdef COMPILE_PYTHON_SUPPORT
 	Py_Initialize();
+#if PY_VERSION_HEX < 0x03070000
 	PyEval_InitThreads();
+#endif
 
 	mainThreadState = PyEval_SaveThread();
 


### PR DESCRIPTION
Since python 3.7 the function call is useless: https://docs.python.org/3.11/c-api/init.html#c.PyEval_InitThreads