### PR TITLE
Port the mediaplayer mpris interface to mpris 2.2; fix #1912

### DIFF
--- a/src/modules/mediaplayer/MpMprisInterface.cpp
+++ b/src/modules/mediaplayer/MpMprisInterface.cpp
@@ -26,44 +26,9 @@
 #if(defined(COMPILE_DBUS_SUPPORT) && !defined(COMPILE_ON_WINDOWS) && !defined(COMPILE_ON_MAC) && !defined(COMPILE_ON_MINGW))
 #include "KviLocale.h"
 
-/*
-	according to MPRIS 1.0, GetStatus returns struct of 4 integers.
-
-	First integer: 0 = Playing, 1 = Paused, 2 = Stopped.
-	Second integer: 0 = Playing linearly, 1 = Playing randomly.
-	Third integer: 0 = Go to the next element once the current has finished playing, 1 = Repeat the current element
-	Fourth integer: 0 = Stop playing once the last element has been played, 1 = Never give up playing
-*/
-
-struct MPRISPlayerStatus
-{
-	int Play;
-	int Random;
-	int RepeatCurrent;
-	int RepeatPlaylist;
-};
-Q_DECLARE_METATYPE(MPRISPlayerStatus)
-
-QDBusArgument & operator<<(QDBusArgument & argument, const MPRISPlayerStatus & status)
-{
-	argument.beginStructure();
-	argument << status.Play << status.Random << status.RepeatCurrent << status.RepeatPlaylist;
-	argument.endStructure();
-	return argument;
-}
-
-const QDBusArgument & operator>>(const QDBusArgument & argument, MPRISPlayerStatus & status)
-{
-	argument.beginStructure();
-	argument >> status.Play >> status.Random >> status.RepeatCurrent >> status.RepeatPlaylist;
-	argument.endStructure();
-	return argument;
-}
-
 MpMprisInterface::MpMprisInterface()
     : MpInterface()
 {
-	qDBusRegisterMetaType<MPRISPlayerStatus>();
 }
 
 MpMprisInterface::~MpMprisInterface()
@@ -83,8 +48,8 @@ int MpMprisInterface::detect(bool)
 }
 
 #define MPRIS_SIMPLE_CALL(__path, __action)                                           \
-	QDBusInterface dbus_iface(m_szServiceName, __path,                                \
-	    "org.freedesktop.MediaPlayer", QDBusConnection::sessionBus());                \
+	QDBusInterface dbus_iface(m_szServiceName, "/org/mpris/MediaPlayer2",             \
+	    __path, QDBusConnection::sessionBus());                                       \
 	QDBusMessage reply = dbus_iface.call(QDBus::Block, __action);                     \
 	if(reply.type() == QDBusMessage::ErrorMessage)                                    \
 	{                                                                                 \
@@ -96,69 +61,63 @@ int MpMprisInterface::detect(bool)
 
 bool MpMprisInterface::prev()
 {
-	MPRIS_SIMPLE_CALL("/Player", "Prev")
+	MPRIS_SIMPLE_CALL("org.mpris.MediaPlayer2.Player", "Previous")
 }
 
 bool MpMprisInterface::next()
 {
-	MPRIS_SIMPLE_CALL("/Player", "Next")
+	MPRIS_SIMPLE_CALL("org.mpris.MediaPlayer2.Player", "Next")
 }
 
 bool MpMprisInterface::play()
 {
-	MPRIS_SIMPLE_CALL("/Player", "Play")
+	MPRIS_SIMPLE_CALL("org.mpris.MediaPlayer2.Player", "Play")
 }
 
 bool MpMprisInterface::stop()
 {
-	MPRIS_SIMPLE_CALL("/Player", "Stop")
+	MPRIS_SIMPLE_CALL("org.mpris.MediaPlayer2.Player", "Stop")
 }
 
 bool MpMprisInterface::pause()
 {
-	MPRIS_SIMPLE_CALL("/Player", "Pause")
+	MPRIS_SIMPLE_CALL("org.mpris.MediaPlayer2.Player", "Pause")
 }
 
 bool MpMprisInterface::quit()
 {
-	MPRIS_SIMPLE_CALL("/", "Quit")
+	MPRIS_SIMPLE_CALL("org.mpris.MediaPlayer2", "Quit")
 }
 
-#define MPRIS_CALL_METHOD(__method, __return_if_fail)                                 \
-	QDBusInterface dbus_iface(m_szServiceName, "/Player",                             \
-	    "org.freedesktop.MediaPlayer", QDBusConnection::sessionBus());                \
-	QDBusMessage reply = dbus_iface.call(QDBus::Block, __method);                     \
-	if(reply.type() == QDBusMessage::ErrorMessage)                                    \
-	{                                                                                 \
-		QDBusError err = reply;                                                       \
-		qDebug("Error: %s\n%s\n", qPrintable(err.name()), qPrintable(err.message())); \
-		return __return_if_fail;                                                      \
-	}
+#define MPRIS_GET_PROPERTY(__property, __return_if_fail)                  \
+	QDBusInterface dbus_iface(m_szServiceName, "/org/mpris/MediaPlayer2", \
+	    "org.mpris.MediaPlayer2.Player", QDBusConnection::sessionBus());  \
+	QVariant reply = dbus_iface.property(__property);                     \
+	if(!reply.isValid())                                                  \
+		return __return_if_fail;
 
 #define MPRIS_GET_METADATA_FIELD(__field, __return_type, __return_if_fail) \
 	if(this->status() != MpInterface::Playing)                             \
 		return __return_if_fail;                                           \
-	MPRIS_CALL_METHOD("GetMetadata", __return_if_fail)                     \
-	foreach(QVariant w, reply.arguments())                                 \
+	MPRIS_GET_PROPERTY("Metadata", __return_if_fail)                       \
+	QVariantMap map = reply.toMap();                                       \
+	foreach (const QString &key, map.keys())                               \
 	{                                                                      \
-		QDBusArgument arg = qvariant_cast<QDBusArgument>(w);               \
-		QVariant v = qdbus_cast<QVariantMap>(arg);                         \
-		if(v.userType() == QVariant::Map)                                  \
-		{                                                                  \
-			const QVariantMap map = v.toMap();                             \
-			QVariantMap::ConstIterator it = map.find(__field);             \
-			if(it != map.end() && it.key() == __field)                     \
-			{                                                              \
-				return it.value().value<__return_type>();                  \
-			}                                                              \
-		}                                                                  \
+		if(key == __field)                                                 \
+			return map.value(key).value<__return_type>();                  \
 	}                                                                      \
 	return __return_if_fail;
 
-#define MPRIS_CALL_METHOD_WITH_ARG(__method, __arg, __return_if_fail)                 \
-	QDBusInterface dbus_iface(m_szServiceName, "/Player",                             \
-	    "org.freedesktop.MediaPlayer", QDBusConnection::sessionBus());                \
-	QDBusMessage reply = dbus_iface.call(QDBus::Block, __method, __arg);              \
+#define MPRIS_SET_PROPERTY(__property, __arg, __return_if_fail)           \
+	QDBusInterface dbus_iface(m_szServiceName, "/org/mpris/MediaPlayer2", \
+	    "org.mpris.MediaPlayer2.Player", QDBusConnection::sessionBus());  \
+	if(false == dbus_iface.setProperty(__property, __arg))                \
+		return __return_if_fail;
+
+#define MPRIS_CALL_METHOD_WITH_TWO_ARG(__method, __arg1, __arg2, __return_if_fail)    \
+	QDBusInterface dbus_iface(m_szServiceName, "/org/mpris/MediaPlayer2",             \
+	    "org.mpris.MediaPlayer2.Player", QDBusConnection::sessionBus());              \
+	QDBusMessage reply = dbus_iface.call(QDBus::Block, __method, __arg1, __arg2);     \
 	if(reply.type() == QDBusMessage::ErrorMessage)                                    \
 	{                                                                                 \
 		QDBusError err = reply;                                                       \
@@ -168,26 +127,16 @@ bool MpMprisInterface::quit()
 
 MpInterface::PlayerStatus MpMprisInterface::status()
 {
-	MPRIS_CALL_METHOD("GetStatus", MpInterface::Unknown)
+	MPRIS_GET_PROPERTY("PlaybackStatus", MpInterface::Unknown)
 
-	MPRISPlayerStatus status;
-
-	if(reply.arguments().isEmpty())
-		return MpInterface::Unknown;
-
-	status = qdbus_cast<MPRISPlayerStatus>(reply.arguments().first());
-
-	switch(status.Play)
-	{
-		case 0:
-			return MpInterface::Playing;
-		case 1:
-			return MpInterface::Paused;
-		case 2:
-			return MpInterface::Stopped;
-		default:
-			return MpInterface::Unknown;
-	}
+	QString szStatus = reply.toString();
+	if(szStatus == "Playing")
+		return MpInterface::Playing;
+	if(szStatus == "Paused")
+		return MpInterface::Paused;
+	if(szStatus == "Stopped")
+		return MpInterface::Stopped;
+	return MpInterface::Unknown;
 }
 
 QString MpMprisInterface::nowPlaying()
@@ -195,27 +144,20 @@ QString MpMprisInterface::nowPlaying()
 	if(this->status() != MpInterface::Playing)
 		return "";
 
-	MPRIS_CALL_METHOD("GetMetadata", "")
+	MPRIS_GET_PROPERTY("Metadata", "")
+	QVariantMap map = reply.toMap();
 
 	QString artist;
 	QString title;
-	foreach(QVariant w, reply.arguments())
+	foreach (const QString &key, map.keys())
 	{
-		QDBusArgument arg = qvariant_cast<QDBusArgument>(w);
-		QVariant v = qdbus_cast<QVariantMap>(arg);
-		if(v.userType() == QVariant::Map)
-		{
-			const QVariantMap map = v.toMap();
-			QVariantMap::ConstIterator it = map.constBegin();
-			for(; it != map.constEnd(); ++it)
-			{ /* maybe do some configurable formatting */
-				if(it.key() == "artist")
-					artist = it.value().toString();
-				else if(it.key() == "title")
-					title = it.value().toString();
-			}
-		}
+		/* maybe do some configurable formatting */
+		if(key == "xesam:artist")
+			artist = map.value(key).toString();
+		else if(key == "xesam:title")
+			title = map.value(key).toString();
 	}
+
 	if(artist.length() && title.length())
 		return artist + " - " + title;
 	else
@@ -224,110 +166,108 @@ QString MpMprisInterface::nowPlaying()
 
 QString MpMprisInterface::mrl()
 {
-	MPRIS_CALL_METHOD("GetMetadata", "")
-
-	foreach(QVariant w, reply.arguments())
-	{
-		QDBusArgument arg = qvariant_cast<QDBusArgument>(w);
-		QVariant v = qdbus_cast<QVariantMap>(arg);
-		if(v.userType() == QVariant::Map)
-		{
-			const QVariantMap map = v.toMap();
-			QVariantMap::ConstIterator it = map.find("location");
-			if(it != map.end() && it.key() == "location")
-			{
-				return it.value().toString();
-			}
-		}
-	}
-	return "";
+	MPRIS_GET_METADATA_FIELD("xesam:url", QString, "")
 }
 
 QString MpMprisInterface::title()
 {
-	MPRIS_GET_METADATA_FIELD("title", QString, "")
+	MPRIS_GET_METADATA_FIELD("xesam:title", QString, "")
 }
 
 QString MpMprisInterface::artist()
 {
-	MPRIS_GET_METADATA_FIELD("artist", QString, "")
+	MPRIS_GET_METADATA_FIELD("xesam:artist", QString, "")
 }
 
 QString MpMprisInterface::genre()
 {
-	MPRIS_GET_METADATA_FIELD("genre", QString, "")
+	MPRIS_GET_METADATA_FIELD("xesam:genre", QString, "")
 }
 
 QString MpMprisInterface::comment()
 {
-	MPRIS_GET_METADATA_FIELD("comment", QString, "")
+	MPRIS_GET_METADATA_FIELD("xesam:comment", QString, "")
 }
 
 QString MpMprisInterface::year()
 {
-	MPRIS_GET_METADATA_FIELD("year", QString, "")
+	MPRIS_GET_METADATA_FIELD("xesam:contentCreated", QString, "")
 }
 
 QString MpMprisInterface::album()
 {
-	MPRIS_GET_METADATA_FIELD("album", QString, "")
+	MPRIS_GET_METADATA_FIELD("xesam:album", QString, "")
 }
 
 int MpMprisInterface::bitRate()
 {
+	// not-standard
 	MPRIS_GET_METADATA_FIELD("audio-bitrate", int, -1)
 }
 
 int MpMprisInterface::sampleRate()
 {
+	// not-standard
 	MPRIS_GET_METADATA_FIELD("audio-samplerate", int, -1)
 }
 
 bool MpMprisInterface::setVol(kvs_int_t & iVol)
 {
-	MPRIS_CALL_METHOD_WITH_ARG("VolumeSet", QVariant((int)(100 * iVol / 255)), false);
+	double dVol = iVol;
+	MPRIS_SET_PROPERTY("Volume", QVariant(dVol / 255), false);
 	return true;
 }
 
 int MpMprisInterface::getVol()
 {
-	MPRIS_CALL_METHOD("VolumeGet", -1)
-
-	int iVol = reply.arguments().first().toInt();
-	return iVol * 255 / 100;
+	MPRIS_GET_PROPERTY("Volume", -1)
+	return reply.toDouble() * 255;
 }
 
 int MpMprisInterface::position()
 {
-	MPRIS_CALL_METHOD("PositionGet", -1)
-	return reply.arguments().first().toInt();
+	MPRIS_GET_PROPERTY("Position", -1)
+	// from usecs to msecs
+	return (int) reply.toLongLong() / 1000;
 }
 
 int MpMprisInterface::length()
 {
-	MPRIS_CALL_METHOD("GetMetadata", -1)
+	if(this->status() != MpInterface::Playing)
+		return -1;
 
-	foreach(QVariant w, reply.arguments())
+	MPRIS_GET_PROPERTY("Metadata", -1)
+	QVariantMap map = reply.toMap();
+	foreach (const QString &key, map.keys())
 	{
-		QDBusArgument arg = qvariant_cast<QDBusArgument>(w);
-		QVariant v = qdbus_cast<QVariantMap>(arg);
-		if(v.userType() == QVariant::Map)
-		{
-			const QVariantMap map = v.toMap();
-			QVariantMap::ConstIterator it = map.constBegin();
-			for(; it != map.constEnd(); ++it)
-			{
-				if(it.key() == "mtime")
-					return it.value().toInt();
-			}
-		}
+		// from usecs to msecs
+		if(key == "mpris:length")
+			return (int) map.value(key).toLongLong() / 1000;
 	}
+
 	return -1;
+}
+
+QVariant MpMprisInterface::getTrackId()
+{
+	if(this->status() != MpInterface::Playing)
+		return QVariant();
+
+	MPRIS_GET_PROPERTY("Metadata", QVariant())
+	QVariantMap map = reply.toMap();
+
+	return map.value("mpris:trackid");
 }
 
 bool MpMprisInterface::jumpTo(kvs_int_t & iPos)
 {
-	MPRIS_CALL_METHOD_WITH_ARG("PositionSet", QVariant((int)iPos), false)
+	QVariant oTrackId = getTrackId();
+	if(!oTrackId.isValid())
+		return false;
+
+	qlonglong llPos = iPos;
+	// from usecs to msecs
+	MPRIS_CALL_METHOD_WITH_TWO_ARG("SetPosition", oTrackId, QVariant(llPos * 1000), false)
 	return true;
 }
 
@@ -343,147 +283,7 @@ MP_IMPLEMENT_DESCRIPTOR(
 MpAudaciousInterface::MpAudaciousInterface()
     : MpMprisInterface()
 {
-	m_szServiceName = "org.mpris.audacious";
-}
-
-int MpAudaciousInterface::getPlayListPos()
-{
-	QDBusInterface dbus_iface("org.mpris.audacious", "/org/atheme/audacious",
-	    "org.atheme.audacious", QDBusConnection::sessionBus());
-	QDBusReply<uint> pos = dbus_iface.call(QDBus::Block, "Position");
-	return pos;
-}
-
-bool MpAudaciousInterface::quit()
-{
-	if(MpMprisInterface::quit())
-		return true;
-
-	/* compatibility with older versions */
-	MPRIS_SIMPLE_CALL("/Player", "Quit")
-}
-
-QString MpAudaciousInterface::mrl()
-{
-	MPRIS_CALL_METHOD("GetMetadata", "")
-
-	foreach(QVariant w, reply.arguments())
-	{
-		QDBusArgument arg = qvariant_cast<QDBusArgument>(w);
-		QVariant v = qdbus_cast<QVariantMap>(arg);
-		if(v.userType() == QVariant::Map)
-		{
-			const QVariantMap map = v.toMap();
-			QVariantMap::ConstIterator it = map.find("location");
-			if(it != map.end() && it.key() == "location")
-			{
-				return it.value().toString();
-			}
-			/* Some audacious versions send URI instead of location */
-			it = map.find("URI");
-			if(it != map.end() && it.key() == "URI")
-			{
-				return it.value().toString();
-			}
-		}
-	}
-	return "";
-}
-
-MpInterface::PlayerStatus MpAudaciousInterface::status()
-{
-	MpInterface::PlayerStatus status;
-	status = MpMprisInterface::status();
-	if(status != MpInterface::Unknown)
-		return status;
-
-	/* compatibility with older versions */
-	QDBusInterface dbus_iface(m_szServiceName, "/Player",
-	    "org.freedesktop.MediaPlayer", QDBusConnection::sessionBus());
-	if(!dbus_iface.isValid())
-		return MpInterface::Unknown;
-
-	QDBusMessage reply = dbus_iface.call(QDBus::Block, "GetStatus");
-
-	switch(reply.arguments().first().toInt())
-	{
-		case 0:
-			return MpInterface::Playing;
-		case 1:
-			return MpInterface::Paused;
-		case 2:
-			return MpInterface::Stopped;
-		default:
-			return MpInterface::Unknown;
-	}
-}
-
-int MpAudaciousInterface::length()
-{
-	int length = MpMprisInterface::length();
-	if(length != -1)
-		return length;
-
-	/* compatibility with older versions */
-	MPRIS_CALL_METHOD("GetMetadata", -1)
-
-	foreach(QVariant w, reply.arguments())
-	{
-		QDBusArgument arg = qvariant_cast<QDBusArgument>(w);
-		QVariant v = qdbus_cast<QVariantMap>(arg);
-		if(v.userType() == QVariant::Map)
-		{
-			const QVariantMap map = v.toMap();
-			QVariantMap::ConstIterator it = map.constBegin();
-			for(; it != map.constEnd(); ++it)
-			{
-				if(it.key() == "length")
-					return it.value().toInt();
-			}
-		}
-	}
-	return -1;
-}
-
-#define AUDACIOUS_GET_TUPLE_FIELD(__field)                                                             \
-	if(this->status() != MpInterface::Playing)                                                         \
-		return "";                                                                                     \
-	QDBusInterface dbus_iface("org.mpris.audacious", "/org/atheme/audacious",                          \
-	    "org.atheme.audacious", QDBusConnection::sessionBus());                                        \
-	QList<QVariant> args;                                                                              \
-	args << (uint) this->getPlayListPos() << QString(__field);                                         \
-	QDBusReply<QDBusVariant> reply = dbus_iface.callWithArgumentList(QDBus::Block, "SongTuple", args); \
-	return reply.value().variant().toString();
-
-QString MpAudaciousInterface::year()
-{
-	AUDACIOUS_GET_TUPLE_FIELD("year")
-}
-
-QString MpAudaciousInterface::mediaType()
-{
-	AUDACIOUS_GET_TUPLE_FIELD("codec")
-}
-
-/* BMPx interface */
-MP_IMPLEMENT_DESCRIPTOR(
-    MpBmpxInterface,
-    "bmpx",
-    __tr2qs_ctx(
-        "An interface for BMPx.\n"
-        "Download it from http://sourceforge.net/projects/beepmp\n",
-        "mediaplayer"))
-
-MpBmpxInterface::MpBmpxInterface()
-    : MpMprisInterface()
-{
-	m_szServiceName = "org.mpris.bmp";
-}
-
-/* BMPx doesn't provide GetStatus method, always assume Playing status */
-MpInterface::PlayerStatus MpBmpxInterface::status()
-{
-	return MpInterface::Playing;
+	m_szServiceName = "org.mpris.MediaPlayer2.audacious";
 }
 
 /* Amarok2 interface */
@@ -498,7 +298,7 @@ MP_IMPLEMENT_DESCRIPTOR(
 MpAmarok2Interface::MpAmarok2Interface()
     : MpMprisInterface()
 {
-	m_szServiceName = "org.mpris.amarok";
+	m_szServiceName = "org.mpris.MediaPlayer2.amarok";
 }
 
 /* Qmmp interface */
@@ -513,7 +313,7 @@ MP_IMPLEMENT_DESCRIPTOR(
 MpQmmpInterface::MpQmmpInterface()
     : MpMprisInterface()
 {
-	m_szServiceName = "org.mpris.qmmp";
+	m_szServiceName = "org.mpris.MediaPlayer2.qmmp";
 }
 
 /* xmms2 interface */
@@ -528,29 +328,7 @@ MP_IMPLEMENT_DESCRIPTOR(
 MpXmms2Interface::MpXmms2Interface()
     : MpMprisInterface()
 {
-	m_szServiceName = "org.mpris.xmms2";
-}
-
-/* mozilla songbird interface */
-MP_IMPLEMENT_DESCRIPTOR(
-    MpSongbirdInterface,
-    "songbird",
-    __tr2qs_ctx(
-        "An interface for the Mozilla Songbird media player.\n"
-        "Download it from http://www.getsongbird.com.\n"
-        "To use it you have to install also the MPRIS addon "
-        "available at http://addons.songbirdnest.com/addon/1626.\n",
-        "mediaplayer"))
-
-MpSongbirdInterface::MpSongbirdInterface()
-    : MpMprisInterface()
-{
-	m_szServiceName = "org.mpris.songbird";
-}
-
-MpInterface::PlayerStatus MpSongbirdInterface::status()
-{
-	return MpInterface::Playing;
+	m_szServiceName = "org.mpris.MediaPlayer2.xmms2";
 }
 
 /* Totem interface */
@@ -565,7 +343,7 @@ MP_IMPLEMENT_DESCRIPTOR(
 MpTotemInterface::MpTotemInterface()
     : MpMprisInterface()
 {
-	m_szServiceName = "org.mpris.Totem";
+	m_szServiceName = "org.mpris.MediaPlayer2.Totem";
 }
 
 /* Vlc interface */
@@ -582,7 +360,7 @@ MP_IMPLEMENT_DESCRIPTOR(
 MpVlcInterface::MpVlcInterface()
     : MpMprisInterface()
 {
-	m_szServiceName = "org.mpris.vlc";
+	m_szServiceName = "org.mpris.MediaPlayer2.vlc";
 }
 
 /* Clementine interface */
@@ -597,6 +375,6 @@ MP_IMPLEMENT_DESCRIPTOR(
 MpClementineInterface::MpClementineInterface()
     : MpMprisInterface()
 {
-	m_szServiceName = "org.mpris.clementine";
+	m_szServiceName = "org.mpris.MediaPlayer2.clementine";
 }
 #endif //COMPILE_ON_WINDOWS

--- a/src/modules/mediaplayer/MpMprisInterface.h
+++ b/src/modules/mediaplayer/MpMprisInterface.h
@@ -107,6 +107,19 @@ public:
 	MpClementineInterface();
 };
 
+class MpStrawberryInterface : public MpMprisInterface
+{
+public:
+	MpStrawberryInterface();
+};
+
+class MpMprisGenericInterface : public MpMprisInterface
+{
+public:
+	MpMprisGenericInterface();
+	virtual int detect(bool bStart) override;
+};
+
 MP_DECLARE_DESCRIPTOR(MpAudaciousInterface)
 MP_DECLARE_DESCRIPTOR(MpAmarok2Interface)
 MP_DECLARE_DESCRIPTOR(MpQmmpInterface)
@@ -114,6 +127,8 @@ MP_DECLARE_DESCRIPTOR(MpXmms2Interface)
 MP_DECLARE_DESCRIPTOR(MpTotemInterface)
 MP_DECLARE_DESCRIPTOR(MpVlcInterface)
 MP_DECLARE_DESCRIPTOR(MpClementineInterface)
+MP_DECLARE_DESCRIPTOR(MpStrawberryInterface)
+MP_DECLARE_DESCRIPTOR(MpMprisGenericInterface)
 #endif //COMPILE_ON_WINDOWS
 
 #endif //_MP_AUDACIOUSINTERFACE_H_

--- a/src/modules/mediaplayer/MpMprisInterface.h
+++ b/src/modules/mediaplayer/MpMprisInterface.h
@@ -62,29 +62,13 @@ public:
 	virtual int position();
 	virtual int length();
 	virtual bool jumpTo(kvs_int_t & iPos);
+	virtual QVariant getTrackId();
 };
 
 class MpAudaciousInterface : public MpMprisInterface
 {
 public:
 	MpAudaciousInterface();
-
-public:
-	virtual bool quit();
-	virtual MpInterface::PlayerStatus status();
-	virtual QString mrl();
-	virtual int length();
-
-	virtual int getPlayListPos();
-	virtual QString year();
-	virtual QString mediaType();
-};
-
-class MpBmpxInterface : public MpMprisInterface
-{
-public:
-	MpBmpxInterface();
-	virtual MpInterface::PlayerStatus status();
 };
 
 class MpAmarok2Interface : public MpMprisInterface
@@ -103,13 +87,6 @@ class MpXmms2Interface : public MpMprisInterface
 {
 public:
 	MpXmms2Interface();
-};
-
-class MpSongbirdInterface : public MpMprisInterface
-{
-public:
-	MpSongbirdInterface();
-	virtual MpInterface::PlayerStatus status();
 };
 
 class MpTotemInterface : public MpMprisInterface
@@ -131,11 +108,9 @@ public:
 };
 
 MP_DECLARE_DESCRIPTOR(MpAudaciousInterface)
-MP_DECLARE_DESCRIPTOR(MpBmpxInterface)
 MP_DECLARE_DESCRIPTOR(MpAmarok2Interface)
 MP_DECLARE_DESCRIPTOR(MpQmmpInterface)
 MP_DECLARE_DESCRIPTOR(MpXmms2Interface)
-MP_DECLARE_DESCRIPTOR(MpSongbirdInterface)
 MP_DECLARE_DESCRIPTOR(MpTotemInterface)
 MP_DECLARE_DESCRIPTOR(MpVlcInterface)
 MP_DECLARE_DESCRIPTOR(MpClementineInterface)

--- a/src/modules/mediaplayer/libkvimediaplayer.cpp
+++ b/src/modules/mediaplayer/libkvimediaplayer.cpp
@@ -1616,10 +1616,8 @@ static bool mediaplayer_module_init(KviModule * m)
 	g_pDescriptorList->append(MP_CREATE_DESCRIPTOR(KviAudaciousClassicInterface));
 	g_pDescriptorList->append(MP_CREATE_DESCRIPTOR(KviXmmsInterface));
 	g_pDescriptorList->append(MP_CREATE_DESCRIPTOR(MpXmms2Interface));
-	g_pDescriptorList->append(MP_CREATE_DESCRIPTOR(MpBmpxInterface));
 	g_pDescriptorList->append(MP_CREATE_DESCRIPTOR(MpAmarok2Interface));
 	g_pDescriptorList->append(MP_CREATE_DESCRIPTOR(MpQmmpInterface));
-	g_pDescriptorList->append(MP_CREATE_DESCRIPTOR(MpSongbirdInterface));
 	g_pDescriptorList->append(MP_CREATE_DESCRIPTOR(MpTotemInterface));
 	g_pDescriptorList->append(MP_CREATE_DESCRIPTOR(MpVlcInterface));
 	g_pDescriptorList->append(MP_CREATE_DESCRIPTOR(MpClementineInterface));

--- a/src/modules/mediaplayer/libkvimediaplayer.cpp
+++ b/src/modules/mediaplayer/libkvimediaplayer.cpp
@@ -1621,6 +1621,8 @@ static bool mediaplayer_module_init(KviModule * m)
 	g_pDescriptorList->append(MP_CREATE_DESCRIPTOR(MpTotemInterface));
 	g_pDescriptorList->append(MP_CREATE_DESCRIPTOR(MpVlcInterface));
 	g_pDescriptorList->append(MP_CREATE_DESCRIPTOR(MpClementineInterface));
+	g_pDescriptorList->append(MP_CREATE_DESCRIPTOR(MpStrawberryInterface));
+	g_pDescriptorList->append(MP_CREATE_DESCRIPTOR(MpMprisGenericInterface));
 #endif
 
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)


### PR DESCRIPTION
This PR updates the mediaplayer module's MPRIS interface from version 1 to version 2.2 (https://specifications.freedesktop.org/mpris-spec/latest/)
Version 1 of the specification is considered obsolete and broken; all media players already updated to the new spec years ago.
Two dead mediaplayers got removed (Mozilla Songbird and BMPx).
This PR has been tested working with VLC, Clementine and Audacity.

A flaw has been found in the position/length handling: the variable holding the milliseconds value is an int, so it will report broken values for long files; from my tests it breaks after around 15 minutes. The fix is not contained in this PR since it requires a data type change in all the other interfaces, too.

