### PR TITLE
Support sending authorization ID in SASL EXTERNAL

### DIFF
--- a/src/kvilib/net/KviSASL.cpp
+++ b/src/kvilib/net/KviSASL.cpp
@@ -68,11 +68,18 @@ namespace KviSASL
 		return false;
 	}
 
-	bool externalMethod(const KviCString & szIn, KviCString & szOut)
+	bool externalMethod(const KviCString & szIn, KviCString & szOut, const QByteArray & baNick)
 	{
 		if(szIn == "+")
 		{
-			szOut = szIn;
+			if(baNick.isEmpty())
+			{
+				szOut = szIn;
+			}
+			else
+			{
+				szOut.bufferToBase64(baNick.data(), baNick.size());
+			}
 
 			return true;
 		}

--- a/src/kvilib/net/KviSASL.h
+++ b/src/kvilib/net/KviSASL.h
@@ -59,9 +59,10 @@ namespace KviSASL
 	* \brief Create the auth message for EXTERNAL authentication
 	* \param szIn The server-provided token
 	* \param szOut A KviCString that will be filled with the authentication message
+	* \param baNick The username, may be empty
 	* \return bool
 	*/
-	extern KVILIB_API bool externalMethod(const KviCString & szIn, KviCString & szOut);
+	extern KVILIB_API bool externalMethod(const KviCString & szIn, KviCString & szOut, const QByteArray & baNick);
 };
 
 #endif //_KVI_SASL_H_

--- a/src/kvirc/kernel/KviIrcConnection.cpp
+++ b/src/kvirc/kernel/KviIrcConnection.cpp
@@ -501,7 +501,7 @@ void KviIrcConnection::handleAuthenticate(KviCString & szAuth)
 	KviCString szOut;
 	bool bSendString = false;
 	if(m_pStateData->sentSaslMethod() == QStringLiteral("EXTERNAL"))
-		bSendString = KviSASL::externalMethod(szAuth, szOut);
+		bSendString = KviSASL::externalMethod(szAuth, szOut, szNick);
 	else // Assume PLAIN
 		bSendString = KviSASL::plainMethod(szAuth, szOut, szNick, szPass);
 


### PR DESCRIPTION
The use case is provide network name and client ID to ZNC
See https://github.com/znc/znc/pull/1936

<!--
Describe the changes you're proposing.
If this pull request is intended to fix a bug, don't forget to mention its #number.
If there are changes in the GUI, include screenshots of the changes.
-->
