### PR TITLE
kernel: We should read the default config on startup (bis)

### DIFF
--- a/src/kvilib/config/kvi_defaults.h
+++ b/src/kvilib/config/kvi_defaults.h
@@ -55,7 +55,9 @@
 
 #include "kvi_settings.h"
 
-#if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
+#ifdef COMPILE_KDE_SUPPORT
+#define KVI_HOME_CONFIG_FILE_NAME "kvircrc"
+#elif defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
 #define KVI_HOME_CONFIG_FILE_NAME "kvirc4.ini"
 #else
 #define KVI_HOME_CONFIG_FILE_NAME ".kvirc4.rc"

--- a/src/kvirc/kernel/KviApplication_setup.cpp
+++ b/src/kvirc/kernel/KviApplication_setup.cpp
@@ -267,12 +267,12 @@ bool KviApplication::findLocalKvircDirectory()
 	if(m_szConfigFile.isEmpty())
 	{
 		// don't do that if user supplied a config file :)
-		KConfig oKCfg("kvirc");
-		KConfigGroup oKCfgMainGroup(&oKCfg, "Main");
+		KConfig kCfg("kvircrc");
+		KConfigGroup kCfgGroup(&kCfg, "General");
 
-		m_szLocalKvircDir = oKCfgMainGroup.readEntry("LocalKvircDirectory");
+		m_szLocalKvircDir = kCfgGroup.readEntry("LocalKvircDirectory");
 
-		unsigned int uSourcesDate = oKCfgMainGroup.readEntry("SourcesDate").toInt();
+		unsigned int uSourcesDate = kCfgGroup.readEntry("SourcesDate").toInt();
 		if(uSourcesDate < KVI_SOURCES_DATE_NUMERIC_FORCE_SETUP)
 			return false; // we force a setup anyway
 
@@ -455,19 +455,14 @@ void KviApplication::saveKvircDirectory()
 	if(m_szConfigFile.isEmpty())
 	{
 		// not if user supplied a config file
-		KConfig * pCfg = new KConfig("kvirc");
-		KConfigGroup * pCfgMainGroup = new KConfigGroup(pCfg, "Main");
-		if(pCfg)
+		KConfig kCfg("kvircrc");
+		if (kCfg.isConfigWritable(true))
 		{
-			if(pCfg->accessMode() == KConfig::ReadWrite)
-			{
-				pCfgMainGroup->writeEntry("LocalKvircDirectory", m_szLocalKvircDir);
-				pCfgMainGroup->writeEntry("SourcesDate", KVI_SOURCES_DATE_NUMERIC);
-				pCfg->sync();
-				delete pCfgMainGroup;
-				pCfgMainGroup = nullptr;
-				return;
-			}
+			KConfigGroup kCfgGroup(&kCfg, "General");
+			kCfgGroup.writeEntry("LocalKvircDirectory", m_szLocalKvircDir);
+			kCfgGroup.writeEntry("SourcesDate", KVI_SOURCES_DATE_NUMERIC);
+			kCfgGroup.sync();
+			return;
 		}
 	}
 #endif //COMPILE_KDE_SUPPORT


### PR DESCRIPTION
This is based on the work made by @cryptomilk on #2170 
When compiled with KDE support, use the correct name for the main kvirc configuration file.