### PR TITLE
update azzurra.org -> azzurra.chat

### DIFF
--- a/data/config/serverdb.kvc
+++ b/data/config/serverdb.kvc
@@ -47,7 +47,7 @@ NServers=2
 1_SSL=true
 NServers=2
 [Azzurra]
-0_Hostname=irc.azzurra.org
+0_Hostname=irc.azzurra.chat
 0_Description=Main%20Random%20Server
 NServers=1
 Description=Italian%20Main%20Network

--- a/data/config/serverdb.kvc
+++ b/data/config/serverdb.kvc
@@ -49,6 +49,8 @@ NServers=2
 [Azzurra]
 0_Hostname=irc.azzurra.chat
 0_Description=Main%20Random%20Server
+0_Port=6697
+0_SSL=true
 NServers=1
 Description=Italian%20Main%20Network
 [Beyondirc]

--- a/src/kvirc/kvs/KviKvsCoreSimpleCommands_mr.cpp
+++ b/src/kvirc/kvs/KviKvsCoreSimpleCommands_mr.cpp
@@ -348,8 +348,8 @@ namespace KviKvsCoreSimpleCommands
 				openurl file://home/pragma/pippo.txt
 				openurl irc://irc.eu.dal.net:6667
 				openurl irc6://irc.ircd.it/#kvirc
-				openurl ircs://crypto.azzurra.org:9999
-				openurl ircs6://ngnet.azzurra.org:9999
+				openurl ircs://irc.azzurra.chat:9999
+				openurl ircs6://irc.azzurra.chat:9999
 				openurl ftp://ftp.localhost.net/pub/kvirc/
 				openurl mailto:users@domain.extension
 			[/example]


### PR DESCRIPTION
Updating the address of Azzurra IRC Network, which is now `irc.azzurra.chat`. I also updated an example which used the old address.

Context: Azzurra IRC Network is a long-running (since 1997) major Italian network. It had used the `azzurra.org` domain name since 2001, but it has been recently forced to renounce it due to the domain owner being uninvolved with network operations. On June 8th, the entire Azzurra network [transitioned to azzurra.chat](https://www.azzurra.chat/?mod=news) as the official domain name. The only link between the former name and the new one is a CNAME on `irc.azzurra.org`, which is only a temporary measure granted by the domain owner, and might not last long.