### PR TITLE
Avoid possible infinite recursion; fix #2505

### DIFF
--- a/src/kvilib/core/KviPointerHashTable.h
+++ b/src/kvilib/core/KviPointerHashTable.h
@@ -170,9 +170,9 @@ inline unsigned int kvi_hash_hash(const KviCString & szKey, bool bCaseSensitive)
 /**
 * \brief Hash key compare function for the KviCString data type
 */
-inline bool kvi_hash_key_equal(const KviCString & szKey1, const KviCString & szKey2)
+inline bool kvi_hash_key_equal(const KviCString & szKey1, const KviCString & szKey2, bool bCaseSensitive)
 {
-	return kvi_hash_key_equal(szKey1.ptr(), szKey2.ptr());
+	return kvi_hash_key_equal(szKey1.ptr(), szKey2.ptr(), bCaseSensitive);
 }
 
 /**


### PR DESCRIPTION
This PR adds a third argument to the helper function kvi_hash_key_equal(KviCString, KviCString, bool).
The function is only used internally by the template class KviPointerHashTable<Key, T> to compare elements using KviCString as the type for the Key.
Currently nothing inside KVIrc is using a KviPointerHashTable<KviCString, T>.
Still, better fix this.