### PR TITLE
Revert part of #2661 to fix the mainwindow icon

### DIFF
--- a/src/kvilib/tal/KviTalApplication.cpp
+++ b/src/kvilib/tal/KviTalApplication.cpp
@@ -29,9 +29,6 @@ KviTalApplication::KviTalApplication(int & iArgc, char ** ppcArgv)
 {
 	// Session management has been broken by source incompatible changes.
 	QObject::connect(this, SIGNAL(commitDataRequest(QSessionManager &)), this, SLOT(commitData(QSessionManager &)));
-
-	// set name of the app desktop file; used by wayland to load the window icon
-	QGuiApplication::setDesktopFileName("net.kvirc.KVIrc" KVIRC_VERSION_MAJOR);
 }
 
 KviTalApplication::~KviTalApplication()

--- a/src/kvirc/ui/KviMainWindow.cpp
+++ b/src/kvirc/ui/KviMainWindow.cpp
@@ -105,6 +105,9 @@ KviMainWindow::KviMainWindow(QWidget * pParent)
 	// We try to avois this as much as possible, since it forces the use of the low-res 16x16 icon
 	setWindowIcon(*(g_pIconManager->getSmallIcon(KviIconManager::KVIrc)));
 #endif
+	// set name of the app desktop file; used by wayland to load the window icon
+	QGuiApplication::setDesktopFileName("net.kvirc.KVIrc" KVIRC_VERSION_MAJOR);
+
 	setWindowTitle(KVI_DEFAULT_FRAME_CAPTION);
 
 	m_pSplitter = new QSplitter(Qt::Horizontal, this);


### PR DESCRIPTION
It seems KviTalApplication ctor is too early to set the desktop file name