### PR TITLE
Win uninstaller: correctly remove the "installed app" entry from registry on 64bit installs

### DIFF
--- a/cmake/KVIrc.nsi.cmake
+++ b/cmake/KVIrc.nsi.cmake
@@ -314,6 +314,11 @@ SectionEnd
 
 Function un.onInit
   !insertmacro MUI_UNGETLANGUAGE
+
+  ${If} ${RunningX64}
+    SetRegView 64
+  ${EndIf}
+
   Call un.CloseKVIrcInstances
 FunctionEnd
 


### PR DESCRIPTION
The command to use the 64-bit version of the registry was present in the installer but not in the uninstaller