### PR TITLE
Fix DBUS notifier arguments

### DIFF
--- a/src/kvirc/kernel/KviApplication.cpp
+++ b/src/kvirc/kernel/KviApplication.cpp
@@ -850,7 +850,7 @@ void KviApplication::notifierMessage(KviWindow * pWnd, int iIconId, const QStrin
 			// org.freedesktop.Notifications.Notify
 			QVariantList args;
 			args << QString("KVIrc");                          // application name
-			args << QVariant((unsigned int) 0);                // notification id
+			args << QVariant(0u);                              // notification id
 			args << szIcon;                                    // application icon
 			args << szTitle;                                   // summary text
 			args << szText;                                    // detailed text

--- a/src/kvirc/kernel/KviApplication.cpp
+++ b/src/kvirc/kernel/KviApplication.cpp
@@ -850,7 +850,7 @@ void KviApplication::notifierMessage(KviWindow * pWnd, int iIconId, const QStrin
 			// org.freedesktop.Notifications.Notify
 			QVariantList args;
 			args << QString("KVIrc");                          // application name
-			args << QVariant(0);                               // notification id
+			args << QVariant((unsigned int) 0);                // notification id
 			args << szIcon;                                    // application icon
 			args << szTitle;                                   // summary text
 			args << szText;                                    // detailed text


### PR DESCRIPTION
Fixes `org.freedesktop.Notifications.Notify()` being called with wrong signedness for notification_id