### PR TITLE
Grow the receive buffer from 1k to 16k to accomodate max ssl packet size

### DIFF
--- a/src/kvirc/kernel/KviIrcSocket.cpp
+++ b/src/kvirc/kernel/KviIrcSocket.cpp
@@ -1451,12 +1451,12 @@ void KviIrcSocket::linkUp()
 void KviIrcSocket::readData(int)
 {
 	//read data
-	char cBuffer[1025];
+	char cBuffer[16385];
 	int iReadLength;
 #ifdef COMPILE_SSL_SUPPORT
 	if(m_pSSL)
 	{
-		iReadLength = m_pSSL->read(cBuffer, 1024);
+		iReadLength = m_pSSL->read(cBuffer, sizeof(cBuffer) - 1);
 		if(iReadLength <= 0)
 		{
 			// ssl error....?
@@ -1501,7 +1501,7 @@ void KviIrcSocket::readData(int)
 	else
 	{
 #endif
-		iReadLength = kvi_socket_recv(m_sock, cBuffer, 1024);
+		iReadLength = kvi_socket_recv(m_sock, cBuffer, sizeof(cBuffer) - 1);
 		if(iReadLength <= 0)
 		{
 			handleInvalidSocketRead(iReadLength);


### PR DESCRIPTION
Historically irc messages were limited in size of 512 bytes, so the 1kb buffer _ought to be enough for anybody_ (semi-cit).
When reading from an SSL buffer, the max record size is 16kb (source: https://docs.openssl.org/master/man3/SSL_read/#notes), so our buffer should be large enough to get the whole record in one single read and avoid missed reads.
fix #2691
