### PR TITLE
Make D-Bus adaptor actually useful and use it as an IPC backend

### DIFF
--- a/src/kvilib/CMakeLists.txt
+++ b/src/kvilib/CMakeLists.txt
@@ -26,7 +26,6 @@ set(kvilib_SRCS
 	ext/KviCryptEngine.cpp
 	ext/KviCryptEngineManager.cpp
 	ext/KviDataBuffer.cpp
-	ext/KviDbusAdaptor.cpp
 	ext/KviDebugContext.cpp
 	ext/KviMediaManager.cpp
 	ext/KviMiscUtils.cpp

--- a/src/kvilib/tal/KviTalMainWindow.cpp
+++ b/src/kvilib/tal/KviTalMainWindow.cpp
@@ -26,6 +26,8 @@
 
 #ifdef COMPILE_KDE_SUPPORT
 
+#include <QEvent>
+
 KviTalMainWindow::KviTalMainWindow(QWidget * pParent, const char * pcName)
     : KMainWindow(pParent)
 {
@@ -44,3 +46,18 @@ KviTalMainWindow::KviTalMainWindow(QWidget * pParent, const char * pcName)
 
 KviTalMainWindow::~KviTalMainWindow()
     = default;
+
+#ifdef COMPILE_KDE_SUPPORT
+bool KviTalMainWindow::event(QEvent *ev)
+{
+    /**
+     * KMainWindow uses this event to ensure the object as an objectname and
+     * also register the mainwindow as an exported object on d-bus.
+     * We already ensure an object name is set and want to avoid the dbus registration
+     */
+	if(ev->type() == QEvent::Polish)
+		return QMainWindow::event(ev);
+
+	return KMainWindow::event(ev);
+}
+#endif

--- a/src/kvilib/tal/KviTalMainWindow.h
+++ b/src/kvilib/tal/KviTalMainWindow.h
@@ -39,7 +39,7 @@
 
 #ifdef COMPILE_KDE_SUPPORT
 
-#include <kmainwindow.h>
+#include <KMainWindow>
 
 class KVILIB_API KviTalMainWindow : public KMainWindow
 
@@ -66,6 +66,11 @@ public:
 	* \return KviTalMainWindow
 	*/
 	~KviTalMainWindow();
+
+#ifdef COMPILE_KDE_SUPPORT
+protected:
+    bool event(QEvent *event) override;
+#endif
 };
 
 #endif // _KVI_TAL_MAINWINDOW_H_

--- a/src/kvirc/CMakeLists.txt
+++ b/src/kvirc/CMakeLists.txt
@@ -210,6 +210,7 @@ set(kvirc_SRCS
 	kernel/KviCoreActions.cpp
 	kernel/KviCustomToolBarDescriptor.cpp
 	kernel/KviCustomToolBarManager.cpp
+	kernel/KviDbusAdaptor.cpp
 	kernel/KviDefaultScript.cpp
 	kernel/KviFileTransfer.cpp
 	kernel/KviHtmlGenerator.cpp

--- a/src/kvirc/kernel/KviDbusAdaptor.cpp
+++ b/src/kvirc/kernel/KviDbusAdaptor.cpp
@@ -28,7 +28,7 @@
 
 #ifdef COMPILE_DBUS_SUPPORT
 
-#include <QtGlobal> //for qWarning()
+#include <QtDebug> //for qWarning()
 #include <QDBusConnection>
 
 KviDbusAdaptor::KviDbusAdaptor(QObject * pObj)

--- a/src/kvirc/kernel/KviDbusAdaptor.cpp
+++ b/src/kvirc/kernel/KviDbusAdaptor.cpp
@@ -28,6 +28,8 @@
 
 #ifdef COMPILE_DBUS_SUPPORT
 
+#include <QDBusConnection>
+
 KviDbusAdaptor::KviDbusAdaptor(QObject * pObj)
     : QDBusAbstractAdaptor(pObj)
 {
@@ -36,12 +38,22 @@ KviDbusAdaptor::KviDbusAdaptor(QObject * pObj)
 
 void KviDbusAdaptor::registerToSessionBus() {
     auto connection = QDBusConnection::sessionBus();
-    if(!connection.registerService(KVI_DBUS_SERVICENAME)) {
+    if(!connection.registerService(KVI_DBUS_INTERFACENAME)) {
         qWarning() << "D-Bus service registration failed:" << connection.lastError().message();
     }
-    if(!connection.registerObject("/", g_pApp)) {
+    if(!connection.registerObject(KVI_DBUS_PATH, this, QDBusConnection::ExportAllSlots)) {
         qWarning() << "D-Bus object registration failed:" << connection.lastError().message();
     }
 }
+
+#ifndef COMPILE_NO_IPC
+void KviDbusAdaptor::ipcMessage(const QString &message)
+{
+    if(!g_pApp)
+        return;
+
+    g_pApp->ipcMessage(message.toUtf8().data());
+}
+#endif
 
 #endif

--- a/src/kvirc/kernel/KviDbusAdaptor.cpp
+++ b/src/kvirc/kernel/KviDbusAdaptor.cpp
@@ -28,6 +28,7 @@
 
 #ifdef COMPILE_DBUS_SUPPORT
 
+#include <QtGlobal> //for qWarning()
 #include <QDBusConnection>
 
 KviDbusAdaptor::KviDbusAdaptor(QObject * pObj)

--- a/src/kvirc/kernel/KviDbusAdaptor.cpp
+++ b/src/kvirc/kernel/KviDbusAdaptor.cpp
@@ -1,8 +1,6 @@
-#ifndef _KVI_DBUSADAPTOR_H_
-#define _KVI_DBUSADAPTOR_H_
 //=============================================================================
 //
-//   File : KviDbusAdaptor.h
+//   File : KviDbusAdaptor.cpp
 //   Creation date : Thu May 08 2008 21:41:45 by Voker57
 //
 //   This file is part of the KVIrc IRC client distribution
@@ -24,21 +22,26 @@
 //
 //=============================================================================
 
-#include "kvi_settings.h"
+#include "KviDbusAdaptor.h"
+
+#include "KviApplication.h"
 
 #ifdef COMPILE_DBUS_SUPPORT
-#include <QDBusAbstractAdaptor>
-#include <QDBusInterface>
-#include <QObject>
 
-class KVILIB_API KviDbusAdaptor : public QDBusAbstractAdaptor
+KviDbusAdaptor::KviDbusAdaptor(QObject * pObj)
+    : QDBusAbstractAdaptor(pObj)
 {
-	Q_OBJECT
-	Q_CLASSINFO("KVIrc D-Bus Interface", "org.kvirc.KVIrc")
+    setAutoRelaySignals(false);
+}
 
-public:
-	KviDbusAdaptor(QObject * pObj);
-};
-#endif // COMPILE_DBUS_SUPPORT
+void KviDbusAdaptor::registerToSessionBus() {
+    auto connection = QDBusConnection::sessionBus();
+    if(!connection.registerService(KVI_DBUS_SERVICENAME)) {
+        qWarning() << "D-Bus service registration failed:" << connection.lastError().message();
+    }
+    if(!connection.registerObject("/", g_pApp)) {
+        qWarning() << "D-Bus object registration failed:" << connection.lastError().message();
+    }
+}
 
-#endif // _KVI_DBUSADAPTOR_H_
+#endif

--- a/src/kvirc/kernel/KviDbusAdaptor.h
+++ b/src/kvirc/kernel/KviDbusAdaptor.h
@@ -32,6 +32,8 @@
 #include <QObject>
 
 #define KVI_DBUS_SERVICENAME "net.kvirc.KVIrc"
+#define KVI_DBUS_INTERFACENAME "net.kvirc.KVIrc"
+#define KVI_DBUS_PATH "/kvirc"
 
 class KVILIB_API KviDbusAdaptor : public QDBusAbstractAdaptor
 {
@@ -43,6 +45,11 @@ public:
 	KviDbusAdaptor(QObject * pObj);
 	virtual ~KviDbusAdaptor() = default;
 	void registerToSessionBus();
+
+public slots:
+#ifndef COMPILE_NO_IPC
+	void ipcMessage(const QString &message);
+#endif
 };
 #endif // COMPILE_DBUS_SUPPORT
 

--- a/src/kvirc/kernel/KviDbusAdaptor.h
+++ b/src/kvirc/kernel/KviDbusAdaptor.h
@@ -1,6 +1,8 @@
+#ifndef _KVI_DBUSADAPTOR_H_
+#define _KVI_DBUSADAPTOR_H_
 //=============================================================================
 //
-//   File : KviDbusAdaptor.cpp
+//   File : KviDbusAdaptor.h
 //   Creation date : Thu May 08 2008 21:41:45 by Voker57
 //
 //   This file is part of the KVIrc IRC client distribution
@@ -22,13 +24,26 @@
 //
 //=============================================================================
 
-#include "KviDbusAdaptor.h"
+#include "kvi_settings.h"
 
 #ifdef COMPILE_DBUS_SUPPORT
+#include <QDBusAbstractAdaptor>
+#include <QDBusInterface>
+#include <QObject>
 
-KviDbusAdaptor::KviDbusAdaptor(QObject * pObj)
-    : QDBusAbstractAdaptor(pObj)
+#define KVI_DBUS_SERVICENAME "net.kvirc.KVIrc"
+
+class KVILIB_API KviDbusAdaptor : public QDBusAbstractAdaptor
 {
-}
+	Q_OBJECT
+	Q_CLASSINFO("D-Bus Interface", KVI_DBUS_SERVICENAME)
+	// don't change "D-Bus Interface", it needs to be exactly that string
 
-#endif
+public:
+	KviDbusAdaptor(QObject * pObj);
+	virtual ~KviDbusAdaptor() = default;
+	void registerToSessionBus();
+};
+#endif // COMPILE_DBUS_SUPPORT
+
+#endif // _KVI_DBUSADAPTOR_H_

--- a/src/kvirc/kernel/KviIpcSentinel.cpp
+++ b/src/kvirc/kernel/KviIpcSentinel.cpp
@@ -131,10 +131,16 @@ static Window kvi_x11_findIpcSentinel(Window win)
 
 	return found;
 }
-#endif //!COMPILE_NO_X
-
+#elif defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
 
 #define KVI_WINDOWS_IPC_MESSAGE 0x2FACE5
+
+#elif defined(COMPILE_DBUS_SUPPORT)
+
+#include <QDBusInterface>
+#include "KviDbusAdaptor.h"
+
+#endif
 
 bool kvi_sendIpcMessage(const char * message)
 {
@@ -184,7 +190,14 @@ bool kvi_sendIpcMessage(const char * message)
 		kvi_ipcSetRemoteCommand(sentinel, message);
 		return true;
 	}
-#endif //!COMPILE_NO_X && COMPILE_ON_WINDOWS
+#elif defined(COMPILE_DBUS_SUPPORT)
+	QDBusInterface remoteApp(KVI_DBUS_SERVICENAME, KVI_DBUS_PATH, KVI_DBUS_INTERFACENAME, QDBusConnection::sessionBus());
+	if(remoteApp.isValid())
+	{
+		remoteApp.call( "ipcMessage", message );
+		return true;
+	}
+#endif
 	return false;
 }
 

--- a/src/kvirc/kernel/KviMain.cpp
+++ b/src/kvirc/kernel/KviMain.cpp
@@ -31,9 +31,7 @@
 #include "KviMessageBox.h"
 #include "KviBuildInfo.h"
 #ifdef COMPILE_DBUS_SUPPORT
-#ifndef COMPILE_KDE_SUPPORT // 'cause kde adds an interface itself
 #include "KviDbusAdaptor.h"
-#endif
 #endif
 #ifndef COMPILE_NO_IPC
 extern bool kvi_sendIpcMessage(const char * message); // KviIpcSentinel.cpp
@@ -382,10 +380,9 @@ int main(int argc, char ** argv)
 #endif
 
 #ifdef COMPILE_DBUS_SUPPORT
-#ifndef COMPILE_KDE_SUPPORT
-	new KviDbusAdaptor(pTheApp); // FIXME: shouldn't this be deleted by someone ?
-	QDBusConnection::sessionBus().registerObject("/MainApplication", pTheApp);
-#endif
+	// deleted automatically when pTheApp gets destroyed
+	KviDbusAdaptor * pDbusAdaptor = new KviDbusAdaptor(pTheApp);
+	pDbusAdaptor->registerToSessionBus();
 #endif
 
 	QString szRemoteCommand = a.szExecCommand;

--- a/src/kvirc/kernel/KviMain.cpp
+++ b/src/kvirc/kernel/KviMain.cpp
@@ -379,12 +379,6 @@ int main(int argc, char ** argv)
 	delete pAboutData;
 #endif
 
-#ifdef COMPILE_DBUS_SUPPORT
-	// deleted automatically when pTheApp gets destroyed
-	KviDbusAdaptor * pDbusAdaptor = new KviDbusAdaptor(pTheApp);
-	pDbusAdaptor->registerToSessionBus();
-#endif
-
 	QString szRemoteCommand = a.szExecCommand;
 	if(!a.szExecRemoteCommand.isEmpty())
 	{
@@ -445,6 +439,15 @@ int main(int argc, char ** argv)
 			return 0;
 		}
 	}
+#endif
+
+#ifdef COMPILE_DBUS_SUPPORT
+	/*
+	 * D-Bus initialization must happen after IPC session handling
+	 * The object itsef is deleted automatically when pTheApp gets destroyed
+	 */
+	KviDbusAdaptor * pDbusAdaptor = new KviDbusAdaptor(pTheApp);
+	pDbusAdaptor->registerToSessionBus();
 #endif
 
 	pTheApp->m_bCreateConfig = a.createFile;


### PR DESCRIPTION
KviDbusAdaptor exists since long time, but it's currently unused/quite useless.
This PR adds the necessary changes to make it working/possibly useful.

IPC is currently broken on Linux/Wayland, as the existing backend is using XAtom.
This PR also adds a D-Bus based backend for IPC, so that kvirc can detect on startup if another instance is already running and eventually pass messages to it (using kvirc -e / -x / -r).

As a bonus, you can now go full [inception](https://wikipedia.org/wiki/Inception) mode by running KVS such as:
```
/$system.dbus("net.kvirc.KVIrc", "/kvirc", "net.kvirc.KVIrc","ipcMessage", "session", "QString=echo ciao")
```


