### PR TITLE
Topic widget: make the read-only label as similar as possible to the editable input editor

### DIFF
--- a/src/kvirc/ui/KviThemedLabel.cpp
+++ b/src/kvirc/ui/KviThemedLabel.cpp
@@ -26,6 +26,7 @@
 #include "KviOptions.h"
 #include "kvi_settings.h"
 #include "KviApplication.h"
+#include "KviInputEditor.h"
 #include "KviMainWindow.h"
 #include "KviWindow.h"
 #include "kvi_out.h"
@@ -47,6 +48,7 @@ KviThemedLabel::KviThemedLabel(QWidget * par, KviWindow * pWindow, const char * 
 	m_pKviWindow = pWindow;
 	setMargin(0);
 	setAutoFillBackground(false);
+	setContentsMargins(KVI_INPUT_MARGIN, KVI_INPUT_MARGIN, KVI_INPUT_MARGIN, KVI_INPUT_MARGIN);
 	applyOptions();
 }
 
@@ -61,14 +63,16 @@ void KviThemedLabel::applyOptions()
 	bool bIsTrasparent = false;
 #endif
 
-	QString szStyle = QString("QLabel { background: %1; background-clip: content; color: %2; font-family: %3; font-size: %4pt; font-weight: %5; font-style: %6; margin-left: 4px; margin-right: 4px;}")
+	QString szStyle = QString("QLabel { background: %1; color: %2;}")
 	                      .arg(bIsTrasparent ? "transparent" : KVI_OPTION_COLOR(KviOption_colorLabelBackground).name())
-	                      .arg(bIsTrasparent ? getMircColor(KVI_OPTION_MSGTYPE(KVI_OUT_NONE).fore()).name() : KVI_OPTION_COLOR(KviOption_colorLabelForeground).name())
-	                      .arg(KVI_OPTION_FONT(KviOption_fontLabel).family())
-	                      .arg(KVI_OPTION_FONT(KviOption_fontLabel).pointSize())
-	                      .arg(KVI_OPTION_FONT(KviOption_fontLabel).weight() == QFont::Bold ? "bold" : "normal")
-	                      .arg(KVI_OPTION_FONT(KviOption_fontLabel).style() == QFont::StyleItalic ? "italic" : "normal");
+	                      .arg(bIsTrasparent ? getMircColor(KVI_OPTION_MSGTYPE(KVI_OUT_NONE).fore()).name() : KVI_OPTION_COLOR(KviOption_colorLabelForeground).name());
 	setStyleSheet(szStyle);
+
+	QFont newFont(KVI_OPTION_FONT(KviOption_fontLabel));
+	newFont.setKerning(false);
+	newFont.setHintingPreference(QFont::PreferFullHinting);
+	setFont(newFont);
+
 	update();
 }
 

--- a/src/kvirc/ui/KviTopicWidget.cpp
+++ b/src/kvirc/ui/KviTopicWidget.cpp
@@ -216,6 +216,7 @@ void KviTopicWidget::applyOptions()
 {
 	//set the font
 	m_pLabel->applyOptions();
+	m_pInput->applyOptions(true);
 	QFont newFont(KVI_OPTION_FONT(KviOption_fontLabel));
 	newFont.setKerning(false);
 	newFont.setHintingPreference(QFont::PreferFullHinting);
@@ -225,6 +226,7 @@ void KviTopicWidget::applyOptions()
 
 	// reset topic html too (in case colors have been changed)
 	m_pLabel->setText(KviHtmlGenerator::convertToHtml(m_szTopic, true));
+	setFixedHeight(m_pInput->heightHint());
 }
 
 static bool isKviControlCode(unsigned short c)


### PR DESCRIPTION
 * use the same contents margins
 * use the same font kerning and hinting preferences
 * use the same contents height
 * on options change (eg. new theme applied), force a recalc of inputeditor cached metrics
