### PR TITLE
Fix path for kde notifier

### DIFF
--- a/src/kvirc/kernel/KviApplication.cpp
+++ b/src/kvirc/kernel/KviApplication.cpp
@@ -687,9 +687,9 @@ void KviApplication::notifierMessage(KviWindow * pWnd, int iIconId, const QStrin
 
 		if(!bKNotifyConfigFileChecked)
 		{
-			QString szFileName = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/" + QString::fromUtf8("kvirc/kvirc.notifyrc");
+			QString szFileName = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/" + QString::fromUtf8("knotifications5/kvirc.notifyrc");
 			if(szFileName.isEmpty())
-				szFileName = QString::fromUtf8("%1/.kde/share/apps/kvirc/kvirc.notifyrc").arg(QDir::homePath());
+				szFileName = QString::fromUtf8("%1/.local/share/knotifications5/kvirc.notifyrc").arg(QDir::homePath());
 
 			QFileInfo inf(szFileName);
 


### PR DESCRIPTION
In order to send notifications in KDE5 you need to create an app-specific notifyrc file.
It was created correctly, but in the wrong path: fix it.
