### PR TITLE
KviControlCodes: fix compilation with Qt >= 6.9

### DIFF
--- a/.github/workflows/build_linux_qt5.yml
+++ b/.github/workflows/build_linux_qt5.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
+        with:
+          version: 5.15.2
 
       - name: Install other prerequisites
         run: |

--- a/.github/workflows/build_linux_qt6.yml
+++ b/.github/workflows/build_linux_qt6.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: 6.8.2
+          version: 6.9.1
           modules: qt5compat qtmultimedia
 
       - name: Install other prerequisites

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: 6.8.2
+          version: 6.9.1
           modules: qt5compat qtmultimedia
 
       - name: Install other prerequisites

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: 6.8.2
+          version: 6.9.1
           modules: qt5compat qtmultimedia
           cache: true
 

--- a/src/kvirc/kvs/KviKvsCoreFunctions_af.cpp
+++ b/src/kvirc/kvs/KviKvsCoreFunctions_af.cpp
@@ -349,7 +349,7 @@ namespace KviKvsCoreFunctions
 
 	KVSCF(b)
 	{
-		KVSCF_pRetBuffer->setString(QString(QChar(KviControlCodes::Bold)));
+		KVSCF_pRetBuffer->setString(QString(QChar((char)KviControlCodes::Bold)));
 		return true;
 	}
 

--- a/src/kvirc/kvs/KviKvsCoreFunctions_gl.cpp
+++ b/src/kvirc/kvs/KviKvsCoreFunctions_gl.cpp
@@ -362,7 +362,7 @@ namespace KviKvsCoreFunctions
 
 	KVSCF(i)
 	{
-		KVSCF_pRetBuffer->setString(QString(QChar(KviControlCodes::Italic)));
+		KVSCF_pRetBuffer->setString(QString(QChar((char)KviControlCodes::Italic)));
 		return true;
 	}
 
@@ -869,7 +869,7 @@ namespace KviKvsCoreFunctions
 		KVSCF_PARAMETER("background", KVS_PT_UINT, KVS_PF_OPTIONAL, iBack)
 		KVSCF_PARAMETERS_END
 
-		QString szRet = QChar(KviControlCodes::Color);
+		QString szRet = QChar((char)KviControlCodes::Color);
 		if(KVSCF_pParams->count() > 0)
 		{
 			KviQString::appendFormatted(szRet, "%u", iFore);

--- a/src/kvirc/kvs/KviKvsCoreFunctions_mr.cpp
+++ b/src/kvirc/kvs/KviKvsCoreFunctions_mr.cpp
@@ -378,7 +378,7 @@ namespace KviKvsCoreFunctions
 
 	KVSCF(o)
 	{
-		KVSCF_pRetBuffer->setString(QString(QChar(KviControlCodes::Reset)));
+		KVSCF_pRetBuffer->setString(QString(QChar((char)KviControlCodes::Reset)));
 		return true;
 	}
 
@@ -504,7 +504,7 @@ namespace KviKvsCoreFunctions
 
 	KVSCF(r)
 	{
-		KVSCF_pRetBuffer->setString(QString(QChar(KviControlCodes::Reverse)));
+		KVSCF_pRetBuffer->setString(QString(QChar((char)KviControlCodes::Reverse)));
 		return true;
 	}
 

--- a/src/kvirc/kvs/KviKvsCoreFunctions_sz.cpp
+++ b/src/kvirc/kvs/KviKvsCoreFunctions_sz.cpp
@@ -772,7 +772,7 @@ namespace KviKvsCoreFunctions
 
 	KVSCF(u)
 	{
-		KVSCF_pRetBuffer->setString(QString(QChar(KviControlCodes::Underline)));
+		KVSCF_pRetBuffer->setString(QString(QChar((char)KviControlCodes::Underline)));
 		return true;
 	}
 

--- a/src/kvirc/kvs/KviKvsReport.cpp
+++ b/src/kvirc/kvs/KviKvsReport.cpp
@@ -135,7 +135,7 @@ void KviKvsReport::findLineColAndListing(const QChar * pBegin, const QChar * pPo
 		pBegin++;
 
 	{
-		QString * pListingStr = new QString(QString("%1%2 ").arg(QChar(KviControlCodes::Bold)).arg(iLine));
+		QString * pListingStr = new QString(QString("%1%2 ").arg(QChar((char)KviControlCodes::Bold)).arg(iLine));
 		*pListingStr += QString(pLineBegin, pBegin - pLineBegin);
 		pListingStr->replace("\n", "");
 		pListing->append(pListingStr);

--- a/src/kvirc/kvs/object/KviKvsObject.cpp
+++ b/src/kvirc/kvs/object/KviKvsObject.cpp
@@ -1120,7 +1120,7 @@ bool KviKvsObject::function_listProperties(KviKvsObjectFunctionCall * c)
 				szOut = QString("%1, %2").arg(szName, szType);
 			else
 			{
-				szOut = QString(__tr2qs_ctx("Property: %1%2%3, type %4", "kvs")).arg(QChar(KviControlCodes::Bold)).arg(szName).arg(QChar(KviControlCodes::Bold)).arg(szType);
+				szOut = QString(__tr2qs_ctx("Property: %1%2%3, type %4", "kvs")).arg(QChar((char)KviControlCodes::Bold)).arg(szName).arg(QChar((char)KviControlCodes::Bold)).arg(szType);
 				szOut.prepend(" ");
 			}
 

--- a/src/kvirc/ui/KviInputEditor.cpp
+++ b/src/kvirc/ui/KviInputEditor.cpp
@@ -1500,7 +1500,7 @@ void KviInputEditor::insertText(const QString & szTxt)
 			if(iIdx != -1)
 			{
 				szBlock = szText.left(iIdx);
-				//else szBlock = QChar(KviControlCodes::Reset);
+				//else szBlock = QChar((char)KviControlCodes::Reset);
 				szText.remove(0, iIdx + 1);
 			}
 			else

--- a/src/kvirc/ui/KviIrcView.cpp
+++ b/src/kvirc/ui/KviIrcView.cpp
@@ -3015,7 +3015,7 @@ KviIrcViewWrappedBlock * KviIrcView::getLinkUnderMouse(int xPos, int yPos, QRect
 													szLink.append(QChar(l->pBlocks[iEndOfLInk].pChunk->type));
 													break;
 												case KviControlCodes::Color:
-													szLink.append(QChar(KviControlCodes::Color));
+													szLink.append(QChar((char)KviControlCodes::Color));
 													if(l->pBlocks[iEndOfLInk].pChunk->colors.fore != KviControlCodes::NoChange)
 													{
 														szLink.append(QString("%1").arg((int)(l->pBlocks[iEndOfLInk].pChunk->colors.fore)));

--- a/src/kvirc/ui/KviTextIconWindow.cpp
+++ b/src/kvirc/ui/KviTextIconWindow.cpp
@@ -182,7 +182,7 @@ void KviTextIconWindow::autoSelectBestMatchBasedOnOwnerText()
 		return;
 
 	QString szText = pOwner->textBeforeCursor();
-	int idx = szText.lastIndexOf(QChar(KviControlCodes::Icon));
+	int idx = szText.lastIndexOf(QChar((char)KviControlCodes::Icon));
 	if(idx < 0)
 		return;
 

--- a/src/modules/regchan/libkviregchan.cpp
+++ b/src/modules/regchan/libkviregchan.cpp
@@ -223,7 +223,7 @@ static bool regchan_kvs_cmd_showlist(KviKvsModuleCommandCall * c)
 			c->window()->outputNoFmt(
 			    KVI_OUT_SYSTEMMESSAGE,
 			    __tr2qs_ctx("Channel: %1%2@%3", "register")
-			        .arg(QChar(KviControlCodes::Bold))
+			        .arg(QChar((char)KviControlCodes::Bold))
 			        .arg(ch->name())
 			        .arg(ch->netMask()));
 

--- a/src/modules/spaste/SlowPasteController.cpp
+++ b/src/modules/spaste/SlowPasteController.cpp
@@ -111,7 +111,7 @@ void SlowPasteController::pasteFile()
 	{
 		line = data;
 		if(line.isEmpty())
-			line = QChar(KviControlCodes::Reset);
+			line = QChar((char)KviControlCodes::Reset);
 
 		line.replace('\t', QString(KVI_OPTION_UINT(KviOption_uintSpacesToExpandTabulationInput), ' ')); //expand tabs to spaces
 


### PR DESCRIPTION
KviControlCodes: Qt >= 6.9's QChar removed implicit casts from ctors, add explicit cast to accommodate
Fix #2704 