### PR TITLE
Fix cmake rules related to CMP0175

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1090,19 +1090,19 @@ if(WANT_GETTEXT)
 		if(APPLE)
 			foreach(curFile ${FILES_TO_TIDY})
 				add_custom_command(TARGET messages-tidy
+				POST_BUILD
 				COMMENT "Tidying ${curFile}..."
 				COMMAND ${SED_EXECUTABLE} -i "" -e "s|${CMAKE_SOURCE_DIR}/||g" "${curFile}"
 				VERBATIM
-				DEPENDS ${curFile}
 				)
 			endforeach()
 		else()
 			foreach(curFile ${FILES_TO_TIDY})
 				add_custom_command(TARGET messages-tidy
+				POST_BUILD
 				COMMENT "Tidying ${curFile}..."
 				COMMAND ${SED_EXECUTABLE} -i -e "s|${CMAKE_SOURCE_DIR}/||g" "${curFile}"
 				VERBATIM
-				DEPENDS ${curFile}
 				)
 			endforeach()
 		endif()
@@ -1141,10 +1141,11 @@ if(WANT_DOXYGEN)
 		)
 
 		add_custom_command(
+			TARGET devdocs
+			POST_BUILD
 			COMMENT "generate the API documentation"
 			COMMAND mkdir -p ${CMAKE_BINARY_DIR}/doc/api
 			COMMAND cd ${CMAKE_BINARY_DIR}/admin && ${DOXYGEN_EXECUTABLE} Doxyfile
-			TARGET devdocs
 		)
 	else()
 		set(CMAKE_STATUS_DOXYGEN_SUPPORT "No")
@@ -1190,7 +1191,7 @@ if(UNIX)
 	)
 	add_custom_command(
 		TARGET  distclean POST_BUILD
-		DEPENDS clean
+		POST_BUILD
 		COMMENT "distribution clean"
 		COMMAND rm
 		ARGS    -Rf CMakeTmp CMakeFiles doc/api ${DISTCLEANED}

--- a/cmake/translation.rules.txt
+++ b/cmake/translation.rules.txt
@@ -59,21 +59,24 @@ IF(USE_GETTEXT_TRANSLATIONS)
 
 		IF(TRANSLATION_KVIRC_CORE)
 			ADD_CUSTOM_COMMAND(
+				TARGET messages-extract-${_potBasename}
+				POST_BUILD
 				COMMENT "Extracting messages for ${_potBasename}"
 				COMMAND ${GETTEXT_XGETTEXT_EXECUTABLE} -o ${_absPotFile} --package-name=${NICENAME} --package-version=${VERSION_RELEASE} --from-code=UTF-8 -k__tr -k__tr_no_lookup -k__tr2qs -k__tr2wc -k__tr2ws -ktr -f ${CMAKE_BINARY_DIR}/${PO_DIR}/filelist.txt
-				TARGET messages-extract-${_potBasename}
 			)
 		ELSEIF(TRANSLATION_DEFSCRIPT)
 			ADD_CUSTOM_COMMAND(
+				TARGET messages-extract-${_potBasename}
+				POST_BUILD
 				COMMENT "Extracting ctx messages for default script ${_potBasename}"
 				COMMAND ${GETTEXT_XGETTEXT_EXECUTABLE} -o ${_absPotFile} --package-name=${NICENAME} --package-version=${VERSION_RELEASE} --from-code=UTF-8 --language=C -ktr -f ${CMAKE_BINARY_DIR}/${PO_DIR}/filelist.txt
-				TARGET messages-extract-${_potBasename}
 			)
 		ELSE()
 			ADD_CUSTOM_COMMAND(
+				TARGET messages-extract-${_potBasename}
+				POST_BUILD
 				COMMENT "Extracting ctx messages for ${_potBasename}"
 				COMMAND ${GETTEXT_XGETTEXT_EXECUTABLE} -o ${_absPotFile} --package-name=${NICENAME} --package-version=${VERSION_RELEASE} --from-code=UTF-8 -k__tr_ctx -k__tr_no_lookup_ctx -k__tr2qs_no_lookup -k__tr2qs_ctx -k__tr2wc_ctx -k__tr2ws_ctx -f ${CMAKE_BINARY_DIR}/${PO_DIR}/filelist.txt
-				TARGET messages-extract-${_potBasename}
 			)
 		ENDIF()
 		# messages-update
@@ -85,10 +88,10 @@ IF(USE_GETTEXT_TRANSLATIONS)
 			GET_FILENAME_COMPONENT(_lang ${_absFile} NAME_WE)
 
 			ADD_CUSTOM_COMMAND(
+				TARGET messages-update-${_potBasename}
+				POST_BUILD
 				COMMENT "Updating messages in ${_currentPoFile}"
 				COMMAND ${GETTEXT_MSGMERGE_EXECUTABLE} --quiet --update --backup=none -s ${_absFile} ${_absPotFile}
-			DEPENDS ${_absPotFile} ${_absFile}
-			TARGET messages-update-${_potBasename}
 			)
 		ENDFOREACH()
 
@@ -102,38 +105,38 @@ IF(USE_GETTEXT_TRANSLATIONS)
 				# this is for the messages-tidy-module target
 				FOREACH(curFile ${FILES_TO_TIDY})
 					ADD_CUSTOM_COMMAND(TARGET messages-tidy-${_potBasename}
+					POST_BUILD
 					COMMENT "Tidying ${curFile}..."
 					COMMAND ${SED_EXECUTABLE} -i "" -e "s|^#:.*/\\(${TRANSLATION_BASEDIR}/.*\\)$|#: \\1|g" "${curFile}"
 					VERBATIM
-					DEPENDS ${curFile}
 					)
 				ENDFOREACH()
 				#this is for the messages-update-module target
 				FOREACH(curFile ${FILES_TO_TIDY})
 					ADD_CUSTOM_COMMAND(TARGET messages-update-${_potBasename}
+					POST_BUILD
 					COMMENT "Tidying ${curFile}..."
 					COMMAND ${SED_EXECUTABLE} -i "" -e "s|^#:.*/\\(${TRANSLATION_BASEDIR}/.*\\)$|#: \\1|g" "${curFile}"
 					VERBATIM
-					DEPENDS ${curFile}
 					)
 				ENDFOREACH()
 			else()
 				# this is for the messages-tidy-module target
 				FOREACH(curFile ${FILES_TO_TIDY})
 					ADD_CUSTOM_COMMAND(TARGET messages-tidy-${_potBasename}
+					POST_BUILD
 					COMMENT "Tidying ${curFile}..."
 					COMMAND ${SED_EXECUTABLE} -i -e "s|^#:.*/\\(${TRANSLATION_BASEDIR}/.*\\)$|#: \\1|g" "${curFile}"
 					VERBATIM
-					DEPENDS ${curFile}
 					)
 				ENDFOREACH()
 				#this is for the messages-update-module target
 				FOREACH(curFile ${FILES_TO_TIDY})
 					ADD_CUSTOM_COMMAND(TARGET messages-update-${_potBasename}
+					POST_BUILD
 					COMMENT "Tidying ${curFile}..."
 					COMMAND ${SED_EXECUTABLE} -i -e "s|^#:.*/\\(${TRANSLATION_BASEDIR}/.*\\)$|#: \\1|g" "${curFile}"
 					VERBATIM
-					DEPENDS ${curFile}
 					)
 				ENDFOREACH()
 			endif()


### PR DESCRIPTION
CMake complains that some usage of add_custom_command() is actually incorrect.
Fix two problems:
 * add explicit POST_BUILD to avoid warning
 * remove DEPENDS since the command signature we are using never supported it 