### PR TITLE
Add support for "Monospace" control code (ASCII 0x11). 

### DIFF
--- a/src/kvilib/irc/KviControlCodes.cpp
+++ b/src/kvilib/irc/KviControlCodes.cpp
@@ -45,6 +45,7 @@ namespace KviControlCodes
 				case KviControlCodes::Underline:
 				case KviControlCodes::Bold:
 				case KviControlCodes::Italic:
+				case KviControlCodes::Monospace:
 				case KviControlCodes::Reset:
 				case KviControlCodes::Reverse:
 				case KviControlCodes::CryptEscape:

--- a/src/kvilib/irc/KviControlCodes.h
+++ b/src/kvilib/irc/KviControlCodes.h
@@ -66,11 +66,11 @@
 // 008 BS  Backspace                  (Should not be assigned: terminal control)
 // 009 HT  Horizontal tabulation      (Should not be assigned: terminal control)
 // 010 LF  Line feed                  (Should not be assigned: terminal control)
-// 011 VT  Vertical tabulation        (Should not be assigned: terminal control)
+// 011 VT  Vertical tabulation        ( Monospace text )
 // 012 FF  Form feed                  (Should not be assigned: terminal control)
 // 013 CR  Carriage return            (Should not be assigned: terminal control)
 // 014 SO  Shift out                  (Should not be assigned: terminal control)
-// 015 SI  Shift in                   ( Resets Bold,Color,Underline and Reverse ) (Conflicting with terminal control)
+// 015 SI  Shift in                   ( Resets Bold,Color,Underline,Monospace and Reverse ) (Conflicting with terminal control)
 // 016 DLE Data link escape           (Decent, can be assigned)
 // 017 DC1 Device control 1           (Good to be assigned)
 // 018 DC2 Device control 2           (Good to be assigned)
@@ -157,6 +157,7 @@ namespace KviControlCodes
 		UnIcon = 0x06,      /**< Unicon, totally artificial and internal to KviIrcView */
 		ArbitraryBreak = UnIcon, /**< Arbitrary block break, totally artificial and internal to KviIrcView */
 		Reset = 0x0f,       /**< Reset */
+		Monospace = 0x11,   /**< Monospace */
 		Reverse = 0x16,     /**< Reverse */
 		Icon = 0x1c,        /**< Icon, KVIrc control code */
 		Italic = 0x1d,      /**< Italic */

--- a/src/kvirc/kernel/KviHtmlGenerator.cpp
+++ b/src/kvirc/kernel/KviHtmlGenerator.cpp
@@ -37,6 +37,7 @@ namespace KviHtmlGenerator
 		bool bCurBold = false;
 		bool bCurItalic = false;
 		bool bCurUnderline = false;
+		bool bCurMonospace = false;
 		bool bIgnoreIcons = false;
 		bool bShowIcons = KVI_OPTION_BOOL(KviOption_boolDrawEmoticons);
 		unsigned char uCurFore = Foreground;
@@ -51,7 +52,7 @@ namespace KviHtmlGenerator
 			unsigned int uStart = uIdx;
 
 			while(
-			    (c != KviControlCodes::Color) && (c != KviControlCodes::Bold) && (c != KviControlCodes::Italic) && (c != KviControlCodes::Underline) && (c != KviControlCodes::Reverse) && (c != KviControlCodes::Reset) && (c != KviControlCodes::Icon) && ((c != ':') || bIgnoreIcons) && ((c != ';') || bIgnoreIcons) && ((c != '=') || bIgnoreIcons))
+			    (c != KviControlCodes::Color) && (c != KviControlCodes::Bold) && (c != KviControlCodes::Italic) && (c != KviControlCodes::Underline) && (c != KviControlCodes::Reverse) && (c != KviControlCodes::Reset) && (c != KviControlCodes::Icon) && (c != KviControlCodes::Monospace) && ((c != ':') || bIgnoreIcons) && ((c != ';') || bIgnoreIcons) && ((c != '=') || bIgnoreIcons))
 			{
 				bIgnoreIcons = false;
 				if(c == '&')
@@ -158,6 +159,19 @@ namespace KviHtmlGenerator
 					}
 				}
 
+				if(bCurMonospace)
+				{
+					if(!bOpened)
+					{
+						szResult.append("<span style=\"font-family:monospace");
+						bOpened = true;
+					}
+					else
+					{
+						szResult.append(";font-family:monospace");
+					}
+				}
+
 				if(bOpened)
 					szResult.append(";\">");
 
@@ -190,6 +204,12 @@ namespace KviHtmlGenerator
 				case KviControlCodes::Reverse:
 				{
 					std::swap(uCurFore, uCurBack);
+					++uIdx;
+					break;
+				}
+				case KviControlCodes::Monospace:
+				{
+					bCurMonospace = !bCurMonospace;
 					++uIdx;
 					break;
 				}

--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -109,7 +109,8 @@ public:
 		IsItalic = 4,
 		IsUnderline = 8,
 		IsSpellingMistake = 16,
-		IsSelected = 32
+		IsSelected = 32,
+		IsMonospace = 64
 	};
 
 public:
@@ -536,7 +537,7 @@ void KviInputEditor::rebuildTextBlocks()
 
 #define NOT_CONTROL_CHAR() \
 	(                      \
-	    (c > 32) || ((c != KviControlCodes::Color) && (c != KviControlCodes::Bold) && (c != KviControlCodes::Italic) && (c != KviControlCodes::Underline) && (c != KviControlCodes::Reset) && (c != KviControlCodes::Reverse) && (c != KviControlCodes::CryptEscape) && (c != KviControlCodes::Icon)))
+	    (c > 32) || ((c != KviControlCodes::Color) && (c != KviControlCodes::Bold) && (c != KviControlCodes::Italic) && (c != KviControlCodes::Underline) && (c != KviControlCodes::Monospace) && (c != KviControlCodes::Reset) && (c != KviControlCodes::Reverse) && (c != KviControlCodes::CryptEscape) && (c != KviControlCodes::Icon)))
 
 	// FIXME: get rid of getLastFontMetrics() ?
 	QFontMetrics * fm = getLastFontMetrics(font());
@@ -604,6 +605,12 @@ void KviInputEditor::rebuildTextBlocks()
 						uFlags &= ~KviInputEditorTextBlock::IsUnderline;
 					else
 						uFlags |= KviInputEditorTextBlock::IsUnderline;
+					break;
+				case KviControlCodes::Monospace:
+					if(uFlags & KviInputEditorTextBlock::IsMonospace)
+						uFlags &= ~KviInputEditorTextBlock::IsMonospace;
+					else
+						uFlags |= KviInputEditorTextBlock::IsMonospace;
 					break;
 				case KviControlCodes::Reset:
 					uCurFore = KVI_INPUT_DEF_FORE;
@@ -975,6 +982,9 @@ QChar KviInputEditor::getSubstituteChar(unsigned short uControlCode)
 			break;
 		case KviControlCodes::Italic:
 			return QChar('I');
+			break;
+		case KviControlCodes::Monospace:
+			return QChar('M');
 			break;
 		case KviControlCodes::Reset:
 			return QChar('O');

--- a/src/kvirc/ui/KviIrcView.cpp
+++ b/src/kvirc/ui/KviIrcView.cpp
@@ -1196,6 +1196,7 @@ void KviIrcView::paintEvent(QPaintEvent * p)
 		bool curBold = false;
 		bool curItalic = false;
 		bool curUnderline = false;
+		bool curMonospace = false;
 		char foreBeforeEscape = KviControlCodes::Black;
 		bool curLink = false;
 		bool bacWasTransp = false;
@@ -1256,10 +1257,14 @@ void KviIrcView::paintEvent(QPaintEvent * p)
 					case KviControlCodes::Underline:
 						curUnderline = !curUnderline;
 						break;
+					case KviControlCodes::Monospace:
+						curMonospace = !curMonospace;
+						break;
 					case KviControlCodes::Reset:
 						curBold = false;
 						curItalic = false;
 						curUnderline = false;
+						curMonospace = false;
 						bacWasTransp = false;
 						curFore = defaultFore;
 						curBack = defaultBack;
@@ -3004,6 +3009,7 @@ KviIrcViewWrappedBlock * KviIrcView::getLinkUnderMouse(int xPos, int yPos, QRect
 												case KviControlCodes::Bold:
 												case KviControlCodes::Italic:
 												case KviControlCodes::Underline:
+												case KviControlCodes::Monospace:
 												case KviControlCodes::Reverse:
 												case KviControlCodes::Reset:
 													szLink.append(QChar(l->pBlocks[iEndOfLInk].pChunk->type));

--- a/src/kvirc/ui/KviIrcView_events.cpp
+++ b/src/kvirc/ui/KviIrcView_events.cpp
@@ -447,6 +447,7 @@ void KviIrcView::addControlCharacter(KviIrcViewLineChunk * pC, QString & szSelec
 		case KviControlCodes::Bold:
 		case KviControlCodes::Italic:
 		case KviControlCodes::Underline:
+		case KviControlCodes::Monospace:
 		case KviControlCodes::Reverse:
 		case KviControlCodes::Reset:
 			szSelectionText.append(QChar(pC->type));

--- a/src/kvirc/ui/KviIrcView_getTextLine.cpp
+++ b/src/kvirc/ui/KviIrcView_getTextLine.cpp
@@ -363,7 +363,7 @@ const kvi_wchar_t * KviIrcView::getTextLine(
 		nullptr                      ,nullptr                      ,nullptr                      ,nullptr                      ,
 		nullptr                      ,&&found_tab                  ,&&found_end_of_line          ,nullptr                      ,
 		nullptr                      ,&&found_command_escape       ,nullptr                      ,&&found_mirc_escape          ,
-		nullptr                      ,nullptr                      ,nullptr                      ,nullptr                      ,
+		nullptr                      ,&&found_mirc_escape          ,nullptr                      ,nullptr                      ,
 		nullptr                      ,nullptr                      ,&&found_mirc_escape          ,nullptr                      ,
 		nullptr                      ,nullptr                      ,nullptr                      ,nullptr                      ,
 		&&found_icon_escape          ,&&found_mirc_escape          ,nullptr                      ,&&found_mirc_escape          , // 000-031
@@ -749,6 +749,7 @@ found_icon_escape:
 		case KviControlCodes::Bold:
 		case KviControlCodes::Italic:
 		case KviControlCodes::Underline:
+		case KviControlCodes::Monospace:
 		case KviControlCodes::Reverse:
 		case KviControlCodes::Reset:
 #ifdef COMPILE_USE_DYNAMIC_LABELS

--- a/src/kvirc/ui/KviTopicWidget.cpp
+++ b/src/kvirc/ui/KviTopicWidget.cpp
@@ -234,6 +234,7 @@ static bool isKviControlCode(unsigned short c)
 	case KviControlCodes::Bold:
 	case KviControlCodes::Italic:
 	case KviControlCodes::Underline:
+	case KviControlCodes::Monospace:
 	case KviControlCodes::Reverse:
 	case KviControlCodes::Reset:
 	case KviControlCodes::Icon:
@@ -249,6 +250,7 @@ void KviTopicWidget::paintColoredText(QPainter * p, QString text, const QPalette
 	bool curBold = false;
 	bool curItalic = false;
 	bool curUnderline = false;
+	bool curMonospace = false;
 	unsigned char curFore = KVI_LABEL_DEF_FORE; //default fore
 	unsigned char curBack = KVI_LABEL_DEF_BACK; //default back
 	int baseline = rect.top() + rect.height() - fm.descent() - 1;
@@ -340,6 +342,10 @@ void KviTopicWidget::paintColoredText(QPainter * p, QString text, const QPalette
 				break;
 			case KviControlCodes::Underline:
 				curUnderline = !curUnderline;
+				++idx;
+				break;
+			case KviControlCodes::Monospace:
+				curMonospace = !curMonospace;
 				++idx;
 				break;
 			case KviControlCodes::Reverse:
@@ -743,6 +749,9 @@ QChar KviTopicWidget::getSubstituteChar(unsigned short control_code)
 			break;
 		case KviControlCodes::Italic:
 			return QChar('I');
+			break;
+		case KviControlCodes::Monospace:
+			return QChar('M');
 			break;
 		case KviControlCodes::Reset:
 			return QChar('O');


### PR DESCRIPTION
Idling in some channels i received some message that our ircview was not able to cope with.
Turns out these messages contained ASCII 0x11, that's supposed to start a text section using monospace font.
https://modern.ircdocs.horse/formatting#monospace
I guess the idea is to replicate the `preformatted text` used eg. by markdown or html's `<pre>`, `<tt>`, `<code>` tags.

This PR add support for detecting this control code, so that the text get printed correctly, but by now the control code gets ignored.
Adding support for rendering different fonts in KviIrcView would require some heavy work and probably a few new options.