### PR TITLE
Force app_id to be set in more places

### DIFF
--- a/src/kvilib/tal/KviTalApplication.cpp
+++ b/src/kvilib/tal/KviTalApplication.cpp
@@ -29,6 +29,9 @@ KviTalApplication::KviTalApplication(int & iArgc, char ** ppcArgv)
 {
 	// Session management has been broken by source incompatible changes.
 	QObject::connect(this, SIGNAL(commitDataRequest(QSessionManager &)), this, SLOT(commitData(QSessionManager &)));
+
+	// set name of the app desktop file; used by wayland to load the window icon
+	QGuiApplication::setDesktopFileName("net.kvirc.KVIrc" KVIRC_VERSION_MAJOR);
 }
 
 KviTalApplication::~KviTalApplication()

--- a/src/kvirc/ui/KviMainWindow.cpp
+++ b/src/kvirc/ui/KviMainWindow.cpp
@@ -105,8 +105,6 @@ KviMainWindow::KviMainWindow(QWidget * pParent)
 	// We try to avois this as much as possible, since it forces the use of the low-res 16x16 icon
 	setWindowIcon(*(g_pIconManager->getSmallIcon(KviIconManager::KVIrc)));
 #endif
-	// set name of the app desktop file; used by wayland to load the window icon
-	QGuiApplication::setDesktopFileName("net.kvirc.KVIrc" KVIRC_VERSION_MAJOR);
 	setWindowTitle(KVI_DEFAULT_FRAME_CAPTION);
 
 	m_pSplitter = new QSplitter(Qt::Horizontal, this);

--- a/src/kvirc/ui/KviWindow.cpp
+++ b/src/kvirc/ui/KviWindow.cpp
@@ -140,6 +140,9 @@ KviWindow::KviWindow(Type eType, const QString & szName, KviConsoleWindow * lpCo
 	setFocusPolicy(Qt::StrongFocus);
 	connect(g_pApp, SIGNAL(reloadImages()), this, SLOT(reloadImages()));
 
+	// set name of the app desktop file; used by wayland to load the window icon
+	QGuiApplication::setDesktopFileName("net.kvirc.KVIrc" KVIRC_VERSION_MAJOR);
+
 	setAttribute(Qt::WA_InputMethodEnabled, true);
 }
 

--- a/src/modules/setup/SetupWizard.cpp
+++ b/src/modules/setup/SetupWizard.cpp
@@ -142,6 +142,9 @@ SetupWizard::SetupWizard()
 	QString szImagePath;
 	g_pApp->getGlobalKvircDirectory(szImagePath, KviApplication::Pics, "kvi_setup_label.png");
 
+	// set name of the app desktop file; used by wayland to load the window icon
+	QGuiApplication::setDesktopFileName("net.kvirc.KVIrc" KVIRC_VERSION_MAJOR);
+
 	m_pLabelPixmap = new QPixmap(szImagePath);
 	if(m_pLabelPixmap->isNull())
 	{


### PR DESCRIPTION
While testing the new version of kvirc I noticed that the setup window was using the `net.kvirc.kvirc` app_id. It seems my previous fix was incomplete since that window is started before the other window where we set the app_id.

Fix it by adding it to the setup window as well, and also just add it to a bunch more locations so that the chances of it not being set elsewhere are lower.
