### PR TITLE
KviShortcut: add new ctor to support  QKeySequence::StandardKey with more than one QKeySequence

### DIFF
--- a/src/kvilib/core/KviShortcut.cpp
+++ b/src/kvilib/core/KviShortcut.cpp
@@ -46,6 +46,14 @@ QShortcut * KviShortcut::create(const QKeySequence & key, QObject * parent, cons
 	return new QShortcut(key, parent, member, ambiguousMember, context);
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+QShortcut * KviShortcut::create(const QKeySequence::StandardKey & key, QObject * parent, const char * member, const char * ambiguousMember, Qt::ShortcutContext context)
+{
+	//qDebug("New StdKey Shortcut %s\n", key.toString().toUtf8().data());
+	return new QShortcut(key, parent, member, ambiguousMember, context);
+}
+#endif
+
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 QShortcut * KviShortcut::create(Qt::KeyboardModifier mod, Qt::Key key, QWidget * parent, const char * member, const char * ambiguousMember, Qt::ShortcutContext context)
 #else

--- a/src/kvilib/core/KviShortcut.h
+++ b/src/kvilib/core/KviShortcut.h
@@ -48,6 +48,7 @@ public:
 #else
 	static QShortcut * create(const char * key, QObject * parent, const char * member = nullptr, const char * ambiguousMember = nullptr, Qt::ShortcutContext context = Qt::WindowShortcut);
 	static QShortcut * create(const QKeySequence & key, QObject * parent, const char * member = nullptr, const char * ambiguousMember = nullptr, Qt::ShortcutContext context = Qt::WindowShortcut);
+	static QShortcut * create(const QKeySequence::StandardKey & key, QObject * parent, const char * member = nullptr, const char * ambiguousMember = nullptr, Qt::ShortcutContext context = Qt::WindowShortcut);
 	static QShortcut * create(Qt::KeyboardModifier mod, Qt::Key key, QObject * parent, const char * member = nullptr, const char * ambiguousMember = nullptr, Qt::ShortcutContext context = Qt::WindowShortcut);
 #endif
 };


### PR DESCRIPTION
On Qt6 the cast from  QKeySequence::StandardKey to QKeySequence will create the shortcut only on the first sequence.
From https://doc.qt.io/qt-6/qkeysequence.html#QKeySequence-1 :
```
The resulting object will be based on the first element in the list of key bindings for the key.
```
Fix #2685