### PR TITLE
Fix Wayland window associations

### DIFF
--- a/cmake/kvi_sysconfig.h.cmake
+++ b/cmake/kvi_sysconfig.h.cmake
@@ -71,6 +71,7 @@
 #define KVIRC_VERSION_RELEASE "${CMAKE_KVIRC_VERSION_RELEASE}"
 #define KVIRC_VERSION_BRANCH "${CMAKE_KVIRC_VERSION_BRANCH}"
 #define KVIRC_VERSION_CODENAME "${CMAKE_KVIRC_VERSION_CODENAME}"
+#define KVIRC_VERSION_MAJOR "${CMAKE_KVIRC_VERSION_MAJOR}"
 
 // KVIrc detects the modules directory on macs/win32 by itself
 // this seems to be used on linux only

--- a/src/kvirc/ui/KviMainWindow.cpp
+++ b/src/kvirc/ui/KviMainWindow.cpp
@@ -106,7 +106,7 @@ KviMainWindow::KviMainWindow(QWidget * pParent)
 	setWindowIcon(*(g_pIconManager->getSmallIcon(KviIconManager::KVIrc)));
 #endif
 	// set name of the app desktop file; used by wayland to load the window icon
-	QGuiApplication::setDesktopFileName("kvirc");
+	QGuiApplication::setDesktopFileName("net.kvirc.KVIrc" KVIRC_VERSION_MAJOR);
 	setWindowTitle(KVI_DEFAULT_FRAME_CAPTION);
 
 	m_pSplitter = new QSplitter(Qt::Horizontal, this);


### PR DESCRIPTION
Wayland uses the `appId/desktopFileName` window property to associate windows to the desktop launcher. 6dc728d2aeae3da55120270729ce9358a1e9537b renamed the `.desktop` launcher from `kvirc.desktop` to `net.kvirc.KVIrc${CMAKE_KVIRC_VERSION_MAJOR}.desktop`, however the `desktopFileName` window property was still being set to `kvirc` causing Wayland compositors to not correctly associate windows if they were behaving in a FreeDesktop specification compliant way (note that GNOME is not FreeDesktop-compliant here as they also use the `StartupWMClass` property from the `.desktop` to match with `.desktop` launchers as well as the filename).

On KDE Plasma 5 and 6 this would manifest in the following ways:
- The generic Wayland icon would be shown in the top left of all kvirc windows, and underneath the window when using the overview effect.
- If a user pinned the kvirc desktop file to the task manager and clicked it the created windows would not be correctly associated with the existing pinned desktop launcher and they would see duplicate icons in the task manager, one of which would be the pinned kvirc launcher and the other would be the kvirc windows.

This fixes all of those cases.