### PR TITLE
Spellchecker: detect clicked word; fix #1918

### DIFF
--- a/src/kvirc/ui/KviInputEditor.h
+++ b/src/kvirc/ui/KviInputEditor.h
@@ -114,6 +114,7 @@ protected:
 	static int g_iCachedHeight;
 	QString m_szTextBuffer; // original buffer
 	int m_iCursorPosition;
+	int m_iSpellCheckPosition;
 	int m_iSelectionBegin;
 	int m_iSelectionEnd;
 	int m_iMaxBufferSize;


### PR DESCRIPTION
On right click menu, check the spelling for the word under the mouse instead of the word where the cursor is located; fix #1918
