### PR TITLE
Fix handling of surrogate pairs in ircview and inputeditor

### DIFF
--- a/src/kvirc/ui/KviIrcView_getTextLine.cpp
+++ b/src/kvirc/ui/KviIrcView_getTextLine.cpp
@@ -584,7 +584,6 @@ found_tab:
 			APPEND_LAST_TEXT_BLOCK(data_ptr, p - data_ptr);
 			NEW_LINE_CHUNK(KviControlCodes::ArbitraryBreak);
 			data_ptr = p;
-			p++;
 		break;
 		case '\r':
 #ifdef COMPILE_USE_DYNAMIC_LABELS


### PR DESCRIPTION
The ircview and input editor (used also in topic editor) contains custom methods to render text on screen.
They didn't take in account that QString can contain surrogate pairs: 2 characters that gets drawn as a single character.
Example of these characters are emojis like 😀😃😄
As a consequence, selecting or editing text containing these characters would lead to the wrong calculation of each character width, causing overlapped and jumping text when selected, or the appearance of [Mojibake](https://it.wikipedia.org/wiki/Mojibake). 
This PR fixes handling of these weirdos.

Possible fix for #2566
Fix #2051 

As a bonus, fix out of bound memory read when a line ends with a tab
Fix #2377