### PR TITLE
Fix nickserv identification (fix wildcard regexp on strings containing a slash)

### DIFF
--- a/src/kvilib/ext/KviRegExp.cpp
+++ b/src/kvilib/ext/KviRegExp.cpp
@@ -33,14 +33,21 @@ QString KviRegExp::getCompletePattern() const
 {
 	if(m_ePs == PatternSyntax::Wildcard)
 	{
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-		// Qt5 always add anchors to the converted regexp, strip them
-		QString tmp = QRegularExpression::wildcardToRegularExpression(m_szPattern);
-		tmp.remove(0, 5);	// "\\A(?:"
-		tmp.chop(3);		// ")\\z"
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+		return QRegularExpression::wildcardToRegularExpression(m_szPattern, QRegularExpression::UnanchoredWildcardConversion | QRegularExpression::NonPathWildcardConversion);
+#elif QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		QString tmp = QRegularExpression::wildcardToRegularExpression(m_szPattern, QRegularExpression::UnanchoredWildcardConversion);
+		// fix #2589 - permit slash chars in matched string
+		tmp.replace("[^/]*", "[\\d\\D]*");
 		return tmp;
 #else
-		return QRegularExpression::wildcardToRegularExpression(m_szPattern, QRegularExpression::UnanchoredWildcardConversion | QRegularExpression::NonPathWildcardConversion);
+		QString tmp = QRegularExpression::wildcardToRegularExpression(m_szPattern);
+		// Qt5 always add anchors to the converted regexp, strip them
+		tmp.remove(0, 5);	// "\\A(?:"
+		tmp.chop(3);		// ")\\z"
+		// fix #2589 - permit slash chars in matched string
+		tmp.replace("[^/]*", "[\\d\\D]*");
+		return tmp;
 #endif
 	}
 	return m_szPattern;

--- a/src/kvilib/ext/KviRegExp.cpp
+++ b/src/kvilib/ext/KviRegExp.cpp
@@ -40,7 +40,7 @@ QString KviRegExp::getCompletePattern() const
 		tmp.chop(3);		// ")\\z"
 		return tmp;
 #else
-		return QRegularExpression::wildcardToRegularExpression(m_szPattern, QRegularExpression::UnanchoredWildcardConversion);
+		return QRegularExpression::wildcardToRegularExpression(m_szPattern, QRegularExpression::UnanchoredWildcardConversion | QRegularExpression::NonPathWildcardConversion);
 #endif
 	}
 	return m_szPattern;


### PR DESCRIPTION
Reported on irc by @Arisha 
KviRegExp has been ported to QRegularExpression, including the "wildcard mode" handled with QRegularExpression::wildcardToRegularExpression().
This method normally assumes that the pattern is a path, so it doesn't consider the slash "/" character as valid.
Eg. the `*IDENTIFY*` pattern used by default by nickserv identification gets converted to the regexp `[^/]*IDENTIFY[^/]*`
Qt 6.6 introduced a specific flag to disable this behavior.