### PR TITLE
Mac CI: ignore brew warnings caused by multiple python installs that makes the run error out early

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install other prerequisites
         run: |
           brew update
-          brew install enchant openssl create-dmg --force-bottle
+          brew install enchant openssl create-dmg --force-bottle || true
 
       - name: Configure CMake
         run: |


### PR DESCRIPTION
It's always ~DNS~ python