### PR TITLE
[WIP] Fix missing localizations on windows; fix 2679

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -56,7 +56,7 @@ jobs:
             --binarysource="clear;x-gha,readwrite" `
             --clean-after-build `
             --overlay-triplets="${{ env.vcpkg_path }}/triplets_overlay" `
-            gettext:x64-windows-release `
+            gettext[core,tools]:x64-windows-release `
             openssl:x64-windows-release `
             zlib:x64-windows-release
 

--- a/.github/workflows/build_windows_qt5.yml
+++ b/.github/workflows/build_windows_qt5.yml
@@ -55,7 +55,7 @@ jobs:
             --binarysource="clear;x-gha,readwrite" `
             --clean-after-build `
             --overlay-triplets="${{ env.vcpkg_path }}/triplets_overlay" `
-            gettext:x64-windows-release `
+            gettext[core,tools]:x64-windows-release `
             openssl:x64-windows-release `
             zlib:x64-windows-release
 


### PR DESCRIPTION
Windows Github actions can't find needed binaries provided by gettext (msgfmt, ..).
Seems like we need to enable the "tools" feature while building gettext: https://vcpkg.io/en/package/gettext
