### PR TITLE
Fix KviTopicWidget label shifted down and clipped

### DIFF
--- a/src/kvirc/ui/KviChannelWindow.cpp
+++ b/src/kvirc/ui/KviChannelWindow.cpp
@@ -99,6 +99,7 @@ KviChannelWindow::KviChannelWindow(KviConsoleWindow * lpConsole, const QString &
 	m_pButtonContainer->setContentsMargins(0, 0, 0, 0);
 	// Topic widget on the left
 	m_pTopicWidget = new KviTopicWidget(m_pTopSplitter, this, "topic_widget");
+	m_pTopSplitter->setStretchFactor(0, 1);
 
 	connect(m_pTopicWidget, SIGNAL(topicSelected(const QString &)),
 	    this, SLOT(topicSelected(const QString &)));

--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -139,6 +139,11 @@ public:
 };
 
 KviInputEditor::KviInputEditor(QWidget * pPar, KviWindow * pWnd, KviUserListView * pView)
+    : KviInputEditor(pPar, pPar, pWnd, pView)
+{
+}
+
+KviInputEditor::KviInputEditor(QWidget * pPar, QWidget * pInputParent, KviWindow * pWnd, KviUserListView * pView)
     : QWidget(pPar)
 {
 	m_p = new KviInputEditorPrivate();
@@ -150,7 +155,7 @@ KviInputEditor::KviInputEditor(QWidget * pPar, KviWindow * pWnd, KviUserListView
 	setObjectName("input_widget");
 
 	m_pIconMenu = nullptr;
-	m_pInputParent = pPar;
+	m_pInputParent = pInputParent;
 	m_iMaxBufferSize = KVI_INPUT_MAX_BUFFER_SIZE;
 	m_iCursorPosition = 0;       //Index of the char AFTER the cursor
 	m_iSpellCheckPosition = 0;   //Index of the char where spell checking is occuring

--- a/src/kvirc/ui/KviInputEditor.h
+++ b/src/kvirc/ui/KviInputEditor.h
@@ -101,6 +101,7 @@ public:
 	* \return KviInputEditor
 	*/
 	KviInputEditor(QWidget * pPar, KviWindow * pWnd, KviUserListView * pView = nullptr);
+	KviInputEditor(QWidget * pPar, QWidget * pInputParent, KviWindow * pWnd, KviUserListView * pView = nullptr);
 
 	/**
 	* \brief Destroys the Input editor object

--- a/src/kvirc/ui/KviThemedLabel.cpp
+++ b/src/kvirc/ui/KviThemedLabel.cpp
@@ -45,7 +45,7 @@ KviThemedLabel::KviThemedLabel(QWidget * par, KviWindow * pWindow, const char * 
 {
 	setObjectName(name);
 	m_pKviWindow = pWindow;
-	setMargin(4);
+	setMargin(0);
 	setAutoFillBackground(false);
 	applyOptions();
 }
@@ -61,7 +61,7 @@ void KviThemedLabel::applyOptions()
 	bool bIsTrasparent = false;
 #endif
 
-	QString szStyle = QString("QLabel { background: %1; background-clip: content; color: %2; font-family: %3; font-size: %4pt; font-weight: %5; font-style: %6;}")
+	QString szStyle = QString("QLabel { background: %1; background-clip: content; color: %2; font-family: %3; font-size: %4pt; font-weight: %5; font-style: %6; margin-left: 4px; margin-right: 4px;}")
 	                      .arg(bIsTrasparent ? "transparent" : KVI_OPTION_COLOR(KviOption_colorLabelBackground).name())
 	                      .arg(bIsTrasparent ? getMircColor(KVI_OPTION_MSGTYPE(KVI_OUT_NONE).fore()).name() : KVI_OPTION_COLOR(KviOption_colorLabelForeground).name())
 	                      .arg(KVI_OPTION_FONT(KviOption_fontLabel).family())

--- a/src/kvirc/ui/KviTopicWidget.cpp
+++ b/src/kvirc/ui/KviTopicWidget.cpp
@@ -38,6 +38,7 @@
 #include "KviIrcConnectionServerInfo.h"
 #include "KviIrcConnectionUserInfo.h"
 #include "KviHtmlGenerator.h"
+#include "KviTalHBox.h"
 #include "KviTalToolTip.h"
 #include "KviThemedLabel.h"
 
@@ -49,6 +50,7 @@
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPushButton>
+#include <QStackedWidget>
 
 extern KviColorWindow * g_pColorWindow;
 
@@ -100,16 +102,56 @@ KviTopicWidget::KviTopicWidget(QWidget * par, KviChannelWindow * pChannel, const
 {
 	setObjectName(name);
 	m_pKviChannelWindow = pChannel;
-	m_pHistory = nullptr;
-	m_pAccept = nullptr;
-	m_pDiscard = nullptr;
 	m_pContextPopup = nullptr;
 	m_iCursorPosition = 0;
-	m_pInput = nullptr;
 
+	// Topic label widget
 	m_pLabel = new KviThemedLabel(this, pChannel, "topic_label");
 	m_pLabel->setTextFormat(Qt::RichText);
 	connect(m_pLabel, SIGNAL(doubleClicked()), this, SLOT(switchMode()));
+
+	m_pInputBox = new KviTalHBox(this);
+
+	// Topic editor input widget
+	m_pInput = new KviInputEditor(m_pInputBox, this, m_pKviChannelWindow);
+	m_pInputBox->setStretchFactor(m_pInput, 1); // allow it to fill all available space excluding history, accept and discard buttons
+	m_pInput->setReadOnly(true);
+	m_pInput->setObjectName("topicw_inputeditor");
+	connect(m_pInput, SIGNAL(enterPressed()), this, SLOT(acceptClicked()));
+	connect(m_pInput, SIGNAL(escapePressed()), this, SLOT(discardClicked()));
+	m_pInput->installEventFilter(this);
+
+
+	m_pHistory = new QPushButton(m_pInputBox);
+	m_pHistory->setObjectName("topicw_historybutton");
+	m_pHistory->setIcon(QIcon(*(g_pIconManager->getSmallIcon(KviIconManager::History))));
+	m_pHistory->setGeometry(width() - (height() << 2) + height(), 0, height(), height());
+	KviTalToolTip::add(m_pHistory, __tr2qs("History"));
+	connect(m_pHistory, SIGNAL(clicked()), this, SLOT(historyClicked()));
+
+	m_pAccept = new QPushButton(m_pInputBox);
+	m_pAccept->setObjectName("topicw_acceptbutton");
+	m_pAccept->setIcon(QIcon(*(g_pIconManager->getSmallIcon(KviIconManager::Accept))));
+	m_pAccept->setGeometry(width() - (height() << 1), 0, height(), height());
+	m_pAccept->setEnabled(false);
+	KviTalToolTip::add(m_pAccept, __tr2qs("Commit changes"));
+	connect(m_pAccept, SIGNAL(clicked()), this, SLOT(acceptClicked()));
+
+	m_pDiscard = new QPushButton(m_pInputBox);
+	m_pDiscard->setObjectName("topicw_discardbutton");
+	m_pDiscard->setIcon(QIcon(*(g_pIconManager->getSmallIcon(KviIconManager::Discard))));
+	m_pDiscard->setGeometry(width() - height(), 0, height(), height());
+	KviTalToolTip::add(m_pDiscard, __tr2qs("Discard changes"));
+	connect(m_pDiscard, SIGNAL(clicked()), this, SLOT(discardClicked()));
+
+	// Stack topic label and input box widgets
+	m_pLabelAndInputBoxStack = new QStackedWidget(this);
+
+	m_pLabelAndInputBoxStack->addWidget(m_pLabel);
+	m_pLabelAndInputBoxStack->addWidget(m_pInputBox);
+
+	// Start showing topic label widget
+	m_pLabelAndInputBoxStack->setCurrentIndex(0);
 
 	reset();
 
@@ -473,49 +515,18 @@ void KviTopicWidget::switchMode()
 		}
 		w = w->parent();
 	}
-	if(m_pInput == nullptr)
+	if(m_pLabelAndInputBoxStack->currentIndex() == 0)
 	{
-		m_pInput = new KviInputEditor(this, m_pKviChannelWindow);
-		m_pInput->setObjectName("topicw_inputeditor");
 		m_pInput->setReadOnly(!bCanEdit);
 		if(iMaxLen > 0)
 			m_pInput->setMaxBufferSize(iMaxLen);
-		m_pInput->setGeometry(0, 0, width() - (height() << 2) + height(), height());
 		m_pInput->setText(m_szTopic);
-		connect(m_pInput, SIGNAL(enterPressed()), this, SLOT(acceptClicked()));
-		connect(m_pInput, SIGNAL(escapePressed()), this, SLOT(discardClicked()));
-		m_pInput->installEventFilter(this);
-
-		m_pHistory = new QPushButton(this);
-		m_pHistory->setObjectName("topicw_historybutton");
-		m_pHistory->setIcon(QIcon(*(g_pIconManager->getSmallIcon(KviIconManager::History))));
-		m_pHistory->setGeometry(width() - (height() << 2) + height(), 0, height(), height());
-		KviTalToolTip::add(m_pHistory, __tr2qs("History"));
-		m_pHistory->show();
-		connect(m_pHistory, SIGNAL(clicked()), this, SLOT(historyClicked()));
-
-		m_pAccept = new QPushButton(this);
-		m_pAccept->setObjectName("topicw_acceptbutton");
-		m_pAccept->setIcon(QIcon(*(g_pIconManager->getSmallIcon(KviIconManager::Accept))));
-		m_pAccept->setGeometry(width() - (height() << 1), 0, height(), height());
 		m_pAccept->setEnabled(bCanEdit);
-		m_pAccept->show();
-		KviTalToolTip::add(m_pAccept, __tr2qs("Commit changes"));
-		connect(m_pAccept, SIGNAL(clicked()), this, SLOT(acceptClicked()));
 
-		m_pDiscard = new QPushButton(this);
-		m_pDiscard->setObjectName("topicw_discardbutton");
-		m_pDiscard->setIcon(QIcon(*(g_pIconManager->getSmallIcon(KviIconManager::Discard))));
-		m_pDiscard->setGeometry(width() - height(), 0, height(), height());
-		KviTalToolTip::add(m_pDiscard, __tr2qs("Discard changes"));
-		m_pDiscard->show();
-		connect(m_pDiscard, SIGNAL(clicked()), this, SLOT(discardClicked()));
+		m_pLabelAndInputBoxStack->setCurrentIndex(1);
 
 		m_pInput->home();
-		m_pInput->show();
 		m_pInput->setFocus();
-
-		m_pLabel->hide();
 	}
 	else
 	{
@@ -621,36 +632,17 @@ void KviTopicWidget::keyPressEvent(QKeyEvent * e)
 
 void KviTopicWidget::resizeEvent(QResizeEvent *)
 {
-	if(m_pInput)
-	{
-		m_pInput->setGeometry(0, 0, width() - (height() << 2) + height(), height());
-		m_pHistory->setGeometry(width() - (height() << 2) + height(), 0, height(), height());
-		m_pAccept->setGeometry(width() - (height() << 1), 0, height(), height());
-		m_pDiscard->setGeometry(width() - height(), 0, height(), height());
-	}
-	else
-	{
-		m_pLabel->setGeometry(0, 0, width(), height());
-	}
+	m_pLabelAndInputBoxStack->setGeometry(0, 0, width(), height());
 }
 
 void KviTopicWidget::deactivate()
 {
 	popDownListBox();
-	if(m_pInput)
+	if(m_pLabelAndInputBoxStack->currentIndex() != 0)
 	{
-		m_pInput->deleteLater();
-		m_pInput = nullptr;
-		m_pHistory->deleteLater();
-		m_pHistory = nullptr;
-		m_pAccept->deleteLater();
-		m_pAccept = nullptr;
-		m_pDiscard->deleteLater();
-		m_pDiscard = nullptr;
+		m_pAccept->setEnabled(false);
+		m_pLabelAndInputBoxStack->setCurrentIndex(0);
 	}
-
-	m_pLabel->show();
-	resizeEvent(nullptr);
 
 	if(g_pColorWindow && g_pColorWindow->isVisible())
 		g_pColorWindow->hide();

--- a/src/kvirc/ui/KviTopicWidget.h
+++ b/src/kvirc/ui/KviTopicWidget.h
@@ -36,9 +36,11 @@
 class KviChannelWindow;
 class KviIrcConnection;
 class KviThemedLabel;
+class KviTalHBox;
 class QComboBox;
 class QMenu;
 class QPushButton;
+class QStackedWidget;
 
 class KVIRC_API KviTopicListBoxItemDelegate : public KviTalIconAndRichTextItemDelegate
 {
@@ -83,6 +85,8 @@ private:
 	QMenu * m_pContextPopup;
 	QAbstractItemDelegate * m_pItemDelegate;
 	KviThemedLabel * m_pLabel;
+	KviTalHBox * m_pInputBox;
+	QStackedWidget * m_pLabelAndInputBoxStack;
 	KviInputEditor * m_pInput;
 	KviTalListWidget * m_pCompletionBox;
 	KviChannelWindow * m_pKviChannelWindow;


### PR DESCRIPTION
`KviThemedLabel` has margin set to 4. While sizing topic widget this is not taken into account. This causes rendered topic label text to be shifted down and clipped at the bottom.

Fix this by setting `KviThemedLabel` margin to zero and using stylesheet left and right margin properties instead.

While at it, simplify management of editor widget lifecycle and widget size. Instead of doing that by hand on events, create `QStackedWidget` to operate visibility and size of label and editing widgets. Create all objects at once in `KviTopicWidget` constructor, attach label widget at index 0 and a `KViTaiHbox` with line editor and 3 buttons at index 1. Only operate visibility by switching current stacked widget index and let `QStackedWidget` resize it's contents as needed.
