### PR TITLE
Workaround qt bug on QRegularExpression;  Fix #2593

### DIFF
--- a/src/kvilib/ext/KviRegExp.cpp
+++ b/src/kvilib/ext/KviRegExp.cpp
@@ -33,7 +33,7 @@ QString KviRegExp::getCompletePattern() const
 {
 	if(m_ePs == PatternSyntax::Wildcard)
 	{
-#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 1)
 		return QRegularExpression::wildcardToRegularExpression(m_szPattern, QRegularExpression::UnanchoredWildcardConversion | QRegularExpression::NonPathWildcardConversion);
 #elif QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 		QString tmp = QRegularExpression::wildcardToRegularExpression(m_szPattern, QRegularExpression::UnanchoredWildcardConversion);


### PR DESCRIPTION
Qt 6.6.0 misses the | operator for QRegularExpression::WildcardConversionOptions
Require Qt 6.6.1 for the codepath using it
See also: https://codereview.qt-project.org/c/qt/qtbase/+/511939
