### PR TITLE
Avoid sending a spurious null byte to the server at the end of raw commands

### DIFF
--- a/src/kvirc/kernel/KviIrcConnection.cpp
+++ b/src/kvirc/kernel/KviIrcConnection.cpp
@@ -832,14 +832,12 @@ bool KviIrcConnection::sendData(const char * pcBuffer, int iBuflen)
 			m_pConsole->outputNoFmt(KVI_OUT_SOCKETWARNING, __tr2qs("[LINK WARNING]: Socket message truncated to 512 bytes."));
 	}
 
-	KviDataBuffer * pData = new KviDataBuffer(iBuflen + 3);
+	KviDataBuffer * pData = new KviDataBuffer(iBuflen + 2);
 	KviMemory::move(pData->data(), pcBuffer, iBuflen);
 	*(pData->data() + iBuflen) = '\r';
 	*(pData->data() + iBuflen + 1) = '\n';
-	*(pData->data() + iBuflen + 2) = '\0';
 
-	QString szMsg = (const char *)(pData->data());
-	szMsg.truncate(iBuflen);
+	QString szMsg = QString::fromUtf8((const char *)(pData->data()), iBuflen);
 
 	// notify the monitors
 	for(auto & m : context()->monitorList())


### PR DESCRIPTION
While investigating #2564 it was noticed that raw commands always add a spurious null byte to the message sent to the server.
This null byte was added in #2502  to fix a possible crash during a strlen() call used to create a QString used by the socketspy.
This PR reworks the original fix: instead of appending a null byte, create the QString with an explicit length.