### PR TITLE
KviCString::getToken(): add option to skip empty elements (default off)

### DIFF
--- a/src/kvilib/core/KviCString.cpp
+++ b/src/kvilib/core/KviCString.cpp
@@ -2657,7 +2657,7 @@ KviCString & KviCString::stripLeft(char c)
 	return (*this);
 }
 
-bool KviCString::getToken(KviCString & str, char sep)
+bool KviCString::getToken(KviCString & str, char sep, bool skipEmpty)
 {
 	KVI_ASSERT(str.m_ptr);
 	KVI_ASSERT(str.m_ptr != m_ptr);
@@ -2673,7 +2673,11 @@ bool KviCString::getToken(KviCString & str, char sep)
 	KviMemory::copy(str.m_ptr, m_ptr, str.m_len);
 	*(str.m_ptr + str.m_len) = '\0';
 	while(*p && (*p == sep))
+	{
 		p++;
+		if(!skipEmpty)
+			break;
+	}
 	cutLeft(p - m_ptr);
 	return (m_len != 0);
 }
@@ -2700,14 +2704,18 @@ bool KviCString::getLine(KviCString & str)
 	return true;
 }
 
-KviCString KviCString::getToken(char sep)
+KviCString KviCString::getToken(char sep, bool skipEmpty)
 {
 	char * p = m_ptr;
 	while(*p && (*p != sep))
 		p++;
 	KviCString ret(m_ptr, p);
 	while(*p && (*p == sep))
+	{
 		p++;
+		if(!skipEmpty)
+			break;
+	}
 	cutLeft(p - m_ptr);
 	return ret;
 }

--- a/src/kvilib/core/KviCString.h
+++ b/src/kvilib/core/KviCString.h
@@ -349,10 +349,10 @@ public:
 	// and returns true if there are more tokens to extract<br>
 	// Does not strip initial separators!!<br>
 	// str can NOT be this string.
-	bool getToken(KviCString & str, char sep);
+	bool getToken(KviCString & str, char sep, bool skipEmpty = false);
 	// Does not strip initial separators!<br>
 	// Can assign also to this string.
-	KviCString getToken(char sep);
+	KviCString getToken(char sep, bool skipEmpty = false);
 	// Extracts a line from the string.<br>
 	// Returns false if there was no data to extract
 	bool getLine(KviCString & str);

--- a/src/kvirc/sparser/KviIrcServerParser_numericHandlers.cpp
+++ b/src/kvirc/sparser/KviIrcServerParser_numericHandlers.cpp
@@ -907,7 +907,7 @@ void KviIrcServerParser::parseNumericWhoReply(KviIrcMessage * msg)
 	bool bIrcOp = szFlag.indexOf('*') != -1;
 
 	KviCString trailing = msg->safeTrailing();
-	KviCString hops = trailing.getToken(' ');
+	KviCString hops = trailing.getToken(' ', true);
 	bool bHopsOk = false;
 	int iHops = hops.toInt(&bHopsOk);
 


### PR DESCRIPTION
KviCString::getToken() is used to read option values for font and colors, that are comma separated.
The current behavior of KviCString::getToken() is to skip empty elements if a string contains multiple separators, eg. `value1,,value3` would end up in `key1=value1, key2=value3, key3=empty`.

This is problematic for font options, that can contain empty fields:
```
"Courier 10 Pitch,10,5,50,,Regular"
family=Courier 10 Pitch pointSize=10 styleHint=5 weight=50 options=Regular stylename= 
```

As you can see "Regular" ended up in the options instead of stylename.
As a result, the font will be underlined (since Regular contains "u")

This PR adds a parameter skipEmpty, default false, to fix this problem.
There's only one more place in the code using this method, in KviIrcServerParser::parseNumericWhoReply(), where is safer to keep the old behavior (skip any space between the 2 parameters)

Fixes a bug introduced in #2568
re-Fix #2567