### PR TITLE
Set portable when it is needed on windows

### DIFF
--- a/src/kvirc/kernel/KviApplication.cpp
+++ b/src/kvirc/kernel/KviApplication.cpp
@@ -227,9 +227,6 @@ KviApplication::KviApplication(int & argc, char ** argv)
 	kvi_socket_flushTrafficCounters();
 	// don't let qt quit the application by itself
 	setQuitOnLastWindowClosed(false);
-#if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
-	m_bPortable = KviFileUtils::fileExists(QString("%1%2%3").arg(g_pApp->applicationDirPath().arg(KVI_PATH_SEPARATOR_CHAR).arg("portable")));
-#endif
 
 //note: the early qApp->style() call leads to a crash on osx
 #if !defined(COMPILE_ENABLE_GTKSTYLE) && !defined(COMPILE_ON_MAC)

--- a/src/kvirc/kernel/KviApplication_setup.cpp
+++ b/src/kvirc/kernel/KviApplication_setup.cpp
@@ -298,6 +298,8 @@ bool KviApplication::findLocalKvircDirectory()
 #endif //COMPILE_KDE_SUPPORT
 
 #if defined(COMPILE_ON_WINDOWS) || defined(COMPILE_ON_MINGW)
+	const auto portable_file = QString("%1%2%3").arg(g_pApp->applicationDirPath()).arg(KVI_PATH_SEPARATOR_CHAR).arg("portable");
+	m_bPortable = KviFileUtils::fileExists(portable_file);
 	if(m_bPortable)
 	{
 		m_szLocalKvircDir = QString("%1%2%3").arg(g_pApp->applicationDirPath()).arg(KVI_PATH_SEPARATOR_CHAR).arg("Settings");


### PR DESCRIPTION
This moves `portable` file check outside of application ctor to avoid `QApplication` weird behavior

Previously on my system (Windows 10) with version 5.2.2, KVirc was unable to detect `portable` file correctly
With this change, it is now able to correctly determine it

The most likely reason is that you can only call `applicationDirPath` outside of ctor

Fixes #2637