### PR TITLE
KviSSL: add SSL_OP_IGNORE_UNEXPECTED_EOF option

### DIFF
--- a/src/kvilib/net/KviSSL.cpp
+++ b/src/kvilib/net/KviSSL.cpp
@@ -392,6 +392,9 @@ bool KviSSL::initContext(Method m)
 #ifdef SSL_OP_SINGLE_ECDH_USE
 		|SSL_OP_SINGLE_ECDH_USE
 #endif
+#ifdef SSL_OP_IGNORE_UNEXPECTED_EOF
+		|SSL_OP_IGNORE_UNEXPECTED_EOF
+#endif
 	);
 	// we want all ciphers to be available here, except insecure ones, orderer by strength;
 	SSL_CTX_set_cipher_list(m_pSSLCtx, "ALL:!eNULL:!LOW:!EXP:!SSLv2:!SSLv3:!TLSv1:@STRENGTH");


### PR DESCRIPTION
KviSSL: add SSL_OP_IGNORE_UNEXPECTED_EOF option to avoid "unexpected eof while reading" errors on SDCC completion. The remote peer may close down the connection without sending the mandatory close_notify alert on shutdown. Since OpenSSL3 this reports an SSL error, but since we can already detect if the transfer has been truncated, just restore the previous behavior and ignore the error.

The error appeared since KVirc 5.2.x moved from bundling OpenSSL1.x to OpenSSL3

More info:
 * https://github.com/openssl/openssl/issues/18866#issuecomment-1194219601
 * https://docs.openssl.org/3.0/man3/SSL_CTX_set_options/


Fix #2702 
Fix #2750