### PR TITLE
Revert "Use floating point widths in KviIrcView: fixes overlapping texts"

### DIFF
--- a/src/kvirc/ui/KviIrcView.cpp
+++ b/src/kvirc/ui/KviIrcView.cpp
@@ -1134,7 +1134,7 @@ void KviIrcView::paintEvent(QPaintEvent * p)
 	// Have lines visible
 	int curBottomCoord = widgetHeight - KVI_IRCVIEW_VERTICAL_BORDER;
 	int maxLineWidth = widgetWidth - KVI_IRCVIEW_DOUBLEBORDER_WIDTH;
-	float defLeftCoord = KVI_IRCVIEW_HORIZONTAL_BORDER;
+	int defLeftCoord = KVI_IRCVIEW_HORIZONTAL_BORDER;
 	int lineWrapsHeight;
 
 	// if we draw an icon as a line preamble, we have to change borders geometry accordingly
@@ -1202,7 +1202,7 @@ void KviIrcView::paintEvent(QPaintEvent * p)
 		bool bacWasTransp = false;
 		char curFore = defaultFore;
 		char curBack = defaultBack;
-		float curLeftCoord = defLeftCoord;
+		int curLeftCoord = defLeftCoord;
 		curBottomCoord -= m_iFontLineVMargin; //rise up the text...
 
 		//
@@ -1360,7 +1360,7 @@ void KviIrcView::paintEvent(QPaintEvent * p)
 #define DRAW_SELECTED_TEXT(_text_str, _text_idx, _text_len, _text_width)                                                                                                               \
 	SET_PEN(KVI_OPTION_MSGTYPE(KVI_OUT_SELECT).fore(), block->pChunk ? block->pChunk->customFore : QColor());                                                                          \
 	{                                                                                                                                                                                  \
-		float theWdth = _text_width;                                                                                                                                                     \
+		int theWdth = _text_width;                                                                                                                                                     \
 		if(theWdth < 0)                                                                                                                                                                \
 			theWdth = width() - (curLeftCoord + KVI_IRCVIEW_HORIZONTAL_BORDER + scrollbarWidth);                                                                                       \
 		pa.fillRect(curLeftCoord, curBottomCoord - m_iFontLineSpacing + m_iFontDescent, theWdth, m_iFontLineSpacing, getMircColor(KVI_OPTION_MSGTYPE(KVI_OUT_SELECT).back())); \
@@ -1449,7 +1449,7 @@ void KviIrcView::paintEvent(QPaintEvent * p)
 							break;
 						case KVI_IRCVIEW_BLOCK_SELECTION_ICON:
 						{
-							float theWdth = block->block_width;
+							int theWdth = block->block_width;
 							if(theWdth < 0)
 								theWdth = width() - (curLeftCoord + KVI_IRCVIEW_HORIZONTAL_BORDER + scrollbarWidth);
 							pa.fillRect(curLeftCoord, curBottomCoord - m_iFontLineSpacing + m_iFontDescent, theWdth, m_iFontLineSpacing,
@@ -1463,7 +1463,7 @@ void KviIrcView::paintEvent(QPaintEvent * p)
 				{
 					if(block->pChunk && block->pChunk->type == KviControlCodes::Icon)
 						goto no_selection_paint;
-					float wdth = block->block_width;
+					int wdth = block->block_width;
 					if(wdth == 0)
 					{
 						// Last block before a word wrap, or a zero characters attribute block ?
@@ -1485,7 +1485,7 @@ void KviIrcView::paintEvent(QPaintEvent * p)
 			no_selection_paint:
 				if(block->pChunk && block->pChunk->type == KviControlCodes::Icon)
 				{
-					float wdth = block->block_width;
+					int wdth = block->block_width;
 					if(wdth < 0)
 						wdth = widgetWidth - (curLeftCoord + KVI_IRCVIEW_HORIZONTAL_BORDER);
 					int imageYPos = curBottomCoord - m_iRelativePixmapY;
@@ -1519,7 +1519,7 @@ void KviIrcView::paintEvent(QPaintEvent * p)
 				}
 				else
 				{
-					float wdth = block->block_width;
+					int wdth = block->block_width;
 					if(wdth < 0)
 						wdth = widgetWidth - (curLeftCoord + KVI_IRCVIEW_HORIZONTAL_BORDER);
 
@@ -1709,7 +1709,7 @@ void KviIrcView::calculateLineWraps(KviIrcViewLine * ptr, int maxWidth)
 	ptr->uLineWraps = 0;                                                                          // no line wraps yet
 
 	unsigned int curAttrBlock = 0; // Current attribute block
-	float curLineWidth = 0;
+	int curLineWidth = 0;
 
 	// init the first block
 	ptr->pBlocks->block_start = 0;
@@ -1727,7 +1727,7 @@ void KviIrcView::calculateLineWraps(KviIrcViewLine * ptr, int maxWidth)
 		const QChar * p = unicode + ptr->pBlocks[ptr->iBlockCount].block_start;
 
 		int curBlockLen = 0;
-		float curBlockWidth = 0;
+		int curBlockWidth = 0;
 
 		if(ptr->pChunks[curAttrBlock].type == KviControlCodes::Icon)
 		{
@@ -2194,7 +2194,7 @@ void KviIrcView::recalcFontVariables(const QFont & font, const QFontInfo & fi)
 	if(m_pFm)
 		delete m_pFm;
 
-	m_pFm = new QFontMetricsF(font);
+	m_pFm = new QFontMetrics(font);
 
 	m_iFontLineSpacing = m_pFm->lineSpacing();
 

--- a/src/kvirc/ui/KviIrcView.h
+++ b/src/kvirc/ui/KviIrcView.h
@@ -107,7 +107,7 @@ private:
 	int m_iFontLineSpacing;
 	int m_iFontLineVMargin;
 	int m_iFontDescent;
-	float m_iFontCharacterWidth[256];
+	int m_iFontCharacterWidth[256]; //1024 bytes fixed
 	bool m_bUseRealBold;
 
 	int m_iWrapMargin;
@@ -138,7 +138,7 @@ private:
 	bool m_bPostedPaintEventPending;
 	std::vector<KviIrcViewLine *> m_pMessagesStoppedWhileSelecting;
 	KviIrcView * m_pMasterView;
-	QFontMetricsF * m_pFm; // assume this valid only inside a paint event (may be 0 in other circumstances)
+	QFontMetrics * m_pFm; // assume this valid only inside a paint event (may be 0 in other circumstances)
 
 	QMouseEvent * m_pLastEvent;
 	qint64 m_iLastMouseClickTime;

--- a/src/kvirc/ui/KviIrcView_private.h
+++ b/src/kvirc/ui/KviIrcView_private.h
@@ -102,7 +102,7 @@ struct KviIrcViewWrappedBlock
 	KviIrcViewLineChunk * pChunk; // pointer to real line chunk or 0 for word wraps
 	int block_start;              // this is generally different than pAttribute->block_idx!
 	int block_len;                // length if the block in characters
-	float block_width;              // width of the block in pixels
+	int block_width;              // width of the block in pixels
 } _KVI_PACKED;
 
 struct KviIrcViewLine
@@ -135,11 +135,11 @@ struct KviIrcViewWrappedBlockSelectionInfo
 {
 	int selection_type;
 	int part_1_length;
-	float part_1_width;
+	int part_1_width;
 	int part_2_length;
-	float part_2_width;
+	int part_2_width;
 	int part_3_length;
-	float part_3_width;
+	int part_3_width;
 };
 
 #ifdef COMPILE_ON_WINDOWS


### PR DESCRIPTION
This reverts commit 148d8d9e1b6530676093f660ec64f6a2ee673235.

Fix #2713 
Possibly fix #2566 as well
