### PR TITLE
Strip leading spaces on command; Fix #2626

### DIFF
--- a/src/kvirc/kernel/KviUserInput.cpp
+++ b/src/kvirc/kernel/KviUserInput.cpp
@@ -45,6 +45,8 @@ namespace KviUserInput
 		if(!c->unicode())
 			return true; // empty
 
+		// check if it's a KVS command. Skip any initial space
+		while(c->isSpace()) c++;
 		if(c->unicode() == '\\')
 		{
 			c++;
@@ -68,6 +70,9 @@ namespace KviUserInput
 				}
 			}
 		}
+
+		// the text is not a command. Reset to original value
+		c = b;
 
 		if(KVS_TRIGGER_EVENT_1_HALTED(KviEvent_OnTextInput, pWindow, szData))
 			return true; // halted


### PR DESCRIPTION
KVIrc used to strip any space at the beginning of a message/command.
This behavior was reported as a bug in #1895 and changed in eed2e4dd7779d38e336834c7054e5be67b97094e.
While it's good to keep any space at the beginning of a text message, it's good to strip them if the message contains a command.
