### PR TITLE
FileTransferWindow: use current theme palette to draw items

### DIFF
--- a/src/modules/dcc/DccFileTransfer.cpp
+++ b/src/modules/dcc/DccFileTransfer.cpp
@@ -65,6 +65,7 @@
 #include <QPushButton>
 #include <QEvent>
 #include <QCloseEvent>
+#include <QPalette>
 #include <QTimer>
 #include <QtEndian>
 
@@ -1638,6 +1639,7 @@ void DccFileTransfer::displayPaint(QPainter * p, int column, QRect rect)
 	int width = rect.width(), height = rect.height();
 	QString txt;
 	bool bIsTerminated = ((m_eGeneralStatus == Success) || (m_eGeneralStatus == Failure));
+	auto palette = QApplication::palette();
 
 	switch(column)
 	{
@@ -1684,7 +1686,7 @@ void DccFileTransfer::displayPaint(QPainter * p, int column, QRect rect)
 
 			int iY = rect.top() + 4;
 
-			p->setPen(Qt::black);
+			p->setPen(palette.color(QPalette::Active, QPalette::Text));
 
 			KviCString szRemote(KviCString::Format, "dcc://%s@%s:%s/%s", m_pDescriptor->szNick.toUtf8().data(), m_pDescriptor->szIp.toUtf8().data(), m_pDescriptor->szPort.toUtf8().data(),
 			    m_pDescriptor->szFileName.toUtf8().data());
@@ -1697,7 +1699,8 @@ void DccFileTransfer::displayPaint(QPainter * p, int column, QRect rect)
 			    m_pDescriptor->bRecvFile ? m_pDescriptor->szLocalFileName.toUtf8().data() : szRemote.ptr());
 			iY += iLineSpacing;
 
-			p->setPen(Qt::darkGray);
+			// lighter color, usually dark grey
+			p->setPen(palette.color(QPalette::Disabled, QPalette::Text));
 
 			p->drawText(rect.left() + 4, rect.top() + 4, width - 8, height - 8, Qt::AlignTop | Qt::AlignLeft, szFrom);
 			p->drawText(rect.left() + 4, rect.top() + 4 + iLineSpacing, width - 8, height - 8, Qt::AlignTop | Qt::AlignLeft, szTo);
@@ -1793,7 +1796,7 @@ void DccFileTransfer::displayPaint(QPainter * p, int column, QRect rect)
 				txt = QString(__tr2qs_ctx("%1", "dcc")).arg(KviQString::makeSizeReadable(uTransferred));
 			}
 
-			p->setPen(Qt::black);
+			p->setPen(palette.color(QPalette::Active, QPalette::Text));
 
 			p->drawText(rect.left() + 4, rect.top() + 19, width - 8, height - 8, Qt::AlignTop | Qt::AlignLeft, txt);
 

--- a/src/modules/filetransferwindow/FileTransferWindow.cpp
+++ b/src/modules/filetransferwindow/FileTransferWindow.cpp
@@ -237,7 +237,7 @@ void FileTransferItemDelegate::paint(QPainter * p, const QStyleOptionViewItem & 
 	p->setPen(transfer->active() ? QColor(180, 180, 180) : QColor(200, 200, 200));
 
 	p->drawRect(option.rect.left() + 1, option.rect.top() + 1, option.rect.width() - 2, option.rect.height() - 2);
-	p->fillRect(option.rect.left() + 2, option.rect.top() + 2, option.rect.width() - 4, option.rect.height() - 4, transfer->active() ? QColor(240, 240, 240) : QColor(225, 225, 225));
+	p->fillRect(option.rect.left() + 2, option.rect.top() + 2, option.rect.width() - 4, option.rect.height() - 4, transfer->active() ? option.palette.alternateBase().color() : option.palette.base().color());
 
 	transfer->displayPaint(p, index.column(), option.rect);
 }

--- a/src/modules/http/HttpFileTransfer.cpp
+++ b/src/modules/http/HttpFileTransfer.cpp
@@ -35,6 +35,7 @@
 #include "KviKvsScript.h"
 
 #include <QPainter>
+#include <QPalette>
 #include <QMenu>
 
 static KviPointerList<HttpFileTransfer> * g_pHttpFileTransfers = nullptr;
@@ -114,6 +115,7 @@ void HttpFileTransfer::displayPaint(QPainter * p, int column, QRect rect)
 	int width = rect.width(), height = rect.height();
 	QString txt;
 	bool bIsTerminated = ((m_eGeneralStatus == Success) || (m_eGeneralStatus == Failure));
+	auto palette = QApplication::palette();
 
 	switch(column)
 	{
@@ -153,7 +155,7 @@ void HttpFileTransfer::displayPaint(QPainter * p, int column, QRect rect)
 				daW1 = daW2;
 			int iLineSpacing = fm.lineSpacing();
 
-			p->setPen(Qt::black);
+			p->setPen(palette.color(QPalette::Active, QPalette::Text));
 
 			int iY = rect.top() + 4;
 
@@ -165,7 +167,8 @@ void HttpFileTransfer::displayPaint(QPainter * p, int column, QRect rect)
 			}
 			iY += iLineSpacing;
 
-			p->setPen(Qt::darkGray);
+			// lighter color, usually dark grey
+			p->setPen(palette.color(QPalette::Disabled, QPalette::Text));
 
 			p->drawText(rect.left() + 4, rect.top() + 4, width - 8, height - 8, Qt::AlignTop | Qt::AlignLeft, szFrom);
 			p->drawText(rect.left() + 4, rect.top() + 4 + iLineSpacing, width - 8, height - 8, Qt::AlignTop | Qt::AlignLeft, szTo);
@@ -224,7 +227,7 @@ void HttpFileTransfer::displayPaint(QPainter * p, int column, QRect rect)
 				txt = KviQString::makeSizeReadable(m_pHttpRequest->receivedSize());
 			}
 
-			p->setPen(Qt::black);
+			p->setPen(palette.color(QPalette::Active, QPalette::Text));
 
 			p->drawText(rect.left() + 4, rect.top() + 19, width - 8, height - 8, Qt::AlignTop | Qt::AlignLeft, txt);
 


### PR DESCRIPTION
fix #2714
Now dark theme is respected:
<img width="1689" height="216" alt="immagine" src="https://github.com/user-attachments/assets/83d9fe02-f86a-4646-a432-897a42633ea2" />
