### PR TITLE
Fix action shortcuts being run only sometimes

### DIFF
--- a/src/kvirc/ui/KviMainWindow.cpp
+++ b/src/kvirc/ui/KviMainWindow.cpp
@@ -321,6 +321,7 @@ void KviMainWindow::freeAccelleratorKeySequence(const QString & key)
 	{
 		if(pS->key() == kS)
 		{
+			pS->setEnabled(false);
 			m_pAccellerators.erase(
 				std::remove(m_pAccellerators.begin(), m_pAccellerators.end(), pS),
 				m_pAccellerators.end()


### PR DESCRIPTION
The Main window registers shortcuts for all the function keys in order to generate the OnAccelKeyPressed event.
If a shortcut is defined in an action, the main window is supposed to free it by deleting its previously registered shortcut.
Still, the old shortcut still lives and is triggered half of the times.
Changes in this PR:
Disable the old accelerator before deleting it to ensure it doesn't mess with the action accellerator

Related to #1096 
Reported by @Ziginox on IRC