### PR TITLE
Fix error handling of QSslSocket

### DIFF
--- a/src/kvilib/net/KviHttpRequest.cpp
+++ b/src/kvilib/net/KviHttpRequest.cpp
@@ -213,7 +213,7 @@ void KviHttpRequest::closeSocket()
 
 	QObject::disconnect(m_p->pSocket, SIGNAL(connected()), this, SLOT(slotSocketConnected()));
 	QObject::disconnect(m_p->pSocket, SIGNAL(disconnected()), this, SLOT(slotSocketDisconnected()));
-	QObject::disconnect(m_p->pSocket, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(slotSocketError(QAbstractSocket::SocketError)));
+	QObject::disconnect(m_p->pSocket, SIGNAL(errorOccurred(QAbstractSocket::SocketError)), this, SLOT(slotSocketError(QAbstractSocket::SocketError)));
 
 	m_p->pSocket->abort();
 	m_p->pSocket->close();
@@ -413,7 +413,7 @@ bool KviHttpRequest::doConnect()
 #endif
 	QObject::connect(m_p->pSocket, SIGNAL(connected()), this, SLOT(slotSocketConnected()));
 	QObject::connect(m_p->pSocket, SIGNAL(disconnected()), this, SLOT(slotSocketDisconnected()));
-	QObject::connect(m_p->pSocket, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(slotSocketError(QAbstractSocket::SocketError)));
+	QObject::connect(m_p->pSocket, SIGNAL(errorOccurred(QAbstractSocket::SocketError)), this, SLOT(slotSocketError(QAbstractSocket::SocketError)));
 	QObject::connect(m_p->pSocket, SIGNAL(readyRead()), this, SLOT(slotSocketReadDataReady()));
 	QObject::connect(m_p->pSocket, SIGNAL(hostFound()), this, SLOT(slotSocketHostResolved()));
 

--- a/src/modules/objects/KvsObject_socket.cpp
+++ b/src/modules/objects/KvsObject_socket.cpp
@@ -587,7 +587,7 @@ void KvsObject_socket::makeConnections()
 	connect(m_pSocket, SIGNAL(connected()), this, SLOT(slotConnected()));
 	connect(m_pSocket, SIGNAL(readyRead()), this, SLOT(slotReadyRead()));
 	connect(m_pSocket, SIGNAL(disconnected()), this, SLOT(slotDisconnected()));
-	connect(m_pSocket, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(slotError(QAbstractSocket::SocketError)));
+	connect(m_pSocket, SIGNAL(errorOccurred(QAbstractSocket::SocketError)), this, SLOT(slotError(QAbstractSocket::SocketError)));
 	connect(m_pSocket, SIGNAL(hostFound()), this, SLOT(slotHostFound()));
 	connect(m_pSocket, SIGNAL(stateChanged(QAbstractSocket::SocketState)), this, SLOT(slotStateChanged(QAbstractSocket::SocketState)));
 	//proxyAuthenticationRequired ( const QNetworkProxy & proxy, QAuthenticator * authenticator )

--- a/src/modules/objects/qtftp/qftp.cpp
+++ b/src/modules/objects/qtftp/qftp.cpp
@@ -168,7 +168,7 @@ void QFtpDTP::connectToHost(const QString & host, quint16 port)
 	socket->setObjectName(QLatin1String("QFtpDTP Passive state socket"));
 	connect(socket, SIGNAL(connected()), SLOT(socketConnected()));
 	connect(socket, SIGNAL(readyRead()), SLOT(socketReadyRead()));
-	connect(socket, SIGNAL(error(QAbstractSocket::SocketError)), SLOT(socketError(QAbstractSocket::SocketError)));
+	connect(socket, SIGNAL(errorOccurred(QAbstractSocket::SocketError)), SLOT(socketError(QAbstractSocket::SocketError)));
 	connect(socket, SIGNAL(disconnected()), SLOT(socketConnectionClosed()));
 	connect(socket, SIGNAL(bytesWritten(qint64)), SLOT(socketBytesWritten(qint64)));
 
@@ -654,7 +654,7 @@ void QFtpDTP::setupSocket()
 	socket->setObjectName(QLatin1String("QFtpDTP Active state socket"));
 	connect(socket, SIGNAL(connected()), SLOT(socketConnected()));
 	connect(socket, SIGNAL(readyRead()), SLOT(socketReadyRead()));
-	connect(socket, SIGNAL(error(QAbstractSocket::SocketError)), SLOT(socketError(QAbstractSocket::SocketError)));
+	connect(socket, SIGNAL(errorOccurred(QAbstractSocket::SocketError)), SLOT(socketError(QAbstractSocket::SocketError)));
 	connect(socket, SIGNAL(disconnected()), SLOT(socketConnectionClosed()));
 	connect(socket, SIGNAL(bytesWritten(qint64)), SLOT(socketBytesWritten(qint64)));
 
@@ -691,7 +691,7 @@ QFtpPI::QFtpPI(QObject * parent) : QObject(parent),
 	    SLOT(connectionClosed()));
 	connect(&commandSocket, SIGNAL(readyRead()),
 	    SLOT(readyRead()));
-	connect(&commandSocket, SIGNAL(error(QAbstractSocket::SocketError)),
+	connect(&commandSocket, SIGNAL(errorOccurred(QAbstractSocket::SocketError)),
 	    SLOT(error(QAbstractSocket::SocketError)));
 
 	connect(&dtp, SIGNAL(connectState(int)),

--- a/src/modules/objects/qthttp/qhttp.cpp
+++ b/src/modules/objects/qthttp/qhttp.cpp
@@ -3314,7 +3314,7 @@ void QHttpPrivate::setSock(QTcpSocket * sock)
 	QObject::connect(socket, SIGNAL(connected()), q, SLOT(_q_slotConnected()));
 	QObject::connect(socket, SIGNAL(disconnected()), q, SLOT(_q_slotClosed()));
 	QObject::connect(socket, SIGNAL(readyRead()), q, SLOT(_q_slotReadyRead()));
-	QObject::connect(socket, SIGNAL(error(QAbstractSocket::SocketError)), q, SLOT(_q_slotError(QAbstractSocket::SocketError)));
+	QObject::connect(socket, SIGNAL(errorOccurred(QAbstractSocket::SocketError)), q, SLOT(_q_slotError(QAbstractSocket::SocketError)));
 	QObject::connect(socket, SIGNAL(bytesWritten(qint64)),
 	    q, SLOT(_q_slotBytesWritten(qint64)));
 #ifndef QT_NO_NETWORKPROXY


### PR DESCRIPTION
The signal name changed since qt5. 