### PR TITLE
Remove QWebEngine usage in core. Rewrite web package manager

### DIFF
--- a/src/kvirc/ui/KviHtmlDialog.h
+++ b/src/kvirc/ui/KviHtmlDialog.h
@@ -96,7 +96,6 @@ public:
 	virtual QVariant loadResource(int type, const QUrl & name)
 	{
 		QString p = m_pHt->htmlResource.value(name.path());
-		qDebug("resource %s type %d and page %s", name.path().toUtf8().data(), type, p.toUtf8().data());
 		if(!p.isEmpty())
 			return QVariant(p);
 		else

--- a/src/kvirc/ui/KviWebPackageManagementDialog.cpp
+++ b/src/kvirc/ui/KviWebPackageManagementDialog.cpp
@@ -108,6 +108,7 @@ void KviWebPackageListItem::downloadIcon(const QString & szIconUrl)
 				setIcon(pixImage);
 			}
 		}
+		pReply->deleteLater();
 	});
 }
 
@@ -296,32 +297,32 @@ void KviWebPackageManagementDialog::slotDataTransferProgress(qint64 iDone, qint6
 
 void KviWebPackageManagementDialog::slotDownloadFinished()
 {
-	QNetworkReply * reply = qobject_cast<QNetworkReply *>(sender());
+	QNetworkReply * pReply = qobject_cast<QNetworkReply *>(sender());
 
 	m_pProgressBar->hide();
 	m_pProgressBar->setValue(0);
 
-	if(reply == nullptr)
+	if(pReply == nullptr)
 		return;
 
-	if(reply->error() != QNetworkReply::NoError)
+	if(pReply->error() != QNetworkReply::NoError)
 	{
 		// get http status code
-		int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-		KviMessageBox::information(__tr2qs("Download failed: %1").arg(reply->errorString()));
-		reply->deleteLater();
+		int httpStatus = pReply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+		KviMessageBox::information(__tr2qs("Download failed: %1").arg(pReply->errorString()));
+		pReply->deleteLater();
 		return;
 	}
 
 	// read data from reply
-	QString szUrl = reply->url().toString();
+	QString szUrl = pReply->url().toString();
 	int iIdx = szUrl.lastIndexOf("/");
 	QString szFile = szUrl.right(szUrl.length() - iIdx - 1);
 	QFile tmpFile;
 	g_pApp->getLocalKvircDirectory(m_szLocalTemporaryPath, KviApplication::Tmp, szFile);
 	tmpFile.setFileName(m_szLocalTemporaryPath);
 	tmpFile.open(QIODevice::ReadWrite);
-	tmpFile.write(reply->readAll());
+	tmpFile.write(pReply->readAll());
 	tmpFile.close();
 
 	QString szError;
@@ -336,7 +337,7 @@ void KviWebPackageManagementDialog::slotDownloadFinished()
 
 	m_bBusy = false;
 	enableDisableButtons();
-	reply->deleteLater();
+	pReply->deleteLater();
 }
 
 void KviWebPackageManagementDialog::showEvent(QShowEvent *)

--- a/src/kvirc/ui/KviWebPackageManagementDialog.cpp
+++ b/src/kvirc/ui/KviWebPackageManagementDialog.cpp
@@ -114,8 +114,8 @@ void KviWebPackageListItem::downloadIcon(const QString & szIconUrl)
 void KviWebPackageListItem::showPopupImage()
 {
 	QDialog dlg;
-	QHBoxLayout *l = new QHBoxLayout(&dlg);
-	QLabel *label = new QLabel;
+	QHBoxLayout * l = new QHBoxLayout(&dlg);
+	QLabel * label = new QLabel;
 	l->addWidget(label);
 	label->setPixmap(icon().pixmap(800, 600));
 	dlg.exec();
@@ -167,7 +167,7 @@ KviWebPackageManagementDialog::KviWebPackageManagementDialog(QWidget * pParent)
 
 	m_pListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
 	m_pListWidget->setSortingEnabled(true);
-	//connect(m_pListWidget, SIGNAL(itemDoubleClicked(QListWidgetItem *)), this, SLOT(applyTheme(QListWidgetItem *)));
+	// connect(m_pListWidget, SIGNAL(itemDoubleClicked(QListWidgetItem *)), this, SLOT(applyTheme(QListWidgetItem *)));
 
 	connect(m_pListWidget, SIGNAL(customContextMenuRequested(const QPoint &)),
 	    this, SLOT(contextMenuRequested(const QPoint &)));
@@ -244,7 +244,8 @@ void KviWebPackageManagementDialog::contextMenuRequested(const QPoint & pos)
 	m_pListWidget->setCurrentItem(pItem);
 	m_pContextPopup->clear();
 
-	if(!pItem->icon().isNull()) {
+	if(!pItem->icon().isNull())
+	{
 		m_pContextPopup->addAction(*(g_pIconManager->getSmallIcon(KviIconManager::Canvas)), __tr2qs("Show Preview"), pItem, SLOT(showPopupImage()));
 	}
 
@@ -305,14 +306,14 @@ void KviWebPackageManagementDialog::slotDownloadFinished()
 
 	if(reply->error() != QNetworkReply::NoError)
 	{
-		//get http status code
+		// get http status code
 		int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
 		KviMessageBox::information(__tr2qs("Download failed: %1").arg(reply->errorString()));
 		reply->deleteLater();
 		return;
 	}
 
-	//read data from reply
+	// read data from reply
 	QString szUrl = reply->url().toString();
 	int iIdx = szUrl.lastIndexOf("/");
 	QString szFile = szUrl.right(szUrl.length() - iIdx - 1);

--- a/src/kvirc/ui/KviWebPackageManagementDialog.h
+++ b/src/kvirc/ui/KviWebPackageManagementDialog.h
@@ -27,37 +27,41 @@
 
 #include "kvi_settings.h"
 
-#ifdef COMPILE_WEBENGINE_SUPPORT
-
 #include <QWidget>
-#include <QWebEnginePage>
+#include <QJsonObject>
+#include "KviTalListWidget.h"
 
 class QToolBar;
-class QVBoxLayout;
-class QWebEngineView;
+class QToolButton;
 class QFile;
 class QProgressBar;
 class QUrl;
+class QTableWidget;
+class QMehu;
 
-class KviWebPackagePage : public QWebEnginePage
+class KviWebPackageListItem : public QObject, public KviTalListWidgetItem
 {
-    Q_OBJECT
+	Q_OBJECT
+
 public:
-    KviWebPackagePage(QObject* parent = 0) : QWebEnginePage(parent){}
+	KviWebPackageListItem(KviTalListWidget * pBox, QJsonObject obj, const QString & szBaseUrl);
+	~KviWebPackageListItem() {};
 
-    bool acceptNavigationRequest(const QUrl & url, QWebEnginePage::NavigationType type, bool)
-    {
-        if (type == QWebEnginePage::NavigationTypeLinkClicked)
-        {
-            emit linkClicked(url);
-            return false;
-        }
-        return true;
-    }
+protected:
+	QString m_szName;
+	QString m_szVersion;
+	QString m_szAuthor;
+	QString m_szDesc;
+	QString m_szScreen;
+	QString m_szDownload;
 
-signals:
-    void linkClicked(const QUrl&);
-
+	void downloadIcon(const QString & szIconUrl);
+public:
+	const QString & name() { return m_szName; };
+	const QString & version() { return m_szVersion; };
+	const QString & download() { return m_szDownload; };
+public slots:
+	void showPopupImage();
 };
 
 ///
@@ -84,12 +88,15 @@ public:
 
 private:
 	QToolBar * m_pToolBar;
-	QVBoxLayout * m_pLayout;
-	QWebEngineView * m_pWebView;
+	KviTalIconAndRichTextItemDelegate * m_pItemDelegate;
+	KviTalListWidget * m_pListWidget;
 	bool m_bBusy;
 	QProgressBar * m_pProgressBar;
 	QString m_szPackagePageUrl;
 	QString m_szLocalTemporaryPath;
+	QMenu * m_pContextPopup;
+	QToolButton * m_pPreviewButton;
+	QToolButton * m_pDeleteButton;
 
 protected:
 	void setPackagePageUrl(const QString & szUrl);
@@ -99,15 +106,12 @@ protected:
 	virtual bool installPackage(const QString & szPath, QString & szError) = 0;
 
 protected slots:
-
-	void slotLoadFinished(bool ok);
-	void slotLoadProgress(int iProgress);
+	void enableDisableButtons();
+	void contextMenuRequested(const QPoint & pos);
+	void showItemPreview();
+	void downloadItem();
 	void slotDataTransferProgress(qint64 iDone, qint64 iTotal);
-	void slotCommandFinished();
-	void slotLinkClicked(const QUrl & url);
-
+	void slotDownloadFinished();
 }; // class KviWebPackageManagementDialog
-
-#endif //COMPILE_WEBENGINE_SUPPORT
 
 #endif //!_KviWebPackageManagementDialog_h_

--- a/src/modules/addon/AddonManagementDialog.cpp
+++ b/src/modules/addon/AddonManagementDialog.cpp
@@ -56,9 +56,7 @@
 #include <QAbstractTextDocumentLayout>
 #include <QShortcut>
 
-#ifdef COMPILE_WEBENGINE_SUPPORT
 #include "WebAddonInterfaceDialog.h"
-#endif //COMPILE_WEBENGINE_SUPPORT
 
 AddonManagementDialog * AddonManagementDialog::m_pInstance = nullptr;
 extern QRect g_rectManagementDialogGeometry;
@@ -98,9 +96,7 @@ AddonManagementDialog::AddonManagementDialog(QWidget * p)
 	setObjectName("Addon manager");
 	setWindowIcon(*(g_pIconManager->getSmallIcon(KviIconManager::Addons)));
 
-#ifdef COMPILE_WEBENGINE_SUPPORT
 	m_pWebInterfaceDialog = nullptr;
-#endif //COMPILE_WEBENGINE_SUPPORT
 
 	m_pInstance = this;
 	QGridLayout * g = new QGridLayout(this);
@@ -200,10 +196,8 @@ AddonManagementDialog::AddonManagementDialog(QWidget * p)
 
 AddonManagementDialog::~AddonManagementDialog()
 {
-#ifdef COMPILE_WEBENGINE_SUPPORT
 	if(m_pWebInterfaceDialog)
 		delete m_pWebInterfaceDialog;
-#endif //COMPILE_WEBENGINE_SUPPORT
 	g_rectManagementDialogGeometry = QRect(pos().x(), pos().y(), size().width(), size().height());
 	m_pInstance = nullptr;
 }
@@ -292,14 +286,22 @@ void AddonManagementDialog::uninstallScript()
 
 void AddonManagementDialog::getMoreScripts()
 {
-#ifdef COMPILE_WEBENGINE_SUPPORT
 	if(m_pWebInterfaceDialog)
-		return;
-	m_pWebInterfaceDialog = new WebAddonInterfaceDialog();
-#else  //!COMPILE_WEBENGINE_SUPPORT
-	// If change this introducing not-fixed text, remember to escape this using KviQString::escapeKvs()!
-	KviKvsScript::run("openurl http://www.kvirc.net/?id=addons&version=" KVI_VERSION "." KVI_SOURCES_DATE, g_pActiveWindow);
-#endif //!COMPILE_WEBENGINE_SUPPORT
+	{
+		m_pWebInterfaceDialog->show();
+	}
+	else
+	{
+		m_pWebInterfaceDialog = new WebAddonInterfaceDialog();
+		QObject::connect(m_pWebInterfaceDialog, SIGNAL(destroyed()), this, SLOT(webInterfaceDialogDestroyed()));
+		m_pWebInterfaceDialog->show();
+	}
+}
+
+void AddonManagementDialog::webInterfaceDialogDestroyed()
+{
+	m_pWebInterfaceDialog = nullptr;
+	fillListView();
 }
 
 void AddonManagementDialog::installScript()

--- a/src/modules/addon/AddonManagementDialog.h
+++ b/src/modules/addon/AddonManagementDialog.h
@@ -54,9 +54,7 @@ public:
 	KviKvsScriptAddon * addon() { return m_pAddon; };
 };
 
-#ifdef COMPILE_WEBENGINE_SUPPORT
 class WebAddonInterfaceDialog;
-#endif //COMPILE_WEBENGINE_SUPPORT
 
 class AddonManagementDialog : public QWidget
 {
@@ -74,9 +72,7 @@ protected:
 	QToolButton * m_pHelpButton;
 	QToolButton * m_pPackButton;
 	QToolButton * m_pUninstallButton;
-#ifdef COMPILE_WEBENGINE_SUPPORT
 	QPointer<WebAddonInterfaceDialog> m_pWebInterfaceDialog;
-#endif //COMPILE_WEBENGINE_SUPPORT
 public:
 	static AddonManagementDialog * instance() { return m_pInstance; };
 	static void display(bool bTopLevel);
@@ -94,6 +90,7 @@ protected slots:
 	void uninstallScript();
 	void getMoreScripts();
 	void installScript();
+	void webInterfaceDialogDestroyed();
 	virtual void reject();
 };
 

--- a/src/modules/addon/WebAddonInterfaceDialog.cpp
+++ b/src/modules/addon/WebAddonInterfaceDialog.cpp
@@ -24,8 +24,6 @@
 
 #include "kvi_settings.h"
 
-#ifdef COMPILE_WEBENGINE_SUPPORT
-
 #include "WebAddonInterfaceDialog.h"
 #include "AddonFunctions.h"
 
@@ -41,10 +39,9 @@ WebAddonInterfaceDialog::WebAddonInterfaceDialog(QWidget * par)
 {
 	setWindowTitle(__tr2qs_ctx("Download Addons - KVIrc", "theme"));
 
-	setPackagePageUrl(
-	    QString::fromLatin1("https://www.kvirc.net/app/addons.php?version=" KVI_VERSION "&lang=%1")
-	        .arg(KviLocale::instance()->localeName()));
+	setPackagePageUrl("http://127.0.0.1/kvirc-addons/");
 }
+
 WebAddonInterfaceDialog::~WebAddonInterfaceDialog()
     = default;
 
@@ -65,5 +62,3 @@ bool WebAddonInterfaceDialog::packageIsInstalled(const QString & szId, const QSt
 	// FIXME: If the version of the installed addon is lower than allow upgrading!
 	return KviMiscUtils::compareVersions(pAddon->version(), szVersion) < 0;
 }
-
-#endif //COMPILE_WEBENGINE_SUPPORT

--- a/src/modules/addon/WebAddonInterfaceDialog.cpp
+++ b/src/modules/addon/WebAddonInterfaceDialog.cpp
@@ -39,7 +39,7 @@ WebAddonInterfaceDialog::WebAddonInterfaceDialog(QWidget * par)
 {
 	setWindowTitle(__tr2qs_ctx("Download Addons - KVIrc", "theme"));
 
-	setPackagePageUrl("http://127.0.0.1/kvirc-addons/");
+	setPackagePageUrl("https://kvirc.github.io/kvirc-addons/");
 }
 
 WebAddonInterfaceDialog::~WebAddonInterfaceDialog()

--- a/src/modules/addon/WebAddonInterfaceDialog.h
+++ b/src/modules/addon/WebAddonInterfaceDialog.h
@@ -26,8 +26,6 @@
 
 #include "kvi_settings.h"
 
-#ifdef COMPILE_WEBENGINE_SUPPORT
-
 #include "KviWebPackageManagementDialog.h"
 
 ///
@@ -57,7 +55,5 @@ protected:
 	virtual bool installPackage(const QString & szPath, QString & szError);
 
 }; // class WebAddonInterfaceDialog
-
-#endif //COMPILE_WEBENGINE_SUPPORT
 
 #endif //!_WebAddonInterfaceDialog_h_

--- a/src/modules/help/HelpWidget.h
+++ b/src/modules/help/HelpWidget.h
@@ -27,11 +27,7 @@
 #include "HelpIndex.h"
 #include "kvi_settings.h"
 
-#ifdef COMPILE_WEBENGINE_SUPPORT
-#include <QWebEngineView>
-#else
 #include <QTextBrowser>
-#endif
 #include <QToolBar>
 #include <QVBoxLayout>
 #include <QProgressBar>
@@ -48,45 +44,20 @@ public:
 	~HelpWidget();
 
 private:
-#ifdef COMPILE_WEBENGINE_SUPPORT
-	QVBoxLayout * m_pLayout;
-	QToolBar * m_pToolBar;
-	QToolBar * m_pToolBarHighlight;
-	QLineEdit * m_pFindText;
-	QWebEngineView * m_pTextBrowser;
-#else
 	QVBoxLayout * m_pLayout;
 	QToolBar * m_pToolBar;
 	QAction * m_pBackAction;
 	QAction * m_pForwardAction;
 	QTextBrowser * m_pTextBrowser;
-#endif
 	bool m_bIsStandalone;
 
 protected slots:
 	void showIndex();
-#ifdef COMPILE_WEBENGINE_SUPPORT
-	void slotLoadFinished(bool ok);
-	void slotFindNext();
-	void slotFindPrev();
-	void slotZoomIn();
-	void slotZoomOut();
-	void slotTextChanged(const QString);
-	void slotCopy();
-	void slotShowHideFind();
-#endif
 public:
-#ifdef COMPILE_WEBENGINE_SUPPORT
-	QWebEngineView * textBrowser()
-	{
-		return m_pTextBrowser;
-	}
-#else
 	QTextBrowser * textBrowser()
 	{
 		return m_pTextBrowser;
 	}
-#endif
 };
 
 #endif //_HELPWIDGET_H_

--- a/src/modules/help/HelpWindow.cpp
+++ b/src/modules/help/HelpWindow.cpp
@@ -268,11 +268,7 @@ void HelpWindow::startSearch()
 	setCursor(Qt::ArrowCursor);
 }
 
-#ifdef COMPILE_WEBENGINE_SUPPORT
-QWebEngineView * HelpWindow::textBrowser()
-#else
 QTextBrowser * HelpWindow::textBrowser()
-#endif
 {
 	return m_pHelpWidget->textBrowser();
 }
@@ -282,11 +278,7 @@ void HelpWindow::showIndexTopic()
 	if(m_pIndexSearch->text().isEmpty() || !m_pIndexListWidget->selectedItems().count())
 		return;
 	int i = g_pDocIndex->titlesList().indexOf(m_pIndexListWidget->selectedItems().at(0)->text());
-#ifdef COMPILE_WEBENGINE_SUPPORT
-	textBrowser()->load(QUrl(g_pDocIndex->documentList()[i]));
-#else
 	textBrowser()->setSource(QUrl(g_pDocIndex->documentList()[i]));
-#endif
 }
 
 void HelpWindow::searchInIndex(const QString & s)
@@ -311,11 +303,7 @@ void HelpWindow::indexSelected(QListWidgetItem * item)
 	if(!item)
 		return;
 	int i = g_pDocIndex->titlesList().indexOf(item->text());
-#ifdef COMPILE_WEBENGINE_SUPPORT
-	textBrowser()->load(QUrl(g_pDocIndex->documentList()[i]));
-#else
 	textBrowser()->setSource(QUrl(g_pDocIndex->documentList()[i]));
-#endif
 }
 
 void HelpWindow::searchSelected(QListWidgetItem * item)
@@ -323,11 +311,7 @@ void HelpWindow::searchSelected(QListWidgetItem * item)
 	if(!item)
 		return;
 	int i = g_pDocIndex->titlesList().indexOf(item->text());
-#ifdef COMPILE_WEBENGINE_SUPPORT
-	textBrowser()->load(QUrl(g_pDocIndex->documentList()[i]));
-#else
 	textBrowser()->setSource(QUrl(g_pDocIndex->documentList()[i]));
-#endif
 }
 
 QPixmap * HelpWindow::myIconPtr()

--- a/src/modules/help/HelpWindow.h
+++ b/src/modules/help/HelpWindow.h
@@ -31,17 +31,11 @@
 #include "kvi_settings.h"
 
 #include <QTabWidget>
-#ifdef COMPILE_WEBENGINE_SUPPORT
-#include <QWebEngineView>
-#else
-class QTextBrowser;
-#endif
-
 #include <QLineEdit>
 
+class QTextBrowser;
 class QProgressBar;
 class QPushButton;
-
 class HelpWidget;
 
 class HelpWindow : public KviWindow
@@ -79,11 +73,7 @@ protected:
 	void loadProperties(KviConfigurationFile * cfg) override;
 
 public:
-#ifdef COMPILE_WEBENGINE_SUPPORT
-	QWebEngineView * textBrowser();
-#else
 	QTextBrowser * textBrowser();
-#endif
 public slots:
 	void indexSelected(QListWidgetItem *);
 	void searchInIndex(const QString & s);

--- a/src/modules/help/libkvihelp.cpp
+++ b/src/modules/help/libkvihelp.cpp
@@ -185,11 +185,7 @@ static bool help_kvs_cmd_open(KviKvsModuleCommandCall * c)
 
 		if(w)
 		{
-#ifdef COMPILE_WEBENGINE_SUPPORT
-			w->textBrowser()->load(QUrl::fromLocalFile(f.absoluteFilePath()));
-#else
 			w->textBrowser()->setSource(QUrl::fromLocalFile(f.absoluteFilePath()));
-#endif
 			HelpWindow * pHelpWindow = g_pHelpWindowList->first();
 			if (pHelpWindow)
 				pHelpWindow->delayedAutoRaise();
@@ -199,21 +195,13 @@ static bool help_kvs_cmd_open(KviKvsModuleCommandCall * c)
 	if(c->switches()->find('m', "mdi"))
 	{
 		HelpWindow * w = new HelpWindow("Help browser");
-#ifdef COMPILE_WEBENGINE_SUPPORT
-		w->textBrowser()->load(QUrl::fromLocalFile(f.absoluteFilePath()));
-#else
 		w->textBrowser()->setSource(QUrl::fromLocalFile(f.absoluteFilePath()));
-#endif
 		g_pMainWindow->addWindow(w);
 	}
 	else
 	{
 		HelpWidget * w = new HelpWidget(g_pMainWindow->splitter(), true);
-#ifdef COMPILE_WEBENGINE_SUPPORT
-		w->textBrowser()->load(QUrl::fromLocalFile(f.absoluteFilePath()));
-#else
 		w->textBrowser()->setSource(QUrl::fromLocalFile(f.absoluteFilePath()));
-#endif
 		w->show();
 	}
 

--- a/src/modules/theme/ThemeFunctions.cpp
+++ b/src/modules/theme/ThemeFunctions.cpp
@@ -144,7 +144,7 @@ namespace ThemeFunctions
 		r.getStringInfoField("Date", szPackageDate);
 
 		QString szWarnings;
-		QString szDetails = "<html><body bgcolor=\"#ffffff\">";
+		QString szDetails = "<html><body>";
 		QString szTmp;
 
 		int iIdx = 0;
@@ -237,8 +237,8 @@ namespace ThemeFunctions
 
 		// clang-format off
 		hd.szHtmlText = QString(
-			"<html bgcolor=\"#ffffff\">" \
-				"<body bgcolor=\"#ffffff\">" \
+			"<html>" \
+				"<body>" \
 					"<p><center>" \
 						"<h2>%1 %2</h2>" \
 					"</center></p>" \

--- a/src/modules/theme/ThemeManagementDialog.cpp
+++ b/src/modules/theme/ThemeManagementDialog.cpp
@@ -23,10 +23,7 @@
 //=============================================================================
 #include "kvi_settings.h"
 
-#if defined(COMPILE_WEBENGINE_SUPPORT)
 #include "WebThemeInterfaceDialog.h"
-#endif
-
 #include "ThemeManagementDialog.h"
 #include "PackThemeDialog.h"
 #include "SaveThemeDialog.h"
@@ -113,9 +110,8 @@ ThemeManagementDialog::ThemeManagementDialog(QWidget * parent)
     : QWidget(parent)
 {
 	m_pItemDelegate = nullptr;
-#ifdef COMPILE_WEBENGINE_SUPPORT
 	m_pWebThemeInterfaceDialog = nullptr;
-#endif
+
 	setObjectName("theme_options_widget");
 	setWindowTitle(__tr2qs_ctx("Manage Themes - KVIrc", "theme"));
 	setWindowIcon(*(g_pIconManager->getSmallIcon(KviIconManager::Theme)));
@@ -144,7 +140,6 @@ ThemeManagementDialog::ThemeManagementDialog(QWidget * parent)
 
 	m_pPackThemeButton = new QToolButton(pHBox);
 	m_pPackThemeButton->setIcon(*(g_pIconManager->getBigIcon(KVI_BIGICON_PACK)));
-
 	m_pPackThemeButton->setIconSize(QSize(32, 32));
 	m_pPackThemeButton->setToolTip(__tr2qs_ctx("Export selected themes to a distributable package", "theme"));
 	connect(m_pPackThemeButton, SIGNAL(clicked()), this, SLOT(packTheme()));
@@ -241,13 +236,11 @@ ThemeManagementDialog::~ThemeManagementDialog()
 		delete m_pItemDelegate;
 	g_rectManagementDialogGeometry = QRect(pos().x(), pos().y(), size().width(), size().height());
 	m_pInstance = nullptr;
-#ifdef COMPILE_WEBENGINE_SUPPORT
 	if(m_pWebThemeInterfaceDialog)
 	{
 		m_pWebThemeInterfaceDialog->deleteLater();
 		m_pWebThemeInterfaceDialog = nullptr;
 	}
-#endif //COMPILE_WEBENGINE_SUPPORT
 }
 
 void ThemeManagementDialog::closeClicked()
@@ -418,7 +411,6 @@ void ThemeManagementDialog::installFromFile()
 
 void ThemeManagementDialog::getMoreThemes()
 {
-#ifdef COMPILE_WEBENGINE_SUPPORT
 	if(m_pWebThemeInterfaceDialog)
 	{
 		m_pWebThemeInterfaceDialog->show();
@@ -429,18 +421,11 @@ void ThemeManagementDialog::getMoreThemes()
 		QObject::connect(m_pWebThemeInterfaceDialog, SIGNAL(destroyed()), this, SLOT(webThemeInterfaceDialogDestroyed()));
 		m_pWebThemeInterfaceDialog->show();
 	}
-#else
-	if(!g_pMainWindow)
-		return;
-	g_pMainWindow->executeInternalCommand(KVI_INTERNALCOMMAND_OPENURL_KVIRC_THEMES);
-#endif
 }
 
 void ThemeManagementDialog::webThemeInterfaceDialogDestroyed()
 {
-#ifdef COMPILE_WEBENGINE_SUPPORT
 	m_pWebThemeInterfaceDialog = nullptr;
-#endif
 	fillThemeBox();
 }
 

--- a/src/modules/theme/ThemeManagementDialog.h
+++ b/src/modules/theme/ThemeManagementDialog.h
@@ -39,9 +39,7 @@
 #include <QMenu>
 #include "kvi_settings.h"
 
-#if defined(COMPILE_WEBENGINE_SUPPORT) || defined(Q_MOC_RUN)
 #include "WebThemeInterfaceDialog.h"
-#endif
 
 class QLineEdit;
 class QPushButton;
@@ -76,9 +74,7 @@ protected:
 	QMenu * m_pContextPopup;
 	QToolButton * m_pDeleteThemeButton;
 	QToolButton * m_pPackThemeButton;
-#if defined(COMPILE_WEBENGINE_SUPPORT) || defined(Q_MOC_RUN)
 	WebThemeInterfaceDialog * m_pWebThemeInterfaceDialog;
-#endif
 public:
 	static ThemeManagementDialog * instance() { return m_pInstance; }
 	static void display(bool bTopLevel);

--- a/src/modules/theme/WebThemeInterfaceDialog.cpp
+++ b/src/modules/theme/WebThemeInterfaceDialog.cpp
@@ -46,7 +46,7 @@ WebThemeInterfaceDialog::WebThemeInterfaceDialog(QWidget * par)
 	g_pApp->getGlobalKvircDirectory(m_szGlobalThemesPath, KviApplication::Themes);
 	m_szGlobalThemesPath += KVI_PATH_SEPARATOR_CHAR;
 
-	setPackagePageUrl("http://127.0.0.1/kvirc-themes/");
+	setPackagePageUrl("https://kvirc.github.io/kvirc-themes/");
 }
 WebThemeInterfaceDialog::~WebThemeInterfaceDialog()
     = default;

--- a/src/modules/theme/WebThemeInterfaceDialog.cpp
+++ b/src/modules/theme/WebThemeInterfaceDialog.cpp
@@ -24,8 +24,6 @@
 
 #include "kvi_settings.h"
 
-#ifdef COMPILE_WEBENGINE_SUPPORT
-
 #include "WebThemeInterfaceDialog.h"
 #include "ThemeFunctions.h"
 
@@ -48,9 +46,7 @@ WebThemeInterfaceDialog::WebThemeInterfaceDialog(QWidget * par)
 	g_pApp->getGlobalKvircDirectory(m_szGlobalThemesPath, KviApplication::Themes);
 	m_szGlobalThemesPath += KVI_PATH_SEPARATOR_CHAR;
 
-	setPackagePageUrl(
-	    QString::fromLatin1("https://www.kvirc.net/app/themes.php?version=" KVI_VERSION "&lang=%1")
-	        .arg(KviLocale::instance()->localeName()));
+	setPackagePageUrl("http://127.0.0.1/kvirc-themes/");
 }
 WebThemeInterfaceDialog::~WebThemeInterfaceDialog()
     = default;
@@ -67,5 +63,3 @@ bool WebThemeInterfaceDialog::packageIsInstalled(const QString & szId, const QSt
 
 	return KviFileUtils::fileExists(m_szGlobalThemesPath + szSubdir) || KviFileUtils::fileExists(m_szLocalThemesPath + szSubdir);
 }
-
-#endif //COMPILE_WEBENGINE_SUPPORT

--- a/src/modules/theme/WebThemeInterfaceDialog.h
+++ b/src/modules/theme/WebThemeInterfaceDialog.h
@@ -26,8 +26,6 @@
 
 #include "kvi_settings.h"
 
-#ifdef COMPILE_WEBENGINE_SUPPORT
-
 #include "KviWebPackageManagementDialog.h"
 
 class WebThemeInterfaceDialog : public KviWebPackageManagementDialog
@@ -45,7 +43,5 @@ protected:
 	bool packageIsInstalled(const QString & szId, const QString & szVersion) override;
 	bool installPackage(const QString & szPath, QString & szError) override;
 };
-
-#endif //COMPILE_WEBENGINE_SUPPORT
 
 #endif //_WEBTHEMEINTERFACEDIALOG_H_


### PR DESCRIPTION
This PR introduces 2 big modifications.

The first one is related to the help module, that right now can use as its backend Qt's QTextBrowser (a simple html browser) or QWebEngine (based on Chromium, supports javascript etc, usually quite outdated and with a bad security record).
This PR removes the QWEbEngine backend from the help module, since we don't need it features, it's more bloated, and it never appeared in any windows release anyway.

The second one is related to WebPackageManager, aka the "get more themes" and "get more addons" features.
Right now they use QWebEngine to show a page from www.kvirc.net and download files via ftp.
This feature is broken since ages because ftp downloads aren't supported anymore and sometimes because the www.kvirc.net website has a broken ssl cert.
This PR rewrites the WebPackageManager to use plain http requests to a json file containing the information about themes/addons. Right now the file is loaded from http://127.0.0.1/ for local testing, but the target is to host the files in a github repo (implementing #1733) so that contributors can use issues and pull requests.

Once these changes are in, the only usage of QWebEngine left is in the "object" module.


Prerequisite to fix #1733
Note: this PR needs an additional commit to fix the theme/addon urls once the repositories are created.