### PR TITLE
Fix #2597: moc may require the full KviMaskEntry declaration

### DIFF
--- a/src/kvirc/ui/KviChannelWindow.cpp
+++ b/src/kvirc/ui/KviChannelWindow.cpp
@@ -38,7 +38,6 @@
 #include "KviWindowListBase.h"
 #include "KviMainWindow.h"
 #include "KviConfigurationFile.h"
-#include "KviMaskEditor.h"
 #include "KviControlCodes.h"
 #include "KviModeEditor.h"
 #include "KviApplication.h"

--- a/src/kvirc/ui/KviChannelWindow.h
+++ b/src/kvirc/ui/KviChannelWindow.h
@@ -34,6 +34,7 @@
 #include "KviConsoleWindow.h"
 #include "KviWindow.h"
 #include "KviIrcUserDataBase.h"
+#include "KviMaskEditor.h"
 #include "KviPixmap.h"
 #include "KviUserListView.h"
 #include "KviTimeUtils.h"
@@ -55,13 +56,6 @@ class KviModeEditor;
 class KviTalHBox;
 class KviThemedLabel;
 class KviTopicWidget;
-
-#ifdef COMPILE_ON_WINDOWS
-// windows compiler wants this instead of the forward decl
-#include "KviMaskEditor.h"
-#else
-struct KviMaskEntry; // KviMaskEditor.h
-#endif
 
 /**
 * \def KVI_CHANNEL_AVERAGE_USERS The average channel users of a channel


### PR DESCRIPTION
moc may require the full KviMaskEntry declaration in the header file
We already noticed this on windows, now got a report on a recent debian 12.
Better apply the fix everywhere
