### PR TITLE
Fix geometry sanity check to permit startup on secondary monitors

### DIFF
--- a/src/kvirc/kernel/KviApplication.cpp
+++ b/src/kvirc/kernel/KviApplication.cpp
@@ -227,9 +227,6 @@ KviApplication::KviApplication(int & argc, char ** argv)
 	kvi_socket_flushTrafficCounters();
 	// don't let qt quit the application by itself
 	setQuitOnLastWindowClosed(false);
-
-	// Restore Qt5-like rounding to fix HiDPI support on QWebEngine
-	QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::Round);
 }
 
 void KviApplication::setup()

--- a/src/kvirc/kernel/KviMain.cpp
+++ b/src/kvirc/kernel/KviMain.cpp
@@ -372,6 +372,9 @@ int main(int argc, char ** argv)
 	qputenv("QT_BEARER_POLL_TIMEOUT", QByteArray::number(-1));
 #endif
 
+	// Restore Qt5-like rounding to fix HiDPI support on QWebEngine
+	QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::Round);
+
 	KviApplication * pTheApp = new KviApplication(argc, argv);
 
 #ifdef COMPILE_KDE_SUPPORT

--- a/src/kvirc/ui/KviMainWindow.cpp
+++ b/src/kvirc/ui/KviMainWindow.cpp
@@ -142,7 +142,9 @@ KviMainWindow::KviMainWindow(QWidget * pParent)
 
 	createWindowList();
 
-	if((KVI_OPTION_RECT(KviOption_rectFrameGeometry).width() < 100) || (KVI_OPTION_RECT(KviOption_rectFrameGeometry).height() < 100) || (KVI_OPTION_RECT(KviOption_rectFrameGeometry).x() > g_pMainWindow->screen()->availableSize().width()) || (KVI_OPTION_RECT(KviOption_rectFrameGeometry).y() > g_pMainWindow->screen()->availableSize().height()))
+	if(!g_pMainWindow->screen()->availableVirtualGeometry().contains(KVI_OPTION_RECT(KviOption_rectFrameGeometry)) ||
+		KVI_OPTION_RECT(KviOption_rectFrameGeometry).width() < 100 ||
+		KVI_OPTION_RECT(KviOption_rectFrameGeometry).height() < 100)
 	{
 		// Try to find some reasonable defaults
 		// prefer primary screen for first startup


### PR DESCRIPTION
Also, avoid a warning due to QGuiApplication::setHighDpiScaleFactorRoundingPolicy being called too late in application startup on qt6

Fix #2693 
